### PR TITLE
M01/WP3 — Harden aggregate project validation

### DIFF
--- a/checkpoints/2026-08-29-m01-wp3-aggregate-hardening-complete.md
+++ b/checkpoints/2026-08-29-m01-wp3-aggregate-hardening-complete.md
@@ -1,0 +1,75 @@
+# M01 / WP3 — Aggregate Validation Hardening Complete
+
+Date: 2026-08-29
+
+Status: `M01_DEVELOPMENT_IN_PROGRESS`
+
+Work package: `WP3 — Aggregate validation hardening`
+
+## Result
+
+WP3 is implementation-complete and verified on Python 3.12.
+
+`ProjectBundle` now rejects structurally invalid project graphs deterministically while preserving provider neutrality and long-form/multi-track compatibility.
+
+## Hardened invariants
+
+- `Project.active_timeline_id`, when set, must reference the loaded Timeline;
+- TimelineTrack IDs are unique;
+- project character/world/prop references cannot contain duplicate IDs;
+- hierarchy membership lists cannot hide duplicate references behind set equality;
+- Acts/Sequences/Scenes/Shots must resolve to their declared parent hierarchy;
+- orphan Shots are rejected explicitly;
+- Take IDs and Shot Take membership remain exact and selected Takes must be loaded;
+- CharacterVersions must belong to loaded Characters;
+- Character version numbers are unique per Character;
+- CharacterLook IDs are unique and lock look pins resolve inside the pinned CharacterVersion;
+- project and scene CharacterLock targets resolve to the current graph;
+- Shot characters must be declared by both the Scene and Project;
+- declared/used props resolve and Shot props must be project-declared;
+- used Locations resolve, their Worlds resolve, and used Worlds must be project-declared;
+- a Shot cannot silently switch away from its Scene's continuous Location;
+- canonical primary-video track item IDs must resolve to Shots and remain unique;
+- only the explicit `primary-video` track receives strict chronological/non-overlap validation;
+- B-roll/overlay-style parallel Shot timing remains allowed because the timeline architecture supports parallel tracks.
+
+## Long-form / performance note
+
+Per-Shot scene lookups use indexed dictionaries instead of repeated linear scans. This avoids introducing an avoidable O(shots × scenes) validation path for long-form projects with potentially thousands of Shots.
+
+## Compatibility fixtures
+
+The test suite explicitly verifies:
+
+- a valid 2-minute project graph remains accepted;
+- a valid 90-minute project graph remains accepted;
+- primary-video overlap is rejected;
+- parallel B-roll overlap is accepted;
+- cross-scene primary-video time reversal is rejected;
+- invalid character/version/look/lock/world/location/prop ownership cases fail with actionable errors.
+
+## Verification evidence
+
+GitHub Actions workflow: `Core Domain Contracts`
+
+Run: `33217875292`
+
+Job: `99005474118`
+
+Verified successful gates:
+
+- Ruff;
+- strict mypy;
+- unit tests;
+- generated-schema synchronization;
+- Python compile/import check.
+
+## Scope boundary preserved
+
+WP3 did **not** implement provider APIs, Temporal workflows, PostgreSQL persistence/migrations, FastAPI/UI, publishing, object storage/FFmpeg runtime, or M02+ behavior.
+
+## Next authorized work
+
+Within the existing M01 consent:
+
+`WP4 — Legacy CNT content importer boundary`

--- a/checkpoints/LATEST.md
+++ b/checkpoints/LATEST.md
@@ -1,7 +1,7 @@
 # Latest Checkpoint
 
 Current checkpoint:
-`checkpoints/2026-08-29-m01-wp2-lineage-complete.md`
+`checkpoints/2026-08-29-m01-wp3-aggregate-hardening-complete.md`
 
 Current phase: **M01 — Core Domain & Persistence Boundary**
 
@@ -25,31 +25,36 @@ Merged via PR #1.
 Merge commit:
 `89e2c69f939a2d2c2350d3f0715da0b310ebeff7`
 
-Verified on Python 3.12 with Ruff, strict mypy, tests, generated-schema synchronization, and compile checks.
+### WP2 — Full production lineage
 
-### WP2 — Full lineage model fixture
+Merged via PR #2.
 
-Implementation and verification complete on the WP2 branch/PR.
+Merge commit:
+`d3aa6ba6c36482628a5540473bac0386b40b808c`
 
 Checkpoint:
 `checkpoints/2026-08-29-m01-wp2-lineage-complete.md`
 
