### PR TITLE
M02 planning — Revalidate stack and prepare development consent brief

### DIFF
--- a/checkpoints/2026-08-29-m02-ready-for-consent.md
+++ b/checkpoints/2026-08-29-m02-ready-for-consent.md
@@ -1,0 +1,76 @@
+# Checkpoint — M02 Ready for Development Consent
+
+Date: 2026-08-29
+
+Status: **M02_READY_FOR_CONSENT**
+
+Milestone:
+**M02 — Durable Workflow Control Plane**
+
+## Entry criteria
+
+- P0 Full Project Preplanning: complete.
+- M01 Core Domain & Persistence Boundary: complete.
+- M01 final checkpoint: `checkpoints/2026-08-29-m01-complete.md`.
+- M02 canonical work-package plan exists: `docs/milestones/M02/PLAN.md`.
+- current FastAPI/Temporal mutable facts revalidated.
+- scoped M02 Development Consent Brief prepared.
+
+## Canonical consent brief
+
+`docs/architecture/M02-DEVELOPMENT-CONSENT-BRIEF.md`
+
+## Current-stack evidence
+
+`docs/architecture/M02-CURRENT-STACK-REVALIDATION-2026-08-29.md`
+
+Revalidation verdict:
+`PASS — EXISTING FASTAPI + TEMPORAL ARCHITECTURE REMAINS VALID`
+
+Planning-time current stable versions observed:
+- FastAPI `0.141.1`;
+- Temporal Python SDK `1.30.0`;
+- Temporal CLI `1.8.1`;
+- Temporal Server `1.31.2`.
+
+These values are evidence, not executable dependency pins. Revalidate immediately before implementation.
+
+## Planned M02 execution sequence
+
+1. WP1 — FastAPI application/control scaffold
+2. WP2 — Temporal foundation
+3. WP3 — job/idempotency/DB↔Temporal durability boundary
+4. WP4 — retry/backoff/circuit/cancellation
+5. WP5 — durable human/approval waits
+6. WP6 — fake external async callback/reconciliation pattern
+7. WP7 — job/control API + SSE progress surface
+8. WP8 — replay/restart/100-shot recovery acceptance
+
+## Exit target
+
+A synthetic 100-shot project can fan out/join, wait, retry, cancel where supported, survive worker/API restarts and resume without duplicate completed jobs or side effects, with retained Temporal histories replaying successfully.
+
+## Scope safety
+
+M02 deliberately excludes:
+- real AI provider execution/credentials/spend;
+- object storage/media pipeline;
+- content intelligence;
+- production generation/rendering;
+- full web/mobile/auth/billing/social implementation;
+- production Temporal HA/DR provisioning;
+- M03+ executable work.
+
+## Known governance risk
+
+GitHub currently reports `main` as unprotected with no required status-check enforcement. This is recorded for early reviewed hardening or explicit temporary acceptance during approved M02 execution. No repository protection setting has been changed by this planning checkpoint.
+
+## Consent state
+
+**Executable M02 development is NOT authorized yet.**
+
+Required explicit approval phrase may be:
+
+`Milestone 2 development approve — start.`
+
+Generic `continue`, `next`, `resume`, or `audit` remains planning-only.

--- a/checkpoints/LATEST.md
+++ b/checkpoints/LATEST.md
@@ -1,142 +1,89 @@
 # Latest Checkpoint
 
 Current checkpoint:
+`checkpoints/2026-08-29-m02-ready-for-consent.md`
+
+Current phase: **M02 — Durable Workflow Control Plane**
+
+Status: **M02_READY_FOR_CONSENT**
+
+## Previous completed milestone
+
+M01 — Core Domain & Persistence Boundary is complete.
+
+Final M01 checkpoint:
 `checkpoints/2026-08-29-m01-complete.md`
 
-Current phase: **M01 — Core Domain & Persistence Boundary**
+M01 closure merge commit:
+`424b76214ab8eb94d3205a2eba2d75cf4ffa0cc7`
 
