### PR TITLE
M01/WP4 — Implement legacy CNT content import boundary

### DIFF
--- a/checkpoints/2026-08-29-m01-wp4-legacy-content-import-complete.md
+++ b/checkpoints/2026-08-29-m01-wp4-legacy-content-import-complete.md
@@ -1,0 +1,81 @@
+# M01 / WP4 — Legacy Content Import Boundary Complete
+
+Date: 2026-08-29
+
+Status: `M01_DEVELOPMENT_IN_PROGRESS`
+
+Work package: `WP4 — Legacy CNT content importer boundary`
+
+## Result
+
+WP4 is implementation-complete and verified on Python 3.12.
+
+The core now has a deterministic, provider-neutral compatibility boundary for legacy `schemas/content-package.schema.json` v1 packages. The mapper accepts parsed legacy metadata plus explicitly resolved exact content text, validates compatibility with current canonical contracts, and returns generalized `Content`, `ContentVersion`, and an import report without filesystem reads or persistence side effects.
+
+## Proven behavior
+
+- legacy source payload is never mutated;
+- stable `CNT-*` identity is preserved;
+- first canonical version identity is deterministic (`CNT-000321` -> `CTV-000321`, version 1);
+- exact content/performance text is preserved without rewriting;
+- source status, timestamps, provenance path, objective, premise/hook, tags/topics and originality fingerprint are mapped deterministically;
+- documented lullaby modes refine safely to `spoken-lullaby` or `sung-lullaby`;
+- free-text legacy character names/settings never fabricate canonical Character/World/Location IDs;
+- missing duration, incompatible duration, malformed metadata, empty exact content and invalid timestamp chronology fail explicitly;
+- deterministic SHA-256 source fingerprint/import key is generated;
+- reconciliation is pure and returns `create`, `noop`, or fail-closed `conflict`;
+- exact repeat import is idempotency-ready and becomes a `noop` once the same canonical records are persisted;
+- changed source material under the same stable legacy identity is a conflict rather than an overwrite;
+- partial or drifted persisted state is a conflict requiring recovery.
+
+## Mapping contract
+
+Canonical documentation:
+
+`docs/architecture/LEGACY-CONTENT-IMPORT-BOUNDARY.md`
+
+Mapping version:
+
+`legacy-content-v1-to-core-v1`
+
+## Repository evidence limitation
+
+At implementation time `memory/content-index.json` contains no legacy catalogue items. WP4 therefore does not claim that a real production catalogue migration has already run.
+
+Acceptance uses a schema-faithful representative legacy fixture. Actual legacy packages, when available, must pass through the same deterministic mapper/reconciliation boundary and be recorded as migration evidence.
+
+## Verification evidence
+
+GitHub Actions workflow: `Core Domain Contracts`
+
+Run: `33218758449`
+
+Job: `99008142155`
+
+Verified successful gates:
+
+- Ruff;
+- strict mypy;
+- unit tests, including positive, negative, deterministic and reconciliation cases;
+- generated-schema synchronization;
+- Python compile/import check.
+
+## Scope boundary preserved
+
+WP4 did **not** implement:
+
+- PostgreSQL writes, tables, migrations or repositories;
+- filesystem traversal/mutation of legacy packages;
+- AI/media provider execution;
+- Temporal workflows;
+- FastAPI/UI/auth;
+- publishing/analytics;
+- M02+ behavior.
+
+## Next authorized work
+
+Within the already-approved M01 scope, the next work package is:
+
+`WP5 — PostgreSQL persistence architecture`
+
+WP5 should define the relational persistence mapping, constraints, transaction boundaries and repository contracts for the stabilized canonical domain without yet applying irreversible production migrations.

--- a/checkpoints/LATEST.md
+++ b/checkpoints/LATEST.md
@@ -1,7 +1,7 @@
 # Latest Checkpoint
 
 Current checkpoint:
-`checkpoints/2026-08-29-m01-wp3-aggregate-hardening-complete.md`
+`checkpoints/2026-08-29-m01-wp4-legacy-content-import-complete.md`
 
 Current phase: **M01 — Core Domain & Persistence Boundary**
 
@@ -37,24 +37,33 @@ Checkpoint:
 
 ### WP3 — Aggregate validation hardening
 
-Implementation and Python 3.12 verification complete on the WP3 branch/PR.
+Merged via PR #3.
+
+Merge commit:
+`2e648fd27c44d0186bab76668002114298cc82b8`
 
 Checkpoint:
 `checkpoints/2026-08-29-m01-wp3-aggregate-hardening-complete.md`
 
-The project graph now rejects duplicate/missing hierarchy references, invalid character/version/look/lock ownership, undeclared character/world/prop use, inconsistent scene locations, and invalid explicit primary-video timing while preserving parallel B-roll timing.
+### WP4 — Legacy CNT content importer boundary
+
+Implementation and Python 3.12 verification complete on PR #4.
+
+Checkpoint:
+`checkpoints/2026-08-29-m01-wp4-legacy-content-import-complete.md`
+
+The legacy v1 compatibility boundary now performs deterministic mapping into canonical Content/ContentVersion records, preserves source identity/provenance, never fabricates canonical entities from free text, and provides fail-closed `create` / `noop` / `conflict` reconciliation for future persistence.
 
 ## Current next step
 
-`WP4 — Legacy CNT content importer boundary`
+`WP5 — PostgreSQL persistence architecture`
 
 ## Remaining M01 sequence
 
-1. WP4 — legacy `CNT-*` content importer boundary;
-2. WP5 — PostgreSQL persistence architecture;
-3. WP6 — reversible migration scaffold;
-4. WP7 — repositories and short/long project round-trip verification;
-5. WP8 — complete M01 verification and final checkpoint.
+1. WP5 — PostgreSQL persistence architecture;
+2. WP6 — reversible migration scaffold;
+3. WP7 — repositories and short/long project round-trip verification;
+4. WP8 — complete M01 verification and final checkpoint.
 
 ## Scope boundary
 