-The full provider-neutral production lineage now validates Project/Content/Character/Timeline/Take/Job/Attempt/Asset/QA/Cost/Rights ownership and fail-closed rights behavior.
+### WP3 — Aggregate validation hardening
+
+Implementation and Python 3.12 verification complete on the WP3 branch/PR.
+
+Checkpoint:
+`checkpoints/2026-08-29-m01-wp3-aggregate-hardening-complete.md`
+
+The project graph now rejects duplicate/missing hierarchy references, invalid character/version/look/lock ownership, undeclared character/world/prop use, inconsistent scene locations, and invalid explicit primary-video timing while preserving parallel B-roll timing.
 
 ## Current next step
 
-`WP3 — Aggregate validation hardening`
-
-WP3 may proceed under the existing M01 consent after WP2 is merged. Only invariants supported by current canonical contracts may be added; unresolved advanced editorial semantics remain deferred.
+`WP4 — Legacy CNT content importer boundary`
 
 ## Remaining M01 sequence
 
-1. WP3 — aggregate validation hardening;
-2. WP4 — legacy `CNT-*` content importer boundary;
-3. WP5 — PostgreSQL persistence architecture;
-4. WP6 — reversible migration scaffold;
-5. WP7 — repositories and short/long project round-trip verification;
-6. WP8 — complete M01 verification and final checkpoint.
+1. WP4 — legacy `CNT-*` content importer boundary;
+2. WP5 — PostgreSQL persistence architecture;
+3. WP6 — reversible migration scaffold;
+4. WP7 — repositories and short/long project round-trip verification;
+5. WP8 — complete M01 verification and final checkpoint.
 
 ## Scope boundary
 

--- a/packages/python-core/src/lullabies_core/aggregate.py
+++ b/packages/python-core/src/lullabies_core/aggregate.py
@@ -117,6 +117,10 @@ class ProjectBundle(StrictModel):
                 )
             self._assert_unique_orders(owned_scenes, sequence.sequence_id, "Scene")
 
+        for shot in self.shots:
+            if shot.scene_id not in scenes:
+                raise ValueError(f"shot {shot.shot_id} has missing parent scene")
+
         for scene in self.scenes:
             if scene.sequence_id not in sequences:
                 raise ValueError(f"scene {scene.scene_id} has missing parent sequence")
@@ -246,6 +250,7 @@ class ProjectBundle(StrictModel):
                 f"project references missing characters: {sorted(missing_declared)}"
             )
 
+        scenes = {scene.scene_id: scene for scene in self.scenes}
         used: set[str] = set()
         for scene in self.scenes:
             self._assert_unique_refs(
@@ -259,8 +264,9 @@ class ProjectBundle(StrictModel):
                 f"shot {shot.shot_id} character_ids",
             )
             used.update(shot.character_ids)