-Status: **M01_COMPLETE**
+Verified M01 executable evidence:
+`33221966779 / 99017705054`
+
+## Full-project planning prerequisite
+
+P0 Full Project Preplanning is complete.
+
+Checkpoint:
+`checkpoints/2026-08-29-full-project-preplanning-complete.md`
+
+Status:
+`FULL_PROJECT_PLANNING_READY_FOR_CONSENT`
+
+## M02 readiness
+
+Canonical milestone plan:
+`docs/milestones/M02/PLAN.md`
+
+Development Consent Brief:
+`docs/architecture/M02-DEVELOPMENT-CONSENT-BRIEF.md`
+
+Current stack revalidation:
+`docs/architecture/M02-CURRENT-STACK-REVALIDATION-2026-08-29.md`
+
+Readiness checkpoint:
+`checkpoints/2026-08-29-m02-ready-for-consent.md`
+
+M02 work-package sequence:
+1. WP1 — FastAPI application/control scaffold;
+2. WP2 — Temporal foundation;
+3. WP3 — job/idempotency/DB↔Temporal durability boundary;
+4. WP4 — retry/backoff/circuit/cancellation;
+5. WP5 — durable human/approval waits;
+6. WP6 — fake external async callback/reconciliation pattern;
+7. WP7 — job/control API + SSE progress;
+8. WP8 — replay/restart/100-shot recovery acceptance.
+
+## Current mutable-stack evidence
+
+Planning-time current stable versions observed on 2026-08-29:
+- FastAPI `0.141.1`;
+- Temporal Python SDK `1.30.0`;
+- Temporal CLI `1.8.1`;
+- Temporal Server `1.31.2`.
+
+These are not runtime pins yet. They must be revalidated immediately before dependency/runtime changes.
 
 ## Consent state
 
-Explicit operator consent for scoped M01 development was received on 2026-08-29 and has now been fully consumed by completed M01 work.
+**M02 executable development is blocked pending fresh explicit operator approval.**
 
-That consent does **not** authorize M02+, provider execution, public publishing, paid provider behavior, or any materially expanded scope.
+The prior M01 approval has been consumed and does not authorize M02.
 
-Development consent policy:
-`ai-native/DEVELOPMENT-CONSENT-GATE.md`
+A valid explicit authorization may be:
 
-## Completed work packages
+`Milestone 2 development approve — start.`
 
-### WP1 — Contract freeze and generated schemas
+Generic `continue`, `next`, `resume`, `audit`, or planning instructions remain non-authorizing.
 
-Merged via PR #1.
+## M02 scope boundary
 