--- a/docs/architecture/LEGACY-CONTENT-IMPORT-BOUNDARY.md
+++ b/docs/architecture/LEGACY-CONTENT-IMPORT-BOUNDARY.md
@@ -1,0 +1,144 @@
+# Legacy Content Import Boundary
+
+Status: M01/WP4 implementation contract  
+Mapping version: `legacy-content-v1-to-core-v1`
+
+## Purpose
+
+Migrate the repository's legacy `schemas/content-package.schema.json` v1 metadata shape into the generalized M01 `Content` / `ContentVersion` domain without mutating legacy source files, inventing canonical identities, or performing persistence inside the mapper.
+
+The importer is a pure compatibility boundary. PostgreSQL persistence begins in later M01 work packages.
+
+## Inputs
+
+The importer receives two explicit inputs:
+
+1. parsed legacy metadata payload;
+2. the exact resolved content/performance text referenced by legacy `paths.content`.
+
+It does **not** read `paths.*` itself. Callers resolve files and pass bytes/text explicitly so path traversal, hidden I/O, repository assumptions, and persistence side effects do not enter the domain mapping function.
+
+## Source validation
+
+`LegacyContentPackageV1` mirrors legacy top-level schema v1 and rejects unknown top-level fields.
+
+Legacy nested objects intentionally permit additional properties because the historical JSON Schema did not set `additionalProperties: false` on those nested objects.
+
+Mapping rejects safely when:
+
+- required legacy fields are absent or malformed;
+- `content_id` is not `CNT-######`;
+- exact content text is empty;
+- `approved_at` precedes `created_at`;
+- duration cannot satisfy the canonical 60..10800 second boundary;
+- metadata cannot be deterministically serialized as canonical JSON.
+
+No duration is guessed or clamped. Legacy schema allowed durations from one second, while current canonical contracts require at least 60 seconds; incompatible legacy input must therefore be repaired or intentionally migrated by a future operator-controlled policy rather than silently rewritten.
+
+## Stable identity mapping
+
+Legacy identity is preserved:
+
+- `CNT-000321` -> `Content.content_id = CNT-000321`;
+- first imported canonical version -> `CTV-000321`;
+- `Content.active_version_id = CTV-000321`;
+- imported canonical version number = `1`.
+
+A changed source package using the same legacy `CNT-*` identity does **not** automatically overwrite `CTV-*`. Reconciliation reports a conflict so a future versioning/migration decision is explicit.
+
+## Field mapping
+
+| Legacy | Canonical | Rule |
+| --- | --- | --- |
+| `content_id` | `Content.content_id` | preserved |
+| `status` | `Content.status` | preserved source state |
+| `paths.package` | `Content.source_legacy_package_path` | preserved provenance path |
+| `title` | `ContentVersion.title` | preserved |
+| `content_type` | `ContentVersion.content_format` | identity-preserved except safe lullaby mode refinement |
+| `language` | `ContentVersion.language` | preserved |
+| `target_duration_seconds` | same | must already satisfy canonical range |
+| `objective.*` | `ContentVersion.objective.*` | preserved |
+| `creative.premise` | `ContentVersion.premise` | preserved |
+| `creative.hook` | `ContentVersion.hook` | preserved |
+| resolved `paths.content` text | `script_or_lyrics` | exact text, no rewrite |
+| `creative.tags + creative.topics` | `tags` | stable de-duplicated union |
+| `fingerprints.exact_text` | `originality_fingerprint` | preserved when present; otherwise SHA-256 of exact content text |
+| `created_at` | audit created time | preserved |
+| `approved_at` | audit updated time | used when present; otherwise `created_at` |
+
+### Lullaby refinement
+
+The current Content Type Bible explicitly distinguishes spoken and sung lullabies. Therefore:
+
+- legacy `lullaby + speech` -> `spoken-lullaby`;
+- legacy `lullaby + music` -> `sung-lullaby`;
+- legacy `lullaby + chant` -> `sung-lullaby`.
+
+No provider-specific behavior is inferred from this refinement.
+
+## Deliberately unmapped legacy fields
+
+Legacy `creative.characters` contains free-text names, not canonical `CHR-*` identities. The importer records them in `unmapped_character_names` and never fabricates Character IDs.
+
+Legacy `creative.setting` is free text. It is recorded as `unmapped_setting`; the importer never fabricates World/Location IDs.
+
+Legacy age-band and detailed audio routing metadata remain source metadata/warnings because project/audience and audio production migration are outside WP4.
+
+## Fingerprint and import key
+
+The importer computes SHA-256 over:
+
+`deterministically serialized metadata + exact content text`
+
+and produces:
+
+`legacy-content-v1-to-core-v1:<CNT-ID>:<sha256>`
+
+The source payload is not mutated while computing this value.
+
+## Reconciliation contract
+
+`reconcile_legacy_content_import(...)` is pure and performs no database write.
+
+It returns one of:
+
+- `create`: neither canonical Content nor ContentVersion exists;
+- `noop`: exact deterministic canonical records already exist;
+- `conflict`: partial state, identity mismatch, changed import key/source, or canonical record drift exists.
+
+A conflict is intentionally fail-closed. The importer never overwrites existing canonical data automatically.
+
+WP5/WP6/WP7 persistence code may consume this decision inside a database transaction, but must preserve the same semantics.
+
+## Idempotency
+
+Repeating the same metadata and exact content text yields the same:
+
+- `CNT-*` identity;
+- `CTV-*` identity;
+- canonical Content and ContentVersion values;
+- source SHA-256;
+- import key;
+- reconciliation result (`noop`) once those exact records are persisted.
+
+This is the M01 idempotency boundary; it does not imply that the pure mapper itself stores anything.
+
+## Current repository evidence
+
+At implementation time `memory/content-index.json` contains no legacy catalogue items. Therefore WP4 does not claim a real production catalogue migration has already run.
+
+Acceptance uses a schema-faithful representative fixture. When actual legacy packages become available, the same deterministic importer/reconciliation contract is used and each result must be recorded as migration evidence.
+
+## Non-goals / scope boundary
+
+WP4 does not:
+
+- mutate or delete legacy files;
+- traverse repository paths;
+- write PostgreSQL;
+- create Characters/Worlds/Locations from free text;
+- call AI/media providers;
+- run Temporal workflows;
+- publish content;
+- migrate audience policy, audio production state, or generation history;
+- authorize M02+ behavior.