-            scene = next(item for item in self.scenes if item.scene_id == shot.scene_id)
-            undeclared_in_scene = set(shot.character_ids) - set(scene.character_ids)
+            undeclared_in_scene = set(shot.character_ids) - set(
+                scenes[shot.scene_id].character_ids
+            )
             if undeclared_in_scene:
                 raise ValueError(
                     f"shot {shot.shot_id} uses characters not declared by scene: "
@@ -292,6 +298,7 @@ class ProjectBundle(StrictModel):
             if location.world_id is not None and location.world_id not in worlds:
                 raise ValueError(f"location {location.location_id} references missing world")
 
+        scenes = {scene.scene_id: scene for scene in self.scenes}
         required_location_ids: set[str] = set()
         for scene in self.scenes:
             if scene.location_id is not None:
@@ -299,7 +306,7 @@ class ProjectBundle(StrictModel):
         for shot in self.shots:
             if shot.location_id is not None:
                 required_location_ids.add(shot.location_id)
-            scene = next(item for item in self.scenes if item.scene_id == shot.scene_id)
+            scene = scenes[shot.scene_id]
             if (
                 scene.location_id is not None
                 and shot.location_id is not None

--- a/packages/python-core/src/lullabies_core/aggregate.py
+++ b/packages/python-core/src/lullabies_core/aggregate.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Iterable
 from typing import Protocol, TypeVar
 
 from pydantic import Field, model_validator
 
 from .character import Character, CharacterVersion
-from .common import StrictModel
+from .common import LockScope, StrictModel
 from .entities import Location, Prop, World
 from .project import Project
 from .timeline import Act, Scene, Sequence, Shot, Take, Timeline
@@ -46,13 +46,25 @@ class ProjectBundle(StrictModel):
         self._validate_hierarchy()
         self._validate_takes()
         self._validate_references()
+        self._validate_primary_edit()
         return self
 
     def _validate_project_timeline(self) -> None:
         if self.timeline.project_id != self.project.project_id:
             raise ValueError("timeline.project_id must equal project.project_id")
+        if (
+            self.project.active_timeline_id is not None
+            and self.project.active_timeline_id != self.timeline.timeline_id
+        ):
+            raise ValueError("project.active_timeline_id must reference the loaded timeline")
         if abs(self.timeline.duration_seconds - self.project.target_duration_seconds) > 0.001:
             raise ValueError("timeline duration must equal project target duration")
+
+        self._unique_by_id(self.timeline.tracks, "track_id", "TimelineTrack")
+        self._assert_unique_refs(self.project.character_ids, "project.character_ids")
+        self._assert_unique_refs(self.project.world_ids, "project.world_ids")
+        self._assert_unique_refs(self.project.prop_ids, "project.prop_ids")
+
         for shot in self.shots:
             if shot.time_range.end_seconds > self.timeline.duration_seconds + 0.001:
                 raise ValueError(f"shot {shot.shot_id} exceeds timeline duration")
@@ -63,6 +75,7 @@ class ProjectBundle(StrictModel):
         scenes = self._unique_by_id(self.scenes, "scene_id", "Scene")
         shots = self._unique_by_id(self.shots, "shot_id", "Shot")
 
+        self._assert_unique_refs(self.timeline.act_ids, "timeline.act_ids")
         if set(self.timeline.act_ids) != set(acts):
             raise ValueError("timeline.act_ids must exactly match loaded acts")
         self._assert_unique_orders(self.acts, "timeline", "Act")
@@ -70,6 +83,7 @@ class ProjectBundle(StrictModel):
         for act in self.acts:
             if act.project_id != self.project.project_id:
                 raise ValueError(f"act {act.act_id} belongs to another project")
+            self._assert_unique_refs(act.sequence_ids, f"act {act.act_id} sequence_ids")
             missing = [item for item in act.sequence_ids if item not in sequences]
             if missing:
                 raise ValueError(f"act {act.act_id} references missing sequences: {missing}")
@@ -85,6 +99,10 @@ class ProjectBundle(StrictModel):
         for sequence in self.sequences:
             if sequence.act_id not in acts:
                 raise ValueError(f"sequence {sequence.sequence_id} has missing parent act")
+            self._assert_unique_refs(
+                sequence.scene_ids,
+                f"sequence {sequence.sequence_id} scene_ids",
+            )
             missing = [item for item in sequence.scene_ids if item not in scenes]
             if missing:
                 raise ValueError(
@@ -102,6 +120,7 @@ class ProjectBundle(StrictModel):
         for scene in self.scenes:
             if scene.sequence_id not in sequences:
                 raise ValueError(f"scene {scene.scene_id} has missing parent sequence")
+            self._assert_unique_refs(scene.shot_ids, f"scene {scene.scene_id} shot_ids")
             missing = [item for item in scene.shot_ids if item not in shots]
             if missing:
                 raise ValueError(f"scene {scene.scene_id} references missing shots: {missing}")
@@ -121,12 +140,15 @@ class ProjectBundle(StrictModel):
             if take.shot_id not in shots:
                 raise ValueError(f"take {take.take_id} references missing shot {take.shot_id}")
         for shot in self.shots:
+            self._assert_unique_refs(shot.take_ids, f"shot {shot.shot_id} take_ids")
             missing = [take_id for take_id in shot.take_ids if take_id not in takes]
             if missing:
                 raise ValueError(f"shot {shot.shot_id} references missing takes: {missing}")
             owned_takes = [take for take in self.takes if take.shot_id == shot.shot_id]
             if set(shot.take_ids) != {take.take_id for take in owned_takes}:
                 raise ValueError(f"shot {shot.shot_id} take membership is inconsistent")
+            if shot.selected_take_id is not None and shot.selected_take_id not in takes:
+                raise ValueError(f"shot {shot.shot_id} selected take is not loaded")
 
     def _validate_references(self) -> None:
         characters = self._unique_by_id(self.characters, "character_id", "Character")
@@ -137,6 +159,44 @@ class ProjectBundle(StrictModel):
         locations = self._unique_by_id(self.locations, "location_id", "Location")
         props = self._unique_by_id(self.props, "prop_id", "Prop")
 
+        self._validate_character_versions(characters, character_versions)
+        self._validate_character_usage(characters)
+        self._validate_world_and_location_usage(worlds, locations)
+        self._validate_prop_usage(props)
+
+    def _validate_character_versions(
+        self,
+        characters: dict[str, Character],
+        character_versions: dict[str, CharacterVersion],
+    ) -> None:
+        versions_by_character: dict[str, set[int]] = defaultdict(set)
+        seen_look_ids: set[str] = set()
+
+        for version in self.character_versions:
+            if version.character_id not in characters:
+                raise ValueError(
+                    f"character version {version.character_version_id} has missing character"
+                )
+            if version.version in versions_by_character[version.character_id]:
+                raise ValueError(
+                    f"character {version.character_id} has duplicate version number "
+                    f"{version.version}"
+                )
+            versions_by_character[version.character_id].add(version.version)
+            local_look_ids = [look.look_id for look in version.looks]
+            self._assert_unique_refs(
+                local_look_ids,
+                f"character version {version.character_version_id} look_ids",
+            )
+            duplicate_global_looks = seen_look_ids.intersection(local_look_ids)
+            if duplicate_global_looks:
+                raise ValueError(
+                    f"duplicate CharacterLook IDs: {sorted(duplicate_global_looks)}"
+                )
+            seen_look_ids.update(local_look_ids)
+
+        scene_ids = {scene.scene_id for scene in self.scenes}
+        scenes = {scene.scene_id: scene for scene in self.scenes}
         for character in self.characters:
             if character.active_version_id not in character_versions:
                 raise ValueError(f"character {character.character_id} active version is not loaded")
@@ -145,52 +205,166 @@ class ProjectBundle(StrictModel):
                 raise ValueError(
                     f"character version {version.character_version_id} belongs to another character"
                 )
-            pinned = character.lock.pinned_character_version_id
+
+            lock = character.lock
+            pinned = lock.pinned_character_version_id
             if pinned is not None:
                 if pinned not in character_versions:
                     raise ValueError(f"character {character.character_id} lock version is missing")
-                if character_versions[pinned].character_id != character.character_id:
+                pinned_version = character_versions[pinned]
+                if pinned_version.character_id != character.character_id:
                     raise ValueError(
                         f"character {character.character_id} lock pins another identity"
                     )
+                if lock.pinned_look_id is not None:
+                    look_ids = {look.look_id for look in pinned_version.looks}
+                    if lock.pinned_look_id not in look_ids:
+                        raise ValueError(
+                            f"character {character.character_id} lock look is not in pinned version"
+                        )
 
-        required_character_ids = set(self.project.character_ids)
+            if lock.scope == LockScope.PROJECT and lock.project_id != self.project.project_id:
+                raise ValueError(
+                    f"character {character.character_id} project lock targets another project"
+                )
+            if lock.scope == LockScope.SCENE:
+                if lock.scene_id not in scene_ids:
+                    raise ValueError(
+                        f"character {character.character_id} scene lock references missing scene"
+                    )
+                if character.character_id not in scenes[lock.scene_id].character_ids:
+                    raise ValueError(
+                        f"character {character.character_id} scene lock targets a scene "
+                        "where the character is not declared"
+                    )
+
+    def _validate_character_usage(self, characters: dict[str, Character]) -> None:
+        declared = set(self.project.character_ids)
+        missing_declared = declared - set(characters)
+        if missing_declared:
+            raise ValueError(
+                f"project references missing characters: {sorted(missing_declared)}"
+            )
+
+        used: set[str] = set()
         for scene in self.scenes:
-            required_character_ids.update(scene.character_ids)
+            self._assert_unique_refs(
+                scene.character_ids,
+                f"scene {scene.scene_id} character_ids",
+            )
+            used.update(scene.character_ids)
         for shot in self.shots:
-            required_character_ids.update(shot.character_ids)
-        missing_characters = required_character_ids - set(characters)
+            self._assert_unique_refs(
+                shot.character_ids,
+                f"shot {shot.shot_id} character_ids",
+            )
+            used.update(shot.character_ids)
+            scene = next(item for item in self.scenes if item.scene_id == shot.scene_id)
+            undeclared_in_scene = set(shot.character_ids) - set(scene.character_ids)
+            if undeclared_in_scene:
+                raise ValueError(
+                    f"shot {shot.shot_id} uses characters not declared by scene: "
+                    f"{sorted(undeclared_in_scene)}"
+                )
+
+        missing_characters = used - set(characters)
         if missing_characters:
             raise ValueError(
                 f"project graph references missing characters: {sorted(missing_characters)}"
             )
+        undeclared_in_project = used - declared
+        if undeclared_in_project:
+            raise ValueError(
+                f"project graph uses undeclared characters: {sorted(undeclared_in_project)}"
+            )
 
-        scene_locations = (scene.location_id for scene in self.scenes)
-        shot_locations = (shot.location_id for shot in self.shots)
-        required_location_ids = {
-            location_id
-            for location_id in [*scene_locations, *shot_locations]
-            if location_id is not None
-        }
+    def _validate_world_and_location_usage(
+        self,
+        worlds: dict[str, World],
+        locations: dict[str, Location],
+    ) -> None:
+        declared_worlds = set(self.project.world_ids)
+        missing_worlds = declared_worlds - set(worlds)
+        if missing_worlds:
+            raise ValueError(f"project references missing worlds: {sorted(missing_worlds)}")
+
+        for location in self.locations:
+            if location.world_id is not None and location.world_id not in worlds:
+                raise ValueError(f"location {location.location_id} references missing world")
+
+        required_location_ids: set[str] = set()
+        for scene in self.scenes:
+            if scene.location_id is not None:
+                required_location_ids.add(scene.location_id)
+        for shot in self.shots:
+            if shot.location_id is not None:
+                required_location_ids.add(shot.location_id)
+            scene = next(item for item in self.scenes if item.scene_id == shot.scene_id)
+            if (
+                scene.location_id is not None
+                and shot.location_id is not None
+                and shot.location_id != scene.location_id
+            ):
+                raise ValueError(
+                    f"shot {shot.shot_id} location differs from its continuous scene location"
+                )
+
         missing_locations = required_location_ids - set(locations)
         if missing_locations:
             raise ValueError(
                 f"project graph references missing locations: {sorted(missing_locations)}"
             )
 
-        required_prop_ids = set(self.project.prop_ids)
+        for location_id in required_location_ids:
+            world_id = locations[location_id].world_id
+            if world_id is not None and world_id not in declared_worlds:
+                raise ValueError(
+                    f"used location {location_id} belongs to undeclared world {world_id}"
+                )
+
+    def _validate_prop_usage(self, props: dict[str, Prop]) -> None:
+        declared = set(self.project.prop_ids)
+        missing_declared = declared - set(props)
+        if missing_declared:
+            raise ValueError(f"project references missing props: {sorted(missing_declared)}")
+
+        used: set[str] = set()
         for shot in self.shots:
-            required_prop_ids.update(shot.prop_ids)
-        missing_props = required_prop_ids - set(props)
+            self._assert_unique_refs(shot.prop_ids, f"shot {shot.shot_id} prop_ids")
+            used.update(shot.prop_ids)
+        missing_props = used - set(props)
         if missing_props:
             raise ValueError(f"project graph references missing props: {sorted(missing_props)}")
+        undeclared = used - declared
+        if undeclared:
+            raise ValueError(f"project graph uses undeclared props: {sorted(undeclared)}")
 
-        missing_worlds = set(self.project.world_ids) - set(worlds)
-        if missing_worlds:
-            raise ValueError(f"project references missing worlds: {sorted(missing_worlds)}")
-        for location in self.locations:
-            if location.world_id is not None and location.world_id not in worlds:
-                raise ValueError(f"location {location.location_id} references missing world")
+    def _validate_primary_edit(self) -> None:
+        if not self.shots:
+            return
+
+        acts = {act.act_id: act for act in self.acts}
+        sequences = {sequence.sequence_id: sequence for sequence in self.sequences}
+        scenes = {scene.scene_id: scene for scene in self.scenes}
+
+        def hierarchy_key(shot: Shot) -> tuple[int, int, int, int]:
+            scene = scenes[shot.scene_id]
+            sequence = sequences[scene.sequence_id]
+            act = acts[sequence.act_id]
+            return (act.order, sequence.order, scene.order, shot.order)
+
+        ordered = sorted(self.shots, key=hierarchy_key)
+        starts = [shot.time_range.start_seconds for shot in ordered]
+        if starts != sorted(starts):
+            raise ValueError("primary edit shot timing moves backwards across hierarchy")
+
+        previous = ordered[0]
+        for current in ordered[1:]:
+            if current.time_range.start_seconds < previous.time_range.end_seconds - 0.001:
+                raise ValueError(
+                    f"primary edit shots overlap: {previous.shot_id} and {current.shot_id}"
+                )
+            previous = current
 
     @staticmethod
     def _unique_by_id(items: Iterable[T], field: str, label: str) -> dict[str, T]:
@@ -207,3 +381,10 @@ class ProjectBundle(StrictModel):
         duplicates = [value for value, count in Counter(values).items() if count > 1]
         if duplicates:
             raise ValueError(f"duplicate {label} order under {parent}: {sorted(duplicates)}")
+
+    @staticmethod
+    def _assert_unique_refs(items: Iterable[str], label: str) -> None:
+        values = list(items)
+        duplicates = [value for value, count in Counter(values).items() if count > 1]
+        if duplicates:
+            raise ValueError(f"duplicate references in {label}: {sorted(duplicates)}")

--- a/packages/python-core/src/lullabies_core/aggregate.py
+++ b/packages/python-core/src/lullabies_core/aggregate.py
@@ -347,23 +347,29 @@ class ProjectBundle(StrictModel):
             raise ValueError(f"project graph uses undeclared props: {sorted(undeclared)}")
 
     def _validate_primary_edit(self) -> None:
-        if not self.shots:
+        primary_tracks = [
+            track
+            for track in self.timeline.tracks
+            if self._normalize_track_kind(track.kind) == "primary-video"
+        ]
+        if len(primary_tracks) > 1:
+            raise ValueError("timeline may contain only one primary-video track")
+        if not primary_tracks:
             return
 
-        acts = {act.act_id: act for act in self.acts}
-        sequences = {sequence.sequence_id: sequence for sequence in self.sequences}
-        scenes = {scene.scene_id: scene for scene in self.scenes}
+        primary_track = primary_tracks[0]
+        self._assert_unique_refs(primary_track.item_ids, "primary-video track item_ids")
+        shots = {shot.shot_id: shot for shot in self.shots}
+        missing = [item_id for item_id in primary_track.item_ids if item_id not in shots]
+        if missing:
+            raise ValueError(f"primary-video track references missing shots: {missing}")
+        if not primary_track.item_ids:
+            return
 
-        def hierarchy_key(shot: Shot) -> tuple[int, int, int, int]:
-            scene = scenes[shot.scene_id]
-            sequence = sequences[scene.sequence_id]
-            act = acts[sequence.act_id]
-            return (act.order, sequence.order, scene.order, shot.order)
-
-        ordered = sorted(self.shots, key=hierarchy_key)
+        ordered = [shots[shot_id] for shot_id in primary_track.item_ids]
         starts = [shot.time_range.start_seconds for shot in ordered]
         if starts != sorted(starts):
-            raise ValueError("primary edit shot timing moves backwards across hierarchy")
+            raise ValueError("primary edit shot timing moves backwards")
 
         previous = ordered[0]
         for current in ordered[1:]:
@@ -372,6 +378,10 @@ class ProjectBundle(StrictModel):
                     f"primary edit shots overlap: {previous.shot_id} and {current.shot_id}"
                 )
             previous = current
+
+    @staticmethod
+    def _normalize_track_kind(kind: str) -> str:
+        return "-".join(kind.strip().lower().replace("_", "-").split())
 
     @staticmethod
     def _unique_by_id(items: Iterable[T], field: str, label: str) -> dict[str, T]:

--- a/packages/python-core/tests/test_aggregate.py
+++ b/packages/python-core/tests/test_aggregate.py
@@ -18,6 +18,7 @@ from lullabies_core import (
     Sequence,
     Shot,
     Timeline,
+    TimelineTrack,
     TimeRange,
 )
 from lullabies_core.common import AuditFields
@@ -44,6 +45,14 @@ def valid_bundle() -> ProjectBundle:
         project_id=project.project_id,
         duration_seconds=600,
         act_ids=["ACT-000100"],
+        tracks=[
+            TimelineTrack(
+                track_id="TRK-000100",
+                kind="primary-video",
+                name="Primary Video",
+                item_ids=["SHT-000100", "SHT-000101"],
+            )
+        ],
         audit=audit(),
     )
     act = Act(
@@ -150,6 +159,7 @@ def test_project_bundle_rejects_missing_shot_reference() -> None:
 def test_project_bundle_rejects_orphan_shot_parent() -> None:
     data = valid_bundle().model_dump()
     data["scenes"][0]["shot_ids"] = ["SHT-000100"]
+    data["timeline"]["tracks"][0]["item_ids"] = ["SHT-000100"]
     data["shots"][1]["scene_id"] = "SCN-999999"
 
     with pytest.raises(ValidationError, match="missing parent scene"):
@@ -175,11 +185,19 @@ def test_project_bundle_rejects_duplicate_membership_reference() -> None:
 def test_project_bundle_rejects_duplicate_track_id() -> None:
     data = valid_bundle().model_dump()
     data["timeline"]["tracks"] = [
-        {"track_id": "TRK-000100", "kind": "video", "name": "Primary"},
+        {"track_id": "TRK-000100", "kind": "primary-video", "name": "Primary"},
         {"track_id": "TRK-000100", "kind": "audio", "name": "Music"},
     ]
 
     with pytest.raises(ValidationError, match="duplicate TimelineTrack IDs"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_primary_track_missing_shot() -> None:
+    data = valid_bundle().model_dump()
+    data["timeline"]["tracks"][0]["item_ids"] = ["SHT-000100", "SHT-999999"]
+
+    with pytest.raises(ValidationError, match="primary-video track references missing shots"):
         ProjectBundle.model_validate(data)
 
 
@@ -191,7 +209,16 @@ def test_project_bundle_rejects_primary_edit_overlap() -> None:
         ProjectBundle.model_validate(data)
 
 
-def test_project_bundle_rejects_cross_scene_time_reversal() -> None:
+def test_project_bundle_allows_parallel_broll_overlap() -> None:
+    data = valid_bundle().model_dump()
+    data["timeline"]["tracks"][0]["kind"] = "b-roll"
+    data["shots"][1]["time_range"]["start_seconds"] = 5
+
+    bundle = ProjectBundle.model_validate(data)
+    assert bundle.shots[1].time_range.start_seconds == 5
+
+
+def test_project_bundle_rejects_cross_scene_primary_time_reversal() -> None:
     data = valid_bundle().model_dump()
     scene_two = dict(data["scenes"][0])
     scene_two["scene_id"] = "SCN-000101"
@@ -205,7 +232,7 @@ def test_project_bundle_rejects_cross_scene_time_reversal() -> None:
     data["shots"][0]["time_range"]["start_seconds"] = 6
     data["shots"][1]["time_range"]["start_seconds"] = 0
 
-    with pytest.raises(ValidationError, match="moves backwards across hierarchy"):
+    with pytest.raises(ValidationError, match="primary edit shot timing moves backwards"):
         ProjectBundle.model_validate(data)
 
 

--- a/packages/python-core/tests/test_aggregate.py
+++ b/packages/python-core/tests/test_aggregate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 import pytest
+from lineage_fixtures import full_lineage_bundle
 from pydantic import ValidationError
 
 from lullabies_core import (
@@ -104,11 +105,37 @@ def test_project_bundle_validates_cross_entity_graph() -> None:
     assert len(bundle.shots) == 2
 
 
+def test_two_minute_lineage_project_remains_valid() -> None:
+    project_bundle = full_lineage_bundle().project_bundle
+    assert project_bundle.project.target_duration_seconds == 120
+    assert ProjectBundle.model_validate(project_bundle.model_dump()) == project_bundle
+
+
+def test_ninety_minute_project_remains_valid() -> None:
+    data = valid_bundle().model_dump()
+    data["project"]["target_duration_seconds"] = 5400
+    data["timeline"]["duration_seconds"] = 5400
+    data["acts"][0]["target_duration_seconds"] = 5400
+    data["sequences"][0]["target_duration_seconds"] = 5400
+    data["scenes"][0]["target_duration_seconds"] = 5400
+
+    bundle = ProjectBundle.model_validate(data)
+    assert bundle.timeline.duration_seconds == 5400
+
+
 def test_project_bundle_rejects_timeline_duration_mismatch() -> None:
     bundle = valid_bundle()
     data = bundle.model_dump()
     data["timeline"]["duration_seconds"] = 599
     with pytest.raises(ValidationError, match="timeline duration"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_wrong_active_timeline() -> None:
+    data = full_lineage_bundle().project_bundle.model_dump()
+    data["project"]["active_timeline_id"] = "TML-999999"
+
+    with pytest.raises(ValidationError, match="active_timeline_id"):
         ProjectBundle.model_validate(data)
 
 
@@ -120,9 +147,164 @@ def test_project_bundle_rejects_missing_shot_reference() -> None:
         ProjectBundle.model_validate(data)
 
 
+def test_project_bundle_rejects_orphan_shot_parent() -> None:
+    data = valid_bundle().model_dump()
+    data["scenes"][0]["shot_ids"] = ["SHT-000100"]
+    data["shots"][1]["scene_id"] = "SCN-999999"
+
+    with pytest.raises(ValidationError, match="missing parent scene"):
+        ProjectBundle.model_validate(data)
+
+
 def test_project_bundle_rejects_duplicate_shot_order() -> None:
     bundle = valid_bundle()
     data = bundle.model_dump()
     data["shots"][1]["order"] = 1
     with pytest.raises(ValidationError, match="duplicate Shot order"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_duplicate_membership_reference() -> None:
+    data = valid_bundle().model_dump()
+    data["timeline"]["act_ids"].append("ACT-000100")
+
+    with pytest.raises(ValidationError, match="duplicate references in timeline.act_ids"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_duplicate_track_id() -> None:
+    data = valid_bundle().model_dump()
+    data["timeline"]["tracks"] = [
+        {"track_id": "TRK-000100", "kind": "video", "name": "Primary"},
+        {"track_id": "TRK-000100", "kind": "audio", "name": "Music"},
+    ]
+
+    with pytest.raises(ValidationError, match="duplicate TimelineTrack IDs"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_primary_edit_overlap() -> None:
+    data = valid_bundle().model_dump()
+    data["shots"][1]["time_range"]["start_seconds"] = 5
+
+    with pytest.raises(ValidationError, match="primary edit shots overlap"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_cross_scene_time_reversal() -> None:
+    data = valid_bundle().model_dump()
+    scene_two = dict(data["scenes"][0])
+    scene_two["scene_id"] = "SCN-000101"
+    scene_two["order"] = 2
+    scene_two["title"] = "Scene 2"
+    scene_two["shot_ids"] = ["SHT-000101"]
+    data["scenes"][0]["shot_ids"] = ["SHT-000100"]
+    data["scenes"].append(scene_two)
+    data["sequences"][0]["scene_ids"] = ["SCN-000100", "SCN-000101"]
+    data["shots"][1]["scene_id"] = "SCN-000101"
+    data["shots"][0]["time_range"]["start_seconds"] = 6
+    data["shots"][1]["time_range"]["start_seconds"] = 0
+
+    with pytest.raises(ValidationError, match="moves backwards across hierarchy"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_character_used_but_not_declared_by_project() -> None:
+    data = full_lineage_bundle().project_bundle.model_dump()
+    data["project"]["character_ids"] = []
+
+    with pytest.raises(ValidationError, match="uses undeclared characters"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_character_used_but_not_declared_by_scene() -> None:
+    data = full_lineage_bundle().project_bundle.model_dump()
+    data["scenes"][0]["character_ids"] = []
+
+    with pytest.raises(ValidationError, match="not declared by scene"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_duplicate_character_version_number() -> None:
+    data = full_lineage_bundle().project_bundle.model_dump()
+    data["character_versions"][1]["version"] = 1
+
+    with pytest.raises(ValidationError, match="duplicate version number"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_invalid_pinned_look() -> None:
+    data = full_lineage_bundle().project_bundle.model_dump()
+    data["characters"][0]["lock"] = {
+        "scope": "look",
+        "pinned_character_version_id": "CHV-000500",
+        "pinned_look_id": "LOOK-999999",
+        "project_id": None,
+        "scene_id": None,
+    }
+
+    with pytest.raises(ValidationError, match="lock look is not in pinned version"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_scene_lock_where_character_is_absent() -> None:
+    data = full_lineage_bundle().project_bundle.model_dump()
+    data["characters"][0]["lock"] = {
+        "scope": "scene",
+        "pinned_character_version_id": "CHV-000500",
+        "pinned_look_id": None,
+        "project_id": None,
+        "scene_id": "SCN-000500",
+    }
+    data["scenes"][0]["character_ids"] = []
+    data["shots"][0]["character_ids"] = []
+
+    with pytest.raises(ValidationError, match="character is not declared"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_used_location_from_undeclared_world() -> None:
+    data = valid_bundle().model_dump()
+    data["worlds"] = [
+        {
+            "world_id": "WRL-000100",
+            "name": "Fixture world",
+            "audit": audit().model_dump(),
+        }
+    ]
+    data["locations"] = [
+        {
+            "location_id": "LOC-000100",
+            "world_id": "WRL-000100",
+            "name": "Fixture location",
+            "audit": audit().model_dump(),
+        }
+    ]
+    data["scenes"][0]["location_id"] = "LOC-000100"
+
+    with pytest.raises(ValidationError, match="undeclared world"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_shot_location_different_from_scene() -> None:
+    data = valid_bundle().model_dump()
+    data["locations"] = [
+        {"location_id": "LOC-000100", "name": "A", "audit": audit().model_dump()},
+        {"location_id": "LOC-000101", "name": "B", "audit": audit().model_dump()},
+    ]
+    data["scenes"][0]["location_id"] = "LOC-000100"
+    data["shots"][0]["location_id"] = "LOC-000101"
+
+    with pytest.raises(ValidationError, match="differs from its continuous scene location"):
+        ProjectBundle.model_validate(data)
+
+
+def test_project_bundle_rejects_used_prop_not_declared_by_project() -> None:
+    data = valid_bundle().model_dump()
+    data["props"] = [
+        {"prop_id": "PRP-000100", "name": "Star wand", "audit": audit().model_dump()}
+    ]
+    data["shots"][0]["prop_ids"] = ["PRP-000100"]
+
+    with pytest.raises(ValidationError, match="uses undeclared props"):
         ProjectBundle.model_validate(data)


### PR DESCRIPTION
## Scope
Implements approved M01/WP3 only.

## Aggregate hardening
- reject wrong active timeline references and duplicate TimelineTrack IDs
- reject duplicate hierarchy/reference memberships previously masked by set comparisons
- reject orphan shots and inconsistent parent ownership
- enforce deterministic selected-Take loading and exact Take membership
- validate CharacterVersion ownership, duplicate version numbers, globally unique look IDs, pinned look resolution, project/scene lock targets
- require used shot characters to be declared by their Scene and Project
- require used props to be declared by the Project
- validate used locations/world declarations and continuous-scene location consistency
- validate canonical non-overlap/order only on an explicitly modeled `primary-video` track
- preserve valid parallel B-roll/overlay timing
- explicitly verify valid 2-minute and 90-minute project graphs
- use indexed scene lookups for long-form validation scalability

## Boundary
No provider execution, Temporal, PostgreSQL, migrations, FastAPI/UI, publishing, storage runtime, or M02+ behavior.

## Verified acceptance
Python 3.12 `Core Domain Contracts` run `33217875292`, job `99005474118` passed:
- Ruff
- strict mypy
- unit tests
- generated-schema synchronization
- compile/import check

Checkpoint: `checkpoints/2026-08-29-m01-wp3-aggregate-hardening-complete.md`.