-Merge commit:
-`89e2c69f939a2d2c2350d3f0715da0b310ebeff7`
-
-### WP2 — Full production lineage
-
-Merged via PR #2.
-
-Merge commit:
-`d3aa6ba6c36482628a5540473bac0386b40b808c`
-
-Checkpoint:
-`checkpoints/2026-08-29-m01-wp2-lineage-complete.md`
-
-### WP3 — Aggregate validation hardening
-
-Merged via PR #3.
-
-Merge commit:
-`2e648fd27c44d0186bab76668002114298cc82b8`
-
-Checkpoint:
-`checkpoints/2026-08-29-m01-wp3-aggregate-hardening-complete.md`
-
-### WP4 — Legacy CNT content importer boundary
-
-Merged via PR #4.
-
-Merge commit:
-`3e3e194be035c6aaf0888a6d2259f12a6219d8ec`
-
-Checkpoint:
-`checkpoints/2026-08-29-m01-wp4-legacy-content-import-complete.md`
-
-### WP5 — PostgreSQL persistence architecture
-
-Merged via PR #5.
-
-Merge commit:
-`b456c1732dcd01e0505f501b3560387613ce54be`
-
-Checkpoint:
-`checkpoints/2026-08-29-m01-wp5-postgresql-architecture-complete.md`
-
-Canonical mapping:
-`docs/architecture/POSTGRESQL-PERSISTENCE-ARCHITECTURE.md`
-
-### WP6 — Reversible PostgreSQL migration scaffold
-
-Merged via PR #6.
-
-Merge commit:
-`6f7d5fcd7dd152f5bc5db9c93658e8fc152ed3b3`
-
-Checkpoint:
-`checkpoints/2026-08-29-m01-wp6-migrations-complete.md`
-
-Verified GitHub Actions run/job:
-`33219768541 / 99011168309`
-
-### WP7 — Persistence repositories and round trips
-
-Merged via PR #7.
-
-Merge commit:
-`8fcc33ae900e2781db34d52622577b2993cf45b8`
-
-Verified PR executable head:
-`c4cb38a385a5412987f160c75c9db190c21df4f7`
-
-Verified GitHub Actions run/job:
-`33221966779 / 99017705054`
-
-The verified PR head and merged squash commit resolve to the same executable tree:
-`89e649726bf071bfb143e4a3a0021eb2317502d9`
-
-Permanent Python 3.12 + PostgreSQL 18 CI passed Ruff, strict mypy, unit/integration tests, schema synchronization and compile checks.
-
-### WP8 — Final M01 verification
-
-Complete.
-
-Final checkpoint:
-`checkpoints/2026-08-29-m01-complete.md`
-
-M01 acceptance includes:
-- domain/full-lineage/aggregate tests;
-- legacy importer and non-mutation protection;
-- PostgreSQL constraints and reversible migration lifecycle;
-- 2-minute and 90-minute persistence round trips;
-- >3-hour rejection protection;
-- pinned CharacterVersion/selected Take retention;
-- fail-closed Rights behavior;
-- transaction rollback/integrity behavior;
-- generated-schema reproducibility;
-- permanent Python 3.12 + PostgreSQL 18 CI evidence.
-
-## Current next step
-
-**Planning/review only for M02 unless new explicit development consent is received.**
-
-Next development milestone:
-`M02 — Durable Workflow Control Plane`
-
-M02 executable development requires a new scoped development brief and fresh explicit operator consent.
-
-Generic `continue`, `next`, `resume`, or `audit` instructions do not authorize M02 development.
-
-## Scope boundary
-
-M01 completion does not include Temporal runtime orchestration, provider adapters/generation calls, object storage/media execution, web/mobile product implementation, auth/RBAC, publishing/analytics, autonomous spend, production DB rollout, or M02+ development.
+M02 excludes real provider execution/credentials/spend, object storage/media generation, content intelligence, full web/mobile/auth/billing/social implementation, production Temporal HA/DR rollout, public publishing, autonomous spend and M03+ development.
 
 ## Known governance risk
 
-GitHub currently reports `main` as unprotected with no required-status-check enforcement. This should be hardened before or during M02 governance work without bypassing the consent gate.
+GitHub currently reports `main` as unprotected with no required-status-check enforcement. No branch-protection setting was changed during planning. Early approved M02 execution should either harden this through a reviewed repository-governance change or explicitly record temporary acceptance.
 
 ## GitHub ↔ Linear
 
-GitHub remains canonical for engineering contracts, implementation evidence, and checkpoints. Linear mirrors work-package status and acceptance evidence.
+GitHub remains canonical for engineering contracts, implementation evidence and checkpoints. Linear mirrors milestone/work-package readiness and execution status.