--- a/packages/python-core/src/lullabies_core/__init__.py
+++ b/packages/python-core/src/lullabies_core/__init__.py
@@ -26,7 +26,9 @@ from .legacy_import import (
     LegacyContentImportReport,
     LegacyContentImportResult,
     LegacyContentPackageV1,
+    LegacyContentReconciliation,
     import_legacy_content_package,
+    reconcile_legacy_content_import,
 )
 from .lineage import ProductionLineageBundle
 from .production import (
@@ -87,6 +89,7 @@ __all__ = [
     "LegacyContentImportReport",
     "LegacyContentImportResult",
     "LegacyContentPackageV1",
+    "LegacyContentReconciliation",
     "Location",
     "LockScope",
     "OutputProfile",
@@ -110,4 +113,5 @@ __all__ = [
     "VoiceProfile",
     "World",
     "import_legacy_content_package",
+    "reconcile_legacy_content_import",
 ]

--- a/packages/python-core/src/lullabies_core/__init__.py
+++ b/packages/python-core/src/lullabies_core/__init__.py
@@ -20,6 +20,14 @@ from .common import (
 )
 from .content import Content, ContentObjective, ContentVersion
 from .entities import Location, Prop, StyleProfile, VoiceProfile, World
+from .legacy_import import (
+    LEGACY_CONTENT_MAPPING_VERSION,
+    LegacyContentImportError,
+    LegacyContentImportReport,
+    LegacyContentImportResult,
+    LegacyContentPackageV1,
+    import_legacy_content_package,
+)
 from .lineage import ProductionLineageBundle
 from .production import (
     Approval,
@@ -43,6 +51,8 @@ from .project import (
 from .timeline import Act, ContinuityState, Scene, Sequence, Shot, Take, Timeline, TimelineTrack
 
 __all__ = [
+    "LEGACY_CONTENT_MAPPING_VERSION",
+    "SCHEMA_VERSION",
     "Act",
     "Approval",
     "ApprovalDecision",
@@ -73,6 +83,10 @@ __all__ = [
     "GenerationRequest",
     "Job",
     "JobStatus",
+    "LegacyContentImportError",
+    "LegacyContentImportReport",
+    "LegacyContentImportResult",
+    "LegacyContentPackageV1",
     "Location",
     "LockScope",
     "OutputProfile",
@@ -85,7 +99,6 @@ __all__ = [
     "ProviderPolicyRef",
     "QARecord",
     "RightsRecord",
-    "SCHEMA_VERSION",
     "Scene",
     "Sequence",
     "Shot",
@@ -96,4 +109,5 @@ __all__ = [
     "TimelineTrack",
     "VoiceProfile",
     "World",
+    "import_legacy_content_package",
 ]

--- a/packages/python-core/src/lullabies_core/legacy_import.py
+++ b/packages/python-core/src/lullabies_core/legacy_import.py
@@ -9,7 +9,9 @@ from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 from .common import AuditFields, ContentId, ContentVersionId, StrictModel
 from .content import Content, ContentObjective, ContentVersion
 
-LEGACY_CONTENT_MAPPING_VERSION = "legacy-content-v1-to-core-v1"
+LEGACY_CONTENT_MAPPING_VERSION: Literal["legacy-content-v1-to-core-v1"] = (
+    "legacy-content-v1-to-core-v1"
+)
 
 LegacyContentType = Literal[
     "song",
@@ -211,7 +213,8 @@ def import_legacy_content_package(
     """
 
     legacy = LegacyContentPackageV1.model_validate(payload)
-    _validate_mapping_preconditions(legacy, content_text)
+    target_duration_seconds = _validated_target_duration(legacy)
+    _validate_content_text(content_text)
 
     content_version_id = _content_version_id(legacy.content_id)
     canonical_format = _canonical_content_format(legacy)
@@ -243,7 +246,7 @@ def import_legacy_content_package(
         title=legacy.title,
         content_format=canonical_format,
         language=legacy.language,
-        target_duration_seconds=legacy.target_duration_seconds,
+        target_duration_seconds=target_duration_seconds,
         objective=ContentObjective(
             primary=legacy.objective.primary,
             entertainment=legacy.objective.entertainment,
@@ -299,27 +302,27 @@ def reconcile_legacy_content_import(
     """
 
     report = imported.report
-    base = {
-        "canonical_content_id": report.canonical_content_id,
-        "canonical_content_version_id": report.canonical_content_version_id,
-        "source_fingerprint_sha256": report.source_fingerprint_sha256,
-        "import_key": report.import_key,
-    }
 
     if existing_content is None and existing_content_version is None:
         return LegacyContentReconciliation(
             action="create",
+            canonical_content_id=report.canonical_content_id,
+            canonical_content_version_id=report.canonical_content_version_id,
+            source_fingerprint_sha256=report.source_fingerprint_sha256,
+            import_key=report.import_key,
             reason="canonical content identity is not persisted",
-            **base,
         )
 
     if existing_content is None or existing_content_version is None:
         missing = "content" if existing_content is None else "content_version"
         return LegacyContentReconciliation(
             action="conflict",
+            canonical_content_id=report.canonical_content_id,
+            canonical_content_version_id=report.canonical_content_version_id,
+            source_fingerprint_sha256=report.source_fingerprint_sha256,
+            import_key=report.import_key,
             reason="canonical persistence state is partial and requires operator recovery",
             conflict_fields=[missing],
-            **base,
         )
 
     conflicts: list[str] = []
@@ -335,9 +338,12 @@ def reconcile_legacy_content_import(
     if conflicts:
         return LegacyContentReconciliation(
             action="conflict",
+            canonical_content_id=report.canonical_content_id,
+            canonical_content_version_id=report.canonical_content_version_id,
+            source_fingerprint_sha256=report.source_fingerprint_sha256,
+            import_key=report.import_key,
             reason="stable legacy identity resolves to conflicting persisted identity or source",
             conflict_fields=conflicts,
-            **base,
         )
 
     record_conflicts: list[str] = []
@@ -348,20 +354,27 @@ def reconcile_legacy_content_import(
     if record_conflicts:
         return LegacyContentReconciliation(
             action="conflict",
+            canonical_content_id=report.canonical_content_id,
+            canonical_content_version_id=report.canonical_content_version_id,
+            source_fingerprint_sha256=report.source_fingerprint_sha256,
+            import_key=report.import_key,
             reason="stable legacy identity already exists with different canonical data",
             conflict_fields=record_conflicts,
-            **base,
         )
 
     return LegacyContentReconciliation(
         action="noop",
+        canonical_content_id=report.canonical_content_id,
+        canonical_content_version_id=report.canonical_content_version_id,
+        source_fingerprint_sha256=report.source_fingerprint_sha256,
+        import_key=report.import_key,
         reason="same deterministic import is already represented canonically",
-        **base,
     )
 
 
-def _validate_mapping_preconditions(legacy: LegacyContentPackageV1, content_text: str) -> None:
-    if legacy.target_duration_seconds is None:
+def _validated_target_duration(legacy: LegacyContentPackageV1) -> int:
+    target_duration_seconds = legacy.target_duration_seconds
+    if target_duration_seconds is None:
         raise LegacyContentImportError(
             "LEGACY_DURATION_REQUIRED",
             (
@@ -370,12 +383,16 @@ def _validate_mapping_preconditions(legacy: LegacyContentPackageV1, content_text
             ),
             "target_duration_seconds",
         )
-    if not 60 <= legacy.target_duration_seconds <= 10800:
+    if not 60 <= target_duration_seconds <= 10800:
         raise LegacyContentImportError(
             "LEGACY_DURATION_OUT_OF_CANONICAL_RANGE",
             "target duration must be within the canonical 60..10800 second range",
             "target_duration_seconds",
         )
+    return target_duration_seconds
+
+
+def _validate_content_text(content_text: str) -> None:
     if not content_text.strip():
         raise LegacyContentImportError(
             "LEGACY_CONTENT_TEXT_REQUIRED",

--- a/packages/python-core/src/lullabies_core/legacy_import.py
+++ b/packages/python-core/src/lullabies_core/legacy_import.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Annotated, Any, Literal
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
+
+from .common import AuditFields, ContentId, ContentVersionId, StrictModel
+from .content import Content, ContentObjective, ContentVersion
+
+LEGACY_CONTENT_MAPPING_VERSION = "legacy-content-v1-to-core-v1"
+
+LegacyContentType = Literal[
+    "song",
+    "lullaby",
+    "poem",
+    "rhyme",
+    "story",
+    "bedtime-story",
+    "educational-narration",
+    "guided-imagination",
+]
+LegacyAgeBand = Literal[
+    "baby-audio",
+    "toddler",
+    "preschool",
+    "early-primary",
+    "junior",
+    "preteen",
+]
+LegacyStatus = Literal[
+    "idea",
+    "researched",
+    "uniqueness-cleared",
+    "drafted",
+    "qa-passed",
+    "audio-ready",
+    "approved",
+    "audio-generated",
+    "video-planned",
+    "video-generated",
+    "publish-ready",
+    "published",
+    "analyzed",
+]
+LegacyAudioMode = Literal["speech", "music", "chant"]
+LegacyProviderFamily = Literal["gemini-tts", "lyria"]
+LegacyRenderStatus = Literal["not-rendered", "queued", "rendered", "qa-passed", "rejected"]
+LegacyOriginalityDecision = Literal[
+    "CLEAR",
+    "CLEAR_WITH_DIFFERENTIATION",
+    "REJECT_DUPLICATE",
+    "REJECT_DERIVATIVE",
+    "DEFER_PORTFOLIO_FATIGUE",
+]
+
+
+class LegacyNestedModel(BaseModel):
+    """Nested legacy objects preserve JSON Schema's default extra-field behavior."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class LegacyObjective(LegacyNestedModel):
+    primary: str
+    entertainment: str
+    learning: str | None = None
+    emotional: str | None = None
+
+
+class LegacyCreative(LegacyNestedModel):
+    premise: str
+    hook: str
+    creative_device: str
+    characters: list[str] = Field(default_factory=list)
+    setting: str | None = None
+    topics: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+
+
+class LegacyAudio(LegacyNestedModel):
+    audio_mode: LegacyAudioMode
+    provider_family: LegacyProviderFamily
+    preferred_model: str
+    female_voice_required: bool
+    prompt_version: str
+    selected_voice: str | None = None
+    render_status: LegacyRenderStatus | None = None
+
+
+class LegacyOriginality(LegacyNestedModel):
+    decision: LegacyOriginalityDecision
+    closest_prior_ids: list[str]
+    notes: str = ""
+
+
+class LegacyQA(LegacyNestedModel):
+    all_mandatory_gates_passed: bool
+    qa_file: str | None = None
+
+
+class LegacyResearch(LegacyNestedModel):
+    research_file: str | None = None
+    source_count: Annotated[int | None, Field(ge=0)] = None
+
+
+class LegacyFingerprints(LegacyNestedModel):
+    title: str | None = None
+    premise: str | None = None
+    hook: str | None = None
+    exact_text: str | None = None
+
+
+class LegacyPaths(LegacyNestedModel):
+    package: str
+    content: str
+    metadata: str
+    audio_prompt: str
+    qa: str
+    research: str
+
+
+class LegacyContentPackageV1(BaseModel):
+    """Executable compatibility model for `schemas/content-package.schema.json` v1."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1]
+    content_id: Annotated[str, Field(pattern=r"^CNT-[0-9]{6}$")]
+    run_id: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    normalized_title: str | None = None
+    slug: str = Field(pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+    content_type: LegacyContentType
+    age_band: LegacyAgeBand
+    language: str = Field(min_length=2)
+    status: LegacyStatus
+    target_duration_seconds: Annotated[int | None, Field(ge=1)] = None
+    objective: LegacyObjective
+    creative: LegacyCreative
+    audio: LegacyAudio
+    originality: LegacyOriginality
+    qa: LegacyQA
+    research: LegacyResearch | None = None
+    fingerprints: LegacyFingerprints | None = None
+    paths: LegacyPaths
+    created_at: AwareDatetime
+    approved_at: AwareDatetime | None = None
+
+
+class LegacyContentImportReport(StrictModel):
+    mapping_version: Literal["legacy-content-v1-to-core-v1"] = LEGACY_CONTENT_MAPPING_VERSION
+    source_schema_version: Literal[1] = 1
+    source_content_id: ContentId
+    canonical_content_id: ContentId
+    canonical_content_version_id: ContentVersionId
+    source_fingerprint_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    import_key: str = Field(min_length=1)
+    source_run_id: str
+    source_package_path: str
+    legacy_age_band: str
+    legacy_content_type: str
+    canonical_content_format: str
+    legacy_audio_mode: str
+    unmapped_character_names: list[str] = Field(default_factory=list)
+    unmapped_setting: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class LegacyContentImportResult(StrictModel):
+    content: Content
+    content_version: ContentVersion
+    report: LegacyContentImportReport
+
+
+class LegacyContentImportError(ValueError):
+    """Recoverable legacy-to-canonical mapping failure with a stable machine code."""
+
+    def __init__(self, code: str, message: str, field: str | None = None) -> None:
+        self.code = code
+        self.field = field
+        detail = f"{code}: {message}"
+        if field is not None:
+            detail = f"{detail} [field={field}]"
+        super().__init__(detail)
+
+
+def import_legacy_content_package(
+    payload: dict[str, Any],
+    content_text: str,
+) -> LegacyContentImportResult:
+    """Map one legacy metadata package plus its resolved canonical text without I/O.
+
+    The function never mutates `payload`, never reads paths from the package, and never
+    writes persistence. Repeating the same inputs produces the same canonical IDs,
+    source fingerprint and import key.
+    """
+
+    legacy = LegacyContentPackageV1.model_validate(payload)
+    _validate_mapping_preconditions(legacy, content_text)
+
+    content_version_id = _content_version_id(legacy.content_id)
+    canonical_format = _canonical_content_format(legacy)
+    source_fingerprint = _source_fingerprint(payload, content_text)
+    updated_at = legacy.approved_at or legacy.created_at
+    if updated_at < legacy.created_at:
+        raise LegacyContentImportError(
+            "LEGACY_APPROVAL_PRECEDES_CREATION",
+            "approved_at cannot precede created_at",
+            "approved_at",
+        )
+
+    audit = AuditFields(
+        created_at=legacy.created_at,
+        updated_at=updated_at,
+        created_by=f"legacy-import:{legacy.run_id}",
+    )
+    content = Content(
+        content_id=legacy.content_id,
+        active_version_id=content_version_id,
+        status=legacy.status,
+        source_legacy_package_path=legacy.paths.package,
+        audit=audit,
+    )
+    content_version = ContentVersion(
+        content_version_id=content_version_id,
+        content_id=legacy.content_id,
+        version=1,
+        title=legacy.title,
+        content_format=canonical_format,
+        language=legacy.language,
+        target_duration_seconds=legacy.target_duration_seconds,
+        objective=ContentObjective(
+            primary=legacy.objective.primary,
+            entertainment=legacy.objective.entertainment,
+            learning=legacy.objective.learning,
+            emotional=legacy.objective.emotional,
+        ),
+        premise=legacy.creative.premise,
+        hook=legacy.creative.hook,
+        script_or_lyrics=content_text,
+        tags=_stable_unique([*legacy.creative.tags, *legacy.creative.topics]),
+        originality_fingerprint=_originality_fingerprint(legacy, content_text),
+        audit=audit.model_copy(deep=True),
+    )
+
+    warnings = _mapping_warnings(legacy)
+    report = LegacyContentImportReport(
+        source_content_id=legacy.content_id,
+        canonical_content_id=content.content_id,
+        canonical_content_version_id=content_version.content_version_id,
+        source_fingerprint_sha256=source_fingerprint,
+        import_key=(
+            f"{LEGACY_CONTENT_MAPPING_VERSION}:{legacy.content_id}:{source_fingerprint}"
+        ),
+        source_run_id=legacy.run_id,
+        source_package_path=legacy.paths.package,
+        legacy_age_band=legacy.age_band,
+        legacy_content_type=legacy.content_type,
+        canonical_content_format=canonical_format,
+        legacy_audio_mode=legacy.audio.audio_mode,
+        unmapped_character_names=list(legacy.creative.characters),
+        unmapped_setting=legacy.creative.setting,
+        warnings=warnings,
+    )
+    return LegacyContentImportResult(
+        content=content,
+        content_version=content_version,
+        report=report,
+    )
+
+
+def _validate_mapping_preconditions(legacy: LegacyContentPackageV1, content_text: str) -> None:
+    if legacy.target_duration_seconds is None:
+        raise LegacyContentImportError(
+            "LEGACY_DURATION_REQUIRED",
+            "target_duration_seconds is optional in v1 metadata but required by the canonical model",
+            "target_duration_seconds",
+        )
+    if not 60 <= legacy.target_duration_seconds <= 10800:
+        raise LegacyContentImportError(
+            "LEGACY_DURATION_OUT_OF_CANONICAL_RANGE",
+            "target duration must be within the canonical 60..10800 second range",
+            "target_duration_seconds",
+        )
+    if not content_text.strip():
+        raise LegacyContentImportError(
+            "LEGACY_CONTENT_TEXT_REQUIRED",
+            "resolved content text is empty",
+            "paths.content",
+        )
+
+
+def _content_version_id(content_id: str) -> str:
+    return f"CTV-{content_id.removeprefix('CNT-')}"
+
+
+def _canonical_content_format(legacy: LegacyContentPackageV1) -> str:
+    if legacy.content_type != "lullaby":
+        return legacy.content_type
+    if legacy.audio.audio_mode == "speech":
+        return "spoken-lullaby"
+    return "sung-lullaby"
+
+
+def _source_fingerprint(payload: dict[str, Any], content_text: str) -> str:
+    try:
+        metadata = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise LegacyContentImportError(
+            "LEGACY_METADATA_NOT_CANONICAL_JSON",
+            "metadata contains a value that cannot be deterministically serialized as JSON",
+        ) from exc
+    material = f"{metadata}\n---CONTENT---\n{content_text}".encode()
+    return hashlib.sha256(material).hexdigest()
+
+
+def _originality_fingerprint(legacy: LegacyContentPackageV1, content_text: str) -> str:
+    if legacy.fingerprints is not None and legacy.fingerprints.exact_text:
+        return legacy.fingerprints.exact_text
+    return hashlib.sha256(content_text.encode()).hexdigest()
+
+
+def _mapping_warnings(legacy: LegacyContentPackageV1) -> list[str]:
+    warnings = [
+        "legacy age_band remains source metadata; audience policy mapping belongs to project import",
+        "legacy audio direction remains source metadata; audio production mapping is outside WP4",
+    ]
+    if legacy.creative.topics:
+        warnings.append("legacy creative.topics were merged into canonical ContentVersion.tags")
+    if legacy.creative.characters:
+        warnings.append(
+            "legacy free-text character names were not fabricated into canonical CHR-* references"
+        )
+    if legacy.creative.setting:
+        warnings.append(
+            "legacy free-text setting was not fabricated into canonical World/Location references"
+        )
+    return warnings
+
+
+def _stable_unique(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/packages/python-core/src/lullabies_core/legacy_import.py
+++ b/packages/python-core/src/lullabies_core/legacy_import.py
@@ -364,7 +364,10 @@ def _validate_mapping_preconditions(legacy: LegacyContentPackageV1, content_text
     if legacy.target_duration_seconds is None:
         raise LegacyContentImportError(
             "LEGACY_DURATION_REQUIRED",
-            "target_duration_seconds is optional in v1 metadata but required by the canonical model",
+            (
+                "target_duration_seconds is optional in v1 metadata "
+                "but required by the canonical model"
+            ),
             "target_duration_seconds",
         )
     if not 60 <= legacy.target_duration_seconds <= 10800:
@@ -419,7 +422,10 @@ def _originality_fingerprint(legacy: LegacyContentPackageV1, content_text: str) 
 
 def _mapping_warnings(legacy: LegacyContentPackageV1) -> list[str]:
     warnings = [
-        "legacy age_band remains source metadata; audience policy mapping belongs to project import",
+        (
+            "legacy age_band remains source metadata; "
+            "audience policy mapping belongs to project import"
+        ),
         "legacy audio direction remains source metadata; audio production mapping is outside WP4",
     ]
     if legacy.creative.topics:

--- a/packages/python-core/src/lullabies_core/legacy_import.py
+++ b/packages/python-core/src/lullabies_core/legacy_import.py
@@ -54,6 +54,7 @@ LegacyOriginalityDecision = Literal[
     "REJECT_DERIVATIVE",
     "DEFER_PORTFOLIO_FATIGUE",
 ]
+LegacyReconciliationAction = Literal["create", "noop", "conflict"]
 
 
 class LegacyNestedModel(BaseModel):
@@ -174,6 +175,18 @@ class LegacyContentImportResult(StrictModel):
     report: LegacyContentImportReport
 
 
+class LegacyContentReconciliation(StrictModel):
+    """Pure persistence decision for an imported legacy content identity."""
+
+    action: LegacyReconciliationAction
+    canonical_content_id: ContentId
+    canonical_content_version_id: ContentVersionId
+    source_fingerprint_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    import_key: str = Field(min_length=1)
+    reason: str = Field(min_length=1)
+    conflict_fields: list[str] = Field(default_factory=list)
+
+
 class LegacyContentImportError(ValueError):
     """Recoverable legacy-to-canonical mapping failure with a stable machine code."""
 
@@ -268,6 +281,82 @@ def import_legacy_content_package(
         content=content,
         content_version=content_version,
         report=report,
+    )
+
+
+def reconcile_legacy_content_import(
+    imported: LegacyContentImportResult,
+    *,
+    existing_content: Content | None = None,
+    existing_content_version: ContentVersion | None = None,
+    existing_import_key: str | None = None,
+) -> LegacyContentReconciliation:
+    """Plan CREATE/NOOP/CONFLICT without performing persistence.
+
+    WP5+ repositories may use this result inside a transaction. A repeated import of the
+    same canonical records is a NOOP. Reusing the same stable CNT/CTV identity for changed
+    source material or partial/mismatched canonical state is a CONFLICT, never an overwrite.
+    """
+
+    report = imported.report
+    base = {
+        "canonical_content_id": report.canonical_content_id,
+        "canonical_content_version_id": report.canonical_content_version_id,
+        "source_fingerprint_sha256": report.source_fingerprint_sha256,
+        "import_key": report.import_key,
+    }
+
+    if existing_content is None and existing_content_version is None:
+        return LegacyContentReconciliation(
+            action="create",
+            reason="canonical content identity is not persisted",
+            **base,
+        )
+
+    if existing_content is None or existing_content_version is None:
+        missing = "content" if existing_content is None else "content_version"
+        return LegacyContentReconciliation(
+            action="conflict",
+            reason="canonical persistence state is partial and requires operator recovery",
+            conflict_fields=[missing],
+            **base,
+        )
+
+    conflicts: list[str] = []
+    if existing_content.content_id != imported.content.content_id:
+        conflicts.append("content.content_id")
+    if existing_content_version.content_version_id != imported.content_version.content_version_id:
+        conflicts.append("content_version.content_version_id")
+    if existing_content_version.content_id != imported.content.content_id:
+        conflicts.append("content_version.content_id")
+    if existing_import_key is not None and existing_import_key != report.import_key:
+        conflicts.append("import_key")
+
+    if conflicts:
+        return LegacyContentReconciliation(
+            action="conflict",
+            reason="stable legacy identity resolves to conflicting persisted identity or source",
+            conflict_fields=conflicts,
+            **base,
+        )
+
+    record_conflicts: list[str] = []
+    if existing_content != imported.content:
+        record_conflicts.append("content")
+    if existing_content_version != imported.content_version:
+        record_conflicts.append("content_version")
+    if record_conflicts:
+        return LegacyContentReconciliation(
+            action="conflict",
+            reason="stable legacy identity already exists with different canonical data",
+            conflict_fields=record_conflicts,
+            **base,
+        )
+
+    return LegacyContentReconciliation(
+        action="noop",
+        reason="same deterministic import is already represented canonically",
+        **base,
     )
 
 

--- a/packages/python-core/tests/fixtures/legacy-content-package-v1.json
+++ b/packages/python-core/tests/fixtures/legacy-content-package-v1.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "content_id": "CNT-000321",
+  "run_id": "RUN-LEGACY-000321",
+  "title": "Counting Stars Together",
+  "normalized_title": "counting stars together",
+  "slug": "counting-stars-together",
+  "content_type": "song",
+  "age_band": "preschool",
+  "language": "en",
+  "status": "approved",
+  "target_duration_seconds": 120,
+  "objective": {
+    "primary": "Practice counting from one to five",
+    "entertainment": "Invite children to sing and point along",
+    "learning": "Count objects in sequence",
+    "emotional": "Calm confidence"
+  },
+  "creative": {
+    "premise": "A child counts friendly stars appearing one by one.",
+    "hook": "Each new star joins the refrain.",
+    "creative_device": "Cumulative counting chorus",
+    "characters": ["Mira"],
+    "setting": "A soft illustrated night meadow",
+    "topics": ["counting", "stars"],
+    "tags": ["preschool", "learning"]
+  },
+  "audio": {
+    "audio_mode": "music",
+    "provider_family": "lyria",
+    "preferred_model": "legacy-music-model",
+    "female_voice_required": true,
+    "selected_voice": null,
+    "prompt_version": "v1",
+    "render_status": "qa-passed"
+  },
+  "originality": {
+    "decision": "CLEAR",
+    "closest_prior_ids": [],
+    "notes": "Original repository fixture."
+  },
+  "qa": {
+    "all_mandatory_gates_passed": true,
+    "qa_file": "content/CNT-000321/qa.md"
+  },
+  "research": {
+    "research_file": "content/CNT-000321/research.md",
+    "source_count": 2
+  },
+  "fingerprints": {
+    "title": "legacy-title-fingerprint",
+    "premise": "legacy-premise-fingerprint",
+    "hook": "legacy-hook-fingerprint",
+    "exact_text": "legacy-exact-text-fingerprint"
+  },
+  "paths": {
+    "package": "content/CNT-000321",
+    "content": "content/CNT-000321/content.md",
+    "metadata": "content/CNT-000321/metadata.json",
+    "audio_prompt": "content/CNT-000321/audio-prompt.md",
+    "qa": "content/CNT-000321/qa.md",
+    "research": "content/CNT-000321/research.md"
+  },
+  "created_at": "2026-08-01T09:00:00Z",
+  "approved_at": "2026-08-01T11:30:00Z"
+}

--- a/packages/python-core/tests/fixtures/legacy-content-v1.md
+++ b/packages/python-core/tests/fixtures/legacy-content-v1.md
@@ -1,0 +1,9 @@
+# Counting Stars Together
+
+[Verse]
+One little star wakes in the sky.
+Two little stars wave hello nearby.
+
+[Chorus]
+Count with me: one, two, three,
+Four, five stars for us to see.

--- a/packages/python-core/tests/test_legacy_import.py
+++ b/packages/python-core/tests/test_legacy_import.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from lullabies_core import (
+    LEGACY_CONTENT_MAPPING_VERSION,
+    LegacyContentImportError,
+    LegacyContentImportResult,
+    import_legacy_content_package,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def fixture_payload() -> dict[str, object]:
+    return json.loads((FIXTURES / "legacy-content-package-v1.json").read_text(encoding="utf-8"))
+
+
+def fixture_text() -> str:
+    return (FIXTURES / "legacy-content-v1.md").read_text(encoding="utf-8")
+
+
+def test_representative_legacy_package_maps_to_canonical_content_without_mutation() -> None:
+    payload = fixture_payload()
+    original_payload = copy.deepcopy(payload)
+    content_text = fixture_text()
+
+    result = import_legacy_content_package(payload, content_text)
+
+    assert payload == original_payload
+    assert result.content.content_id == "CNT-000321"
+    assert result.content.active_version_id == "CTV-000321"
+    assert result.content.source_legacy_package_path == "content/CNT-000321"
+    assert result.content.status == "approved"
+    assert result.content_version.content_version_id == "CTV-000321"
+    assert result.content_version.content_id == "CNT-000321"
+    assert result.content_version.version == 1
+    assert result.content_version.content_format == "song"
+    assert result.content_version.target_duration_seconds == 120
+    assert result.content_version.script_or_lyrics == content_text
+    assert result.content_version.character_ids == []
+    assert result.content_version.tags == ["preschool", "learning", "counting", "stars"]
+    assert result.content_version.originality_fingerprint == "legacy-exact-text-fingerprint"
+    assert result.report.mapping_version == LEGACY_CONTENT_MAPPING_VERSION
+    assert result.report.unmapped_character_names == ["Mira"]
+    assert result.report.unmapped_setting == "A soft illustrated night meadow"
+
+
+def test_repeat_import_is_deterministic_and_idempotency_ready() -> None:
+    payload = fixture_payload()
+    content_text = fixture_text()
+
+    first = import_legacy_content_package(payload, content_text)
+    second = import_legacy_content_package(copy.deepcopy(payload), content_text)
+
+    assert first == second
+    assert first.report.import_key == second.report.import_key
+    assert first.report.source_fingerprint_sha256 == second.report.source_fingerprint_sha256
+    assert first.content.active_version_id == second.content.active_version_id
+
+
+def test_import_result_round_trips_without_identity_drift() -> None:
+    result = import_legacy_content_package(fixture_payload(), fixture_text())
+    restored = LegacyContentImportResult.model_validate(result.model_dump())
+
+    assert restored == result
+    assert restored.report.canonical_content_id == "CNT-000321"
+    assert restored.report.canonical_content_version_id == "CTV-000321"
+
+
+def test_lullaby_mode_maps_to_spoken_or_sung_without_guessing_provider_behavior() -> None:
+    speech = fixture_payload()
+    speech["content_type"] = "lullaby"
+    speech_audio = speech["audio"]
+    assert isinstance(speech_audio, dict)
+    speech_audio["audio_mode"] = "speech"
+    speech_result = import_legacy_content_package(speech, fixture_text())
+    assert speech_result.content_version.content_format == "spoken-lullaby"
+
+    music = fixture_payload()
+    music["content_type"] = "lullaby"
+    music_audio = music["audio"]
+    assert isinstance(music_audio, dict)
+    music_audio["audio_mode"] = "music"
+    music_result = import_legacy_content_package(music, fixture_text())
+    assert music_result.content_version.content_format == "sung-lullaby"
+
+
+def test_import_rejects_missing_duration_instead_of_inventing_one() -> None:
+    payload = fixture_payload()
+    payload.pop("target_duration_seconds")
+
+    with pytest.raises(LegacyContentImportError) as exc_info:
+        import_legacy_content_package(payload, fixture_text())
+
+    assert exc_info.value.code == "LEGACY_DURATION_REQUIRED"
+    assert exc_info.value.field == "target_duration_seconds"
+
+
+def test_import_rejects_duration_outside_canonical_range() -> None:
+    payload = fixture_payload()
+    payload["target_duration_seconds"] = 30
+
+    with pytest.raises(LegacyContentImportError) as exc_info:
+        import_legacy_content_package(payload, fixture_text())
+
+    assert exc_info.value.code == "LEGACY_DURATION_OUT_OF_CANONICAL_RANGE"
+
+
+def test_import_rejects_empty_resolved_content_text() -> None:
+    with pytest.raises(LegacyContentImportError) as exc_info:
+        import_legacy_content_package(fixture_payload(), "  \n")
+
+    assert exc_info.value.code == "LEGACY_CONTENT_TEXT_REQUIRED"
+    assert exc_info.value.field == "paths.content"
+
+
+def test_import_rejects_partial_legacy_metadata() -> None:
+    payload = fixture_payload()
+    payload.pop("objective")
+
+    with pytest.raises(ValidationError, match="objective"):
+        import_legacy_content_package(payload, fixture_text())
+
+
+def test_import_rejects_unknown_top_level_legacy_fields() -> None:
+    payload = fixture_payload()
+    payload["unexpected_top_level"] = True
+
+    with pytest.raises(ValidationError, match="unexpected_top_level"):
+        import_legacy_content_package(payload, fixture_text())
+
+
+def test_import_rejects_invalid_legacy_content_id() -> None:
+    payload = fixture_payload()
+    payload["content_id"] = "CNT-invalid"
+
+    with pytest.raises(ValidationError, match="content_id"):
+        import_legacy_content_package(payload, fixture_text())
+
+
+def test_import_rejects_approval_timestamp_before_creation() -> None:
+    payload = fixture_payload()
+    payload["approved_at"] = "2026-07-31T23:00:00Z"
+
+    with pytest.raises(LegacyContentImportError) as exc_info:
+        import_legacy_content_package(payload, fixture_text())
+
+    assert exc_info.value.code == "LEGACY_APPROVAL_PRECEDES_CREATION"
+
+
+def test_source_fingerprint_changes_when_exact_content_changes() -> None:
+    first = import_legacy_content_package(fixture_payload(), fixture_text())
+    second = import_legacy_content_package(
+        fixture_payload(),
+        fixture_text() + "\nA deliberately changed line.\n",
+    )
+
+    assert first.report.source_fingerprint_sha256 != second.report.source_fingerprint_sha256
+    assert first.report.import_key != second.report.import_key
+    assert first.content.active_version_id == second.content.active_version_id

--- a/packages/python-core/tests/test_legacy_import.py
+++ b/packages/python-core/tests/test_legacy_import.py
@@ -12,6 +12,7 @@ from lullabies_core import (
     LegacyContentImportError,
     LegacyContentImportResult,
     import_legacy_content_package,
+    reconcile_legacy_content_import,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -62,6 +63,77 @@ def test_repeat_import_is_deterministic_and_idempotency_ready() -> None:
     assert first.report.import_key == second.report.import_key
     assert first.report.source_fingerprint_sha256 == second.report.source_fingerprint_sha256
     assert first.content.active_version_id == second.content.active_version_id
+
+
+def test_reconciliation_creates_when_identity_is_not_persisted() -> None:
+    imported = import_legacy_content_package(fixture_payload(), fixture_text())
+
+    decision = reconcile_legacy_content_import(imported)
+
+    assert decision.action == "create"
+    assert decision.conflict_fields == []
+    assert decision.import_key == imported.report.import_key
+
+
+def test_reconciliation_is_noop_for_exact_repeat_import() -> None:
+    imported = import_legacy_content_package(fixture_payload(), fixture_text())
+
+    decision = reconcile_legacy_content_import(
+        imported,
+        existing_content=imported.content.model_copy(deep=True),
+        existing_content_version=imported.content_version.model_copy(deep=True),
+        existing_import_key=imported.report.import_key,
+    )
+
+    assert decision.action == "noop"
+    assert decision.conflict_fields == []
+
+
+def test_reconciliation_detects_partial_persistence_state() -> None:
+    imported = import_legacy_content_package(fixture_payload(), fixture_text())
+
+    decision = reconcile_legacy_content_import(
+        imported,
+        existing_content=imported.content,
+    )
+
+    assert decision.action == "conflict"
+    assert decision.conflict_fields == ["content_version"]
+
+
+def test_reconciliation_rejects_changed_source_for_same_stable_identity() -> None:
+    original = import_legacy_content_package(fixture_payload(), fixture_text())
+    changed = import_legacy_content_package(
+        fixture_payload(),
+        fixture_text() + "\nA deliberately changed line.\n",
+    )
+
+    decision = reconcile_legacy_content_import(
+        changed,
+        existing_content=original.content,
+        existing_content_version=original.content_version,
+        existing_import_key=original.report.import_key,
+    )
+
+    assert decision.action == "conflict"
+    assert "import_key" in decision.conflict_fields
+
+
+def test_reconciliation_detects_canonical_record_drift_even_without_import_key() -> None:
+    imported = import_legacy_content_package(fixture_payload(), fixture_text())
+    drifted_version = imported.content_version.model_copy(
+        update={"title": "Unexpected persisted rewrite"},
+        deep=True,
+    )
+
+    decision = reconcile_legacy_content_import(
+        imported,
+        existing_content=imported.content,
+        existing_content_version=drifted_version,
+    )
+
+    assert decision.action == "conflict"
+    assert decision.conflict_fields == ["content_version"]
 
 
 def test_import_result_round_trips_without_identity_drift() -> None:


### PR DESCRIPTION
## Scope
Implements approved M01/WP4 only.

## Changes
- add schema-faithful executable compatibility model for legacy `content-package.schema.json` v1
- map legacy metadata + explicitly resolved exact content text into canonical `Content` / `ContentVersion`
- preserve stable `CNT-*` identity and derive deterministic first canonical `CTV-*` identity
- preserve source status, timestamps, provenance path, objective, premise/hook, exact content text and originality fingerprint
- refine only documented lullaby modes (`speech` -> `spoken-lullaby`; `music/chant` -> `sung-lullaby`)
- never fabricate `CHR-*`, World or Location identities from legacy free text
- fail safely on missing/incompatible duration, empty content, malformed metadata and invalid chronology
- compute deterministic SHA-256 source fingerprint/import key
- add pure `CREATE / NOOP / CONFLICT` reconciliation contract for future persistence idempotency
- document mapping/versioning/recovery behavior in `docs/architecture/LEGACY-CONTENT-IMPORT-BOUNDARY.md`
- add representative schema-faithful fixtures/tests because the current repository legacy content index is empty
- record WP4 completion checkpoint and advance `checkpoints/LATEST.md`

## Boundary
No legacy source mutation, filesystem traversal, PostgreSQL writes, migrations, provider execution, Temporal, UI, publishing, or M02+ behavior.

## Verified acceptance
Python 3.12 `Core Domain Contracts` run `33218758449`, job `99008142155` passed:
- Ruff
- strict mypy
- unit tests
- generated-schema synchronization
- compile/import check

The verified executable head was `385d9dc49a1a50f8867b2e1a2aaa042fc6ee8a83`. The only two commits after that are checkpoint documentation (`checkpoints/2026-08-29-m01-wp4-legacy-content-import-complete.md` and `checkpoints/LATEST.md`); no executable files changed after the green run.

Real catalogue migration is not claimed because no actual legacy `CNT-*` catalogue entries are currently present.