--- a/docs/architecture/M02-CURRENT-STACK-REVALIDATION-2026-08-29.md
+++ b/docs/architecture/M02-CURRENT-STACK-REVALIDATION-2026-08-29.md
@@ -1,0 +1,176 @@
+# M02 Current Stack Revalidation — 2026-08-29
+
+Status: `PLANNING_EVIDENCE_ONLY`
+
+This document refreshes mutable implementation facts for M02. It does not add dependencies, change CI, enable infrastructure, or authorize executable development.
+
+## Scope
+
+M02 is the durable workflow/control-plane milestone. The existing architectural decision remains:
+
+- Python 3.12+ backend;
+- FastAPI for the HTTP/OpenAPI control plane;
+- Temporal for durable multi-step workflows;
+- PostgreSQL for operational canonical state;
+- provider-neutral fake activities during M02;
+- SSE initially for progress streaming;
+- no real AI provider execution in M02.
+
+Canonical milestone plan:
+`docs/milestones/M02/PLAN.md`
+
+## Current upstream facts checked on 2026-08-29
+
+### Temporal Python SDK
+
+Current public GitHub release observed:
+- `temporalio/sdk-python` — `1.30.0`
+
+Relevant current SDK behavior:
+- workflow code must remain deterministic;
+- Python workflows run in the workflow sandbox by default;
+- external side effects belong in Activities;
+- workflow history can be replayed with `Replayer` to detect non-determinism/regression;
+- workflow sandbox bypass is possible but explicitly discouraged as a normal design;
+- current SDK/core behavior requires an Activity close timeout to be configured.
+
+M02 implication:
+- keep workflow modules minimal and deterministic;
+- keep Pydantic/domain imports explicitly safe/passthrough where justified;
+- never perform network, file, process, environment, random or database side effects directly inside workflow code;
+- require explicit Activity timeout policy in the workflow conventions;
+- make replay compatibility a permanent CI gate before changing workflow code.
+
+Sources checked:
+- https://github.com/temporalio/sdk-python
+- https://github.com/temporalio/sdk-python/releases
+- https://docs.temporal.io/
+
+### Temporal Server
+
+Current public GitHub release observed:
+- `temporalio/temporal` — `v1.31.2`
+
+M02 is not a production Temporal deployment milestone. For development/CI, prefer a pinned local development server/CLI path rather than designing production cluster topology here.
+
+M02 implication:
+- do not use floating `latest` tags in durable CI evidence;
+- pin an exact tested Temporal CLI/server version or digest when implementation starts;
+- run dependency/container vulnerability checks at implementation time;
+- production Temporal Cloud/self-host topology, HA, scaling and DR remain later operations scope unless a narrow M02 test dependency requires configuration.
+
+Sources checked:
+- https://github.com/temporalio/temporal
+- https://github.com/temporalio/temporal/releases
+
+### Temporal CLI
+
+Current public GitHub release observed:
+- `temporalio/cli` — `v1.8.1`
+
+The current CLI includes `temporal server start-dev` for local development. Historical `tctl` is deprecated/end-of-support and must not be introduced into new M02 tooling.
+
+M02 implication:
+- use the current Temporal CLI, not `tctl`;
+- exact version must be pinned in implementation/CI;
+- persistent/restart acceptance must not rely only on an in-memory test that cannot prove process-restart recovery.
+
+Sources checked:
+- https://github.com/temporalio/cli
+- https://github.com/temporalio/cli/releases
+
+### FastAPI
+
+Current public GitHub release observed:
+- `fastapi/fastapi` — `0.141.1`
+
+Current official FastAPI documentation confirms:
+- application lifespan hooks are appropriate for app-scoped resource setup/cleanup;
+- dependency injection remains the request-resource boundary;
+- SSE is available in current FastAPI releases;
+- `BackgroundTasks` is suitable for small post-response work but is not a durable distributed workflow engine; heavy work that does not need to share the process should be delegated to a separate worker/tool.
+
+M02 implication:
+- FastAPI starts/inspects/signals Temporal work; it does not own durable execution;
+- do not implement long media/job execution with `BackgroundTasks`;
+- use lifespan-managed clients/pools where appropriate;
+- use versioned REST/OpenAPI for control APIs;
+- use SSE first for progress unless a concrete bidirectional WebSocket need appears.
+
+Sources checked:
+- https://fastapi.tiangolo.com/advanced/events/
+- https://fastapi.tiangolo.com/tutorial/background-tasks/
+- https://fastapi.tiangolo.com/tutorial/dependencies/
+- https://github.com/fastapi/fastapi/releases
+
+## Proposed implementation-time dependency policy
+
+Do not hard-code dependency versions from this planning document into runtime files before consent.
+
+At M02 implementation start:
+1. re-check latest stable FastAPI, Temporal Python SDK, Temporal CLI and compatible Temporal Server behavior;
+2. choose exact compatible pins/ranges according to repository dependency policy;
+3. record the chosen versions in the M02 executable PR;
+4. pin CI Temporal tooling exactly rather than using floating tags;
+5. run vulnerability/advisory checks;
+6. reject a version upgrade if replay/determinism, Python 3.12 compatibility or existing M01 contracts regress.
+
+Current planning candidates, not executable pins:
+- FastAPI: current stable `0.141.1` line;
+- Temporal Python SDK: current stable `1.30.0` line;
+- Temporal CLI: current stable `1.8.1` line;
+- Temporal Server/dev-server compatibility target: current `1.31.2` line.
+
+## Architecture decisions reaffirmed
+
+### FastAPI is a control plane, not the durable engine
+
+HTTP request lifecycle and background-task execution must never be treated as authoritative workflow durability.
+
+### PostgreSQL owns application/job projection; Temporal owns workflow execution history
+
+Do not duplicate Temporal history inside PostgreSQL. Store canonical application state plus workflow/run references, idempotency records, projections, audit/event/outbox data required by the product.
+
+### External side effects are Activities
+
+Provider calls, callbacks, database mutations requiring side-effect boundaries, filesystem/media calls and future external integrations belong outside deterministic workflow code.
+
+### Durable idempotency is multi-layered
+
+M02 must combine:
+- stable workflow IDs;
+- request/idempotency keys;
+- operation fingerprints;
+- PostgreSQL uniqueness/concurrency constraints;
+- activity-side idempotency/attempt semantics;
+- callback deduplication;
+- workflow replay compatibility.
+
+Temporal retries alone are not sufficient to guarantee no duplicated external side effects.
+
+### Long workflow history must have an explicit continuation policy
+
+M02 should define a safe Continue-As-New/history-growth policy before long-form milestones depend on the control plane. The initial 100-shot acceptance should prove the architecture without prematurely optimizing for three-hour real generation.
+
+### Replay testing is mandatory
+
+Workflow code changes require replay tests against retained representative histories. A green ordinary unit test does not substitute for replay compatibility.
+
+## Security and cost position
+
+M02 uses fake/synthetic providers by default and requires no production AI provider credentials or paid generation.
+
+Workflow payloads must not contain:
+- provider secrets;
+- raw large media blobs;
+- unnecessary sensitive user data.
+
+Use stable IDs/references to canonical PostgreSQL/object-storage records instead.
+
+## Revalidation verdict
+
+`PASS — EXISTING FASTAPI + TEMPORAL ARCHITECTURE REMAINS VALID`
+
+No current upstream fact found requires replacing the M02 architecture.
+
+Implementation still requires explicit M02 development consent.

--- a/docs/architecture/M02-DEVELOPMENT-CONSENT-BRIEF.md
+++ b/docs/architecture/M02-DEVELOPMENT-CONSENT-BRIEF.md
@@ -1,0 +1,287 @@
+# M02 Development Consent Brief — Durable Workflow Control Plane
+
+Status: `M02_READY_FOR_CONSENT`
+
+Prepared: 2026-08-29
+
+This document requests scoped executable-development approval for M02 only. It does not itself authorize implementation.
+
+## Prerequisites verified
+
+- P0 Full Project Preplanning Gate: `FULL_PROJECT_PLANNING_READY_FOR_CONSENT`.
+- M01 Core Domain & Persistence Boundary: `M01_COMPLETE`.
+- M01 final checkpoint: `checkpoints/2026-08-29-m01-complete.md`.
+- M02 canonical plan: `docs/milestones/M02/PLAN.md`.
+- Mutable FastAPI/Temporal facts revalidated: `docs/architecture/M02-CURRENT-STACK-REVALIDATION-2026-08-29.md`.
+
+## 1. Milestone / scope
+
+Implement **M02 — Durable Workflow Control Plane** only.
+
+Goal:
+build the provider-neutral FastAPI + Temporal execution foundation that can start, inspect, pause, retry, cancel, resume and recover long-running project jobs without duplicating completed work or external side effects.
+
+Approved scope would cover these work packages in order:
+
+### M02-WP1 — FastAPI control scaffold
+- `apps/api/` application scaffold;
+- validated environment/settings boundary;
+- lifespan-managed application resources;
+- liveness/readiness endpoints;
+- request/correlation IDs;
+- structured API errors;
+- versioned REST/OpenAPI contract generation;
+- internal development identity only where an endpoint requires a caller identity; no full auth/RBAC implementation.
+
+### M02-WP2 — Temporal foundation
+- `apps/worker/` scaffold;
+- current Temporal Python SDK integration;
+- client/namespace/task-queue configuration;
+- worker bootstrap and shutdown;
+- workflow/activity conventions;
+- deterministic sandbox rules;
+- explicit Activity timeout policy;
+- workflow/run references persisted in application state;
+- test/dev Temporal server path with exact version pinning at implementation time.
+
+### M02-WP3 — Job, command and idempotency control
+- canonical execution/job state transitions using existing M01 domain direction;
+- mutation idempotency keys;
+- operation fingerprints;
+- duplicate command suppression;
+- DB uniqueness/concurrency boundary;
+- leases/claim/version conflict where application-level coordination needs them;
+- transactional outbox/inbox or equivalent durable event handoff where required to close DB↔Temporal failure windows.
+
+### M02-WP4 — Retry, timeout, circuit and cancellation policy
+- normalized retry/failure classes;
+- bounded exponential backoff/jitter policy;
+- Activity/workflow timeouts;
+- retry exhaustion behavior;
+- circuit/open/degraded provider placeholder behavior using fake activities;
+- cancellation propagation;
+- terminal/manual-action states;
+- retry-scoped behavior that does not restart completed sibling jobs.
+
+### M02-WP5 — Durable human/approval waits
+- pause for explicit approval;
+- approval signal/update contract;
+- stale version/revision rejection;
+- expiry/timeout behavior;
+- manual-handoff and budget-wait state representation without actual provider spend;
+- safe resume after worker/API restart.
+
+### M02-WP6 — External asynchronous callback/reconciliation pattern
+Using a **fake provider only**:
+- submit asynchronous external job;
+- poll path;
+- webhook/callback path;
+- callback verification abstraction;
+- duplicate callback suppression;
+- out-of-order/stale callback handling;
+- provider timeout/unavailable simulation;
+- reconciliation to canonical state.
+
+No real provider credential, endpoint or paid generation is included.
+
+### M02-WP7 — Job/control API and progress surface
+- create/start synthetic job/workflow;
+- inspect job/workflow/project execution state;
+- cancel/retry supported operations;
+- cursor-paginated history where needed;
+- normalized errors;
+- SSE progress stream initially;
+- WebSocket remains out unless a concrete bidirectional requirement is proven.
+
+### M02-WP8 — Recovery, replay and 100-shot acceptance
+- synthetic 100-shot fan-out/join workflow;
+- controlled worker termination/restart;
+- API process restart while workflow continues;
+- Activity retry/recovery;
+- duplicate callback/event injection;
+- cancellation tests;
+- manual approval wait/resume;
+- retained Temporal histories + replay verification;
+- Continue-As-New/history-growth policy proof where the acceptance fixture reaches the configured threshold;
+- assert no duplicate terminal work/side effects.
+
+## 2. Why now
+
+M01 has stabilized and verified:
+- provider-neutral domain contracts;
+- full lineage/aggregate invariants;
+- PostgreSQL schema/migrations;
+- repository round trips;
+- stable IDs, rights and persistence boundaries.
+
+M02 is therefore the next dependency-safe layer. Provider adapters, asset storage, content intelligence, media generation and product UI should not build their own ad-hoc retry/background-job systems before the durable control plane exists.
+
+## 3. Expected files/components
+
+Likely new/changed areas:
+
+```text
+apps/
+  api/
+  worker/
+packages/
+  python-core/
+    workflow/job/control services as needed
+  contracts/
+    generated OpenAPI artifacts when introduced
+tests/
+  api/
+  workflows/
+  integration/
+packages/python-core/migrations/
+  versions/   # additive M02 persistence changes if needed
+infra/ or test tooling
+  only minimal local/CI Temporal dev-server configuration required for M02 verification
+.github/workflows/
+  only if permanent M02 CI gates need to be added
+```
+
+Exact paths may be refined without expanding the approved behavior.
+
+## 4. Behavioral changes
+
+After M02, the repository will have executable capability to:
+- start synthetic durable project workflows through an API/control interface;
+- execute workflow activities on Temporal workers;
+- persist application-facing job/workflow references/state;
+- safely deduplicate repeated start/mutation commands;
+- wait durably for approval/callback/timers;
+- retry bounded failures;
+- cancel supported executions;
+- survive process restart;
+- report progress/state;
+- replay retained histories for deterministic compatibility.
+
+It will **not** generate real AI media.
+
+## 5. Data / migration impact
+
+M02 may add **expand-only, reversible where practical** PostgreSQL structures needed for durable control-plane state, for example:
+- workflow execution references;
+- command/idempotency records;
+- operation fingerprints;
+- durable inbox/outbox/event-delivery records where required;
+- callback deduplication/reconciliation records;
+- execution projections/attempt metadata not already represented by M01;
+- indexes/uniqueness constraints supporting the above.
+
+Rules:
+- do not copy Temporal event history into PostgreSQL;
+- do not make provider-specific payloads canonical application state;
+- preserve M01 stable external IDs;
+- no destructive rewrite of M01 canonical records;
+- every migration gets upgrade + downgrade/recovery verification appropriate to its safety model.
+
+## 6. Security / rights / cost impact
+
+### Security
+- no provider secrets are required;
+- API and worker settings must fail closed on missing/invalid configuration;
+- workflow payloads carry stable references rather than raw secrets/large media;
+- fake webhook verification must establish the interface for later signed callbacks without pretending a real provider signature scheme exists;
+- request/idempotency keys are bounded/validated and must not become an injection/storage-abuse surface;
+- structured logs must avoid secrets and large/sensitive payload dumps;
+- Temporal workflow sandbox remains enabled by default;
+- direct workflow side effects/network/DB/filesystem/process calls are prohibited;
+- current dependency/container advisories must be checked before pinning implementation versions.
+
+### Rights
+No new media rights decision is introduced. Existing fail-closed Rights behavior remains unchanged.
+
+### Cost
+- no paid AI/provider generation;
+- fake/synthetic providers only;
+- local/CI Temporal infrastructure should use free/local tooling where practical;
+- no autonomous spend behavior.
+
+## 7. Tests / verification
+
+M02 cannot be marked complete from unit tests alone.
+
+Required permanent gates include, as applicable:
+- Ruff;
+- strict mypy;
+- existing M01 domain/persistence tests remain green;
+- FastAPI/OpenAPI contract tests;
+- settings/config fail-closed tests;
+- API idempotency tests;
+- PostgreSQL migration/constraint/transaction tests;
+- Temporal workflow/activity integration tests;
+- deterministic sandbox tests;
+- retained-history replay tests;
+- Activity timeout/retry/cancellation tests;
+- signal/update/manual-wait tests;
+- callback duplicate/out-of-order tests;
+- DB↔Temporal failure-window/idempotency tests;
+- worker restart recovery;
+- API restart independence;
+- synthetic 100-shot fan-out/join acceptance;
+- assertion that completed work/terminal side effects are not duplicated.
+
+CI evidence must use pinned test tooling and identify the tested Python/Temporal/FastAPI versions.
+
+## 8. Rollback / recovery
+
+Rollback strategy:
+- code/workflow changes through normal PR/revert;
+- additive M02 DB migrations reversible where safe;
+- no destructive M01 data rewrite;
+- retain representative workflow histories so code rollback/forward replay compatibility can be evaluated;
+- do not deploy incompatible workflow-code changes without a Temporal versioning/change strategy;
+- in-progress synthetic/dev workflows may be terminated/reset only inside test/dev evidence procedures;
+- external side effects in M02 are fake, limiting irreversible rollback risk.
+
+If a workflow-code change is non-deterministic against retained histories, CI must fail rather than silently accepting it.
+
+## 9. Explicitly out of scope
+
+M02 approval would **not** authorize:
+- real Google/Runway/Pika/Kling/Hailuo/Luma or other AI provider integration;
+- provider production credentials;
+- paid/free-credit generation routing execution;
+- object-storage/media upload pipeline (M03);
+- Character Library implementation (M04);
+- content intelligence/pgvector memory (M05);
+- production audio/video generation (M06+);
+- FFmpeg production assembly;
+- full Next.js product UI;
+- full authentication/RBAC/workspaces;
+- billing/entitlements;
+- social publishing;
+- autonomous spend;
+- production Temporal cluster provisioning/HA/DR;
+- production deployment/public launch;
+- M03+ executable development.
+
+## Repository-governance preflight risk
+
+Current GitHub API evidence shows `main` is not branch-protected and has no required status-check enforcement.
+
+M02 implementation should preserve PR-only discipline and, if repository permissions allow, branch-protection/required-check hardening should be handled as an explicitly reviewed repository-governance change. It must not be silently changed under a generic planning instruction.
+
+This risk does not block presenting the M02 development brief, but it should be resolved early in the approved M02 execution window or explicitly accepted as a temporary governance exception.
+
+## Current dependency revalidation snapshot
+
+Planning evidence observed on 2026-08-29:
+- FastAPI latest stable observed: `0.141.1`;
+- Temporal Python SDK latest stable observed: `1.30.0`;
+- Temporal CLI latest stable observed: `1.8.1`;
+- Temporal Server latest stable observed: `1.31.2`.
+
+These are **not yet executable dependency pins**. Revalidate once more immediately before changing dependency/runtime files.
+
+## 10. Consent request
+
+M02 is planning-ready, but executable work is still blocked.
+
+To authorize only the scope above, the operator can explicitly state:
+
+**`Milestone 2 development approve — start.`**
+
+Any generic `continue`, `next`, `resume`, `audit`, or planning instruction remains non-authorizing.


### PR DESCRIPTION
## Scope
Planning/documentation only. Prepares M02 for a fresh explicit development-consent decision after M01 completion.

## Adds
- current FastAPI/Temporal stack revalidation
- scoped M02 Development Consent Brief
- M02 consent-readiness checkpoint
- `checkpoints/LATEST.md` advance to `M02_READY_FOR_CONSENT`

## Revalidated current facts
Planning-time stable versions observed on 2026-08-29:
- FastAPI 0.141.1
- Temporal Python SDK 1.30.0
- Temporal CLI 1.8.1
- Temporal Server 1.31.2

These are evidence only, not dependency pins.

## Architecture result
Existing FastAPI control-plane + Temporal durable-workflow decision remains valid. M02 keeps workflows deterministic/sandboxed, external side effects in Activities, replay testing mandatory, fake providers only, SSE first for progress, and no real provider credentials/spend.

## Consent boundary
This PR does not add/change runtime dependencies, code, migrations, workflows, API behavior, CI, infrastructure, or branch protection. M02 executable development remains blocked until fresh explicit operator approval, e.g. `Milestone 2 development approve — start.`