### PR TITLE
M02/WP1 — Add FastAPI control-plane scaffold

### DIFF
--- a/.github/workflows/control-plane.yml
+++ b/.github/workflows/control-plane.yml
@@ -1,0 +1,91 @@
+name: Durable Control Plane
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/**"
+      - "packages/python-core/**"
+      - "packages/contracts/**"
+      - ".github/workflows/control-plane.yml"
+  pull_request:
+    paths:
+      - "apps/api/**"
+      - "packages/python-core/**"
+      - "packages/contracts/**"
+      - ".github/workflows/control-plane.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ai_automation_force_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d ai_automation_force_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/ai_automation_force_test
+      AAF_ENVIRONMENT: test
+      AAF_BUILD_REVISION: ci
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            packages/python-core/pyproject.toml
+            apps/api/pyproject.toml
+
+      - name: Install core and control plane
+        run: >-
+          python -m pip install
+          -e "packages/python-core[dev]"
+          -e "apps/api[dev]"
+
+      - name: Ruff
+        run: ruff check packages/python-core apps/api
+
+      - name: Mypy
+        run: >-
+          mypy
+          packages/python-core/src
+          packages/python-core/scripts
+          packages/python-core/migrations
+          apps/api/src
+          apps/api/scripts
+
+      - name: Unit and PostgreSQL integration tests
+        run: pytest packages/python-core/tests apps/api/tests
+
+      - name: Verify generated core schemas are synchronized
+        run: python packages/python-core/scripts/export_schemas.py --check
+
+      - name: Verify deterministic OpenAPI generation
+        run: |
+          python apps/api/scripts/export_openapi.py --output /tmp/control-plane-v1.json
+          cp /tmp/control-plane-v1.json /tmp/control-plane-v1.first.json
+          python apps/api/scripts/export_openapi.py --output /tmp/control-plane-v1.json
+          cmp /tmp/control-plane-v1.first.json /tmp/control-plane-v1.json
+
+      - name: Compile core, API and migrations
+        run: >-
+          python -m compileall -q
+          packages/python-core/src
+          packages/python-core/migrations
+          apps/api/src

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ai-automation-force-api"
+version = "0.1.0"
+description = "FastAPI control plane for AI Automation Force"
+requires-python = ">=3.12"
+dependencies = [
+  "fastapi==0.141.1",
+]
+
+[project.optional-dependencies]
+dev = [
+  "httpx>=0.28,<1",
+  "pytest>=8,<9",
+  "ruff>=0.6,<1",
+  "mypy>=1.11,<2",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ai_automation_force_api"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_unused_ignores = true
+warn_redundant_casts = true

--- a/apps/api/scripts/export_openapi.py
+++ b/apps/api/scripts/export_openapi.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ai_automation_force_api import Settings, create_app
+
+ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_OUTPUT = ROOT / "packages" / "contracts" / "openapi" / "control-plane-v1.json"
+
+
+def rendered_schema() -> str:
+    app = create_app(Settings(environment="test", build_revision="schema-export"))
+    return json.dumps(app.openapi(), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    rendered = rendered_schema()
+    if args.check:
+        if not args.output.exists() or args.output.read_text(encoding="utf-8") != rendered:
+            raise SystemExit(f"OpenAPI artifact is out of sync: {args.output}")
+        return 0
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/api/src/ai_automation_force_api/__init__.py
+++ b/apps/api/src/ai_automation_force_api/__init__.py
@@ -1,0 +1,4 @@
+from .app import create_app
+from .settings import Settings, SettingsError, load_settings
+
+__all__ = ["Settings", "SettingsError", "create_app", "load_settings"]

--- a/apps/api/src/ai_automation_force_api/app.py
+++ b/apps/api/src/ai_automation_force_api/app.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import Final
+
+from fastapi import APIRouter, FastAPI, Request, status
+from pydantic import BaseModel, ConfigDict
+
+from .errors import APIError, ErrorEnvelope, install_error_handlers
+from .request_context import RequestContextMiddleware
+from .settings import Settings, load_settings
+
+OPENAPI_VERSION: Final[str] = "3.1.0"
+
+
+class RuntimeState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    started_at: datetime
+    ready: bool = False
+
+
+class HealthResponse(BaseModel):
+    status: str
+    service: str
+    api_version: str
+    build_revision: str
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    resolved = settings or load_settings()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        runtime = RuntimeState(started_at=datetime.now(UTC), ready=True)
+        app.state.runtime = runtime
+        try:
+            yield
+        finally:
+            runtime.ready = False
+
+    app = FastAPI(
+        title="AI Automation Force Control API",
+        version="0.1.0",
+        docs_url="/docs",
+        redoc_url=None,
+        lifespan=lifespan,
+    )
+    app.state.settings = resolved
+    app.openapi_version = OPENAPI_VERSION
+    app.add_middleware(RequestContextMiddleware)
+    install_error_handlers(app)
+
+    router = APIRouter(tags=["system"])
+
+    @router.get("/health/live", response_model=HealthResponse)
+    async def liveness() -> HealthResponse:
+        return HealthResponse(
+            status="ok",
+            service=resolved.service_name,
+            api_version=resolved.api_version,
+            build_revision=resolved.build_revision,
+        )
+
+    @router.get(
+        "/health/ready",
+        response_model=HealthResponse,
+        responses={status.HTTP_503_SERVICE_UNAVAILABLE: {"model": ErrorEnvelope}},
+    )
+    async def readiness(request: Request) -> HealthResponse:
+        runtime = getattr(request.app.state, "runtime", None)
+        if runtime is None or not runtime.ready:
+            raise APIError(
+                "SERVICE_NOT_READY",
+                "service readiness dependencies are not available",
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        return HealthResponse(
+            status="ready",
+            service=resolved.service_name,
+            api_version=resolved.api_version,
+            build_revision=resolved.build_revision,
+        )
+
+    app.include_router(router, prefix=resolved.api_prefix)
+    return app

--- a/apps/api/src/ai_automation_force_api/errors.py
+++ b/apps/api/src/ai_automation_force_api/errors.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from .request_context import current_request_id
+
+
+class ErrorDetail(BaseModel):
+    code: str = Field(min_length=3, max_length=80)
+    message: str = Field(min_length=1, max_length=500)
+    request_id: str
+    details: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class ErrorEnvelope(BaseModel):
+    error: ErrorDetail
+
+
+class APIError(RuntimeError):
+    def __init__(self, code: str, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+def _request_id(request: Request) -> str:
+    return str(getattr(request.state, "request_id", None) or current_request_id() or "unavailable")
+
+
+def _response(
+    request: Request,
+    *,
+    code: str,
+    message: str,
+    status_code: int,
+    details: list[dict[str, Any]] | None = None,
+) -> JSONResponse:
+    payload = ErrorEnvelope(
+        error=ErrorDetail(
+            code=code,
+            message=message,
+            request_id=_request_id(request),
+            details=details or [],
+        )
+    )
+    return JSONResponse(status_code=status_code, content=payload.model_dump(mode="json"))
+
+
+def install_error_handlers(app: FastAPI) -> None:
+    @app.exception_handler(APIError)
+    async def api_error_handler(request: Request, exc: APIError) -> JSONResponse:
+        return _response(
+            request,
+            code=exc.code,
+            message=exc.message,
+            status_code=exc.status_code,
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error_handler(
+        request: Request,
+        exc: RequestValidationError,
+    ) -> JSONResponse:
+        return _response(
+            request,
+            code="REQUEST_VALIDATION_FAILED",
+            message="request validation failed",
+            status_code=422,
+            details=jsonable_encoder(exc.errors()),
+        )
+
+    @app.exception_handler(HTTPException)
+    async def http_error_handler(request: Request, exc: HTTPException) -> JSONResponse:
+        return _response(
+            request,
+            code="HTTP_ERROR",
+            message=str(exc.detail),
+            status_code=exc.status_code,
+        )
+
+    @app.exception_handler(Exception)
+    async def unexpected_error_handler(request: Request, exc: Exception) -> JSONResponse:
+        _ = exc
+        return _response(
+            request,
+            code="INTERNAL_ERROR",
+            message="an unexpected internal error occurred",
+            status_code=500,
+        )

--- a/apps/api/src/ai_automation_force_api/main.py
+++ b/apps/api/src/ai_automation_force_api/main.py
@@ -1,0 +1,3 @@
+from .app import create_app
+
+app = create_app()

--- a/apps/api/src/ai_automation_force_api/request_context.py
+++ b/apps/api/src/ai_automation_force_api/request_context.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+from contextvars import ContextVar
+from uuid import uuid4
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+REQUEST_ID_HEADER = "X-Request-ID"
+_REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$")
+_current_request_id: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+def current_request_id() -> str | None:
+    return _current_request_id.get()
+
+
+def _request_id_from_header(value: str | None) -> str:
+    if value is not None and _REQUEST_ID_PATTERN.fullmatch(value):
+        return value
+    return str(uuid4())
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        request_id = _request_id_from_header(request.headers.get(REQUEST_ID_HEADER))
+        token = _current_request_id.set(request_id)
+        request.state.request_id = request_id
+        try:
+            response = await call_next(request)
+        finally:
+            _current_request_id.reset(token)
+        response.headers[REQUEST_ID_HEADER] = request_id
+        return response

--- a/apps/api/src/ai_automation_force_api/settings.py
+++ b/apps/api/src/ai_automation_force_api/settings.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from os import environ
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+Environment = Literal["development", "test", "staging", "production"]
+
+
+class SettingsError(RuntimeError):
+    """Raised when control-plane configuration is invalid or unsafe."""
+
+
+class Settings(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    environment: Environment = "development"
+    service_name: str = Field(default="ai-automation-force-api", min_length=3, max_length=80)
+    api_version: str = Field(default="v1", pattern=r"^v[1-9][0-9]*$")
+    build_revision: str = Field(default="dev", min_length=1, max_length=80)
+    internal_dev_identity: str | None = Field(default=None, min_length=3, max_length=120)
+
+    @field_validator("service_name", "build_revision", "internal_dev_identity")
+    @classmethod
+    def reject_control_characters(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if any(ord(character) < 32 or ord(character) == 127 for character in value):
+            raise ValueError("control characters are not allowed")
+        return value
+
+    @model_validator(mode="after")
+    def prevent_insecure_identity_outside_dev(self) -> Settings:
+        if self.environment in {"staging", "production"} and self.internal_dev_identity:
+            raise ValueError("internal_dev_identity is allowed only in development/test")
+        return self
+
+    @property
+    def api_prefix(self) -> str:
+        return f"/api/{self.api_version}"
+
+
+def load_settings(source: Mapping[str, str] | None = None) -> Settings:
+    values = environ if source is None else source
+    payload: dict[str, str] = {}
+    env_map = {
+        "AAF_ENVIRONMENT": "environment",
+        "AAF_SERVICE_NAME": "service_name",
+        "AAF_API_VERSION": "api_version",
+        "AAF_BUILD_REVISION": "build_revision",
+        "AAF_INTERNAL_DEV_IDENTITY": "internal_dev_identity",
+    }
+    for environment_key, model_key in env_map.items():
+        value = values.get(environment_key)
+        if value is not None:
+            payload[model_key] = value
+    try:
+        return Settings.model_validate(payload)
+    except ValidationError as exc:
+        raise SettingsError(f"invalid API configuration: {exc}") from exc

--- a/apps/api/tests/test_app.py
+++ b/apps/api/tests/test_app.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+from ai_automation_force_api import Settings, create_app
+from ai_automation_force_api.errors import APIError
+
+UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def test_health_endpoints_and_request_id() -> None:
+    app = create_app(Settings(environment="test", build_revision="test-sha"))
+    with TestClient(app) as client:
+        live = client.get("/api/v1/health/live", headers={"X-Request-ID": "req-test-001"})
+        ready = client.get("/api/v1/health/ready")
+
+    assert live.status_code == 200
+    assert live.headers["X-Request-ID"] == "req-test-001"
+    assert live.json() == {
+        "status": "ok",
+        "service": "ai-automation-force-api",
+        "api_version": "v1",
+        "build_revision": "test-sha",
+    }
+    assert ready.status_code == 200
+    assert ready.json()["status"] == "ready"
+    assert UUID_PATTERN.fullmatch(ready.headers["X-Request-ID"])
+
+
+def test_invalid_request_id_is_not_reflected() -> None:
+    app = create_app(Settings(environment="test"))
+    with TestClient(app) as client:
+        response = client.get("/api/v1/health/live", headers={"X-Request-ID": "bad id value"})
+
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"] != "bad id value"
+    assert UUID_PATTERN.fullmatch(response.headers["X-Request-ID"])
+
+
+def test_structured_api_error_contains_request_id() -> None:
+    app = create_app(Settings(environment="test"))
+    router = APIRouter()
+
+    @router.get("/boom")
+    async def boom() -> None:
+        raise APIError("TEST_FAILURE", "synthetic failure", status_code=409)
+
+    app.include_router(router, prefix="/api/v1")
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/boom", headers={"X-Request-ID": "req-error-001"})
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": {
+            "code": "TEST_FAILURE",
+            "message": "synthetic failure",
+            "request_id": "req-error-001",
+            "details": [],
+        }
+    }
+
+
+def test_openapi_schema_is_deterministic_and_versioned() -> None:
+    first = create_app(Settings(environment="test", build_revision="schema-export")).openapi()
+    second = create_app(Settings(environment="test", build_revision="schema-export")).openapi()
+
+    assert first == second
+    assert first["openapi"] == "3.1.0"
+    assert "/api/v1/health/live" in first["paths"]
+    assert "/api/v1/health/ready" in first["paths"]

--- a/apps/api/tests/test_settings.py
+++ b/apps/api/tests/test_settings.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from ai_automation_force_api import SettingsError, load_settings
+
+
+def test_settings_defaults_are_safe_for_local_development() -> None:
+    settings = load_settings({})
+    assert settings.environment == "development"
+    assert settings.api_prefix == "/api/v1"
+    assert settings.internal_dev_identity is None
+
+
+def test_settings_reject_internal_dev_identity_in_production() -> None:
+    with pytest.raises(SettingsError, match="internal_dev_identity"):
+        load_settings(
+            {
+                "AAF_ENVIRONMENT": "production",
+                "AAF_INTERNAL_DEV_IDENTITY": "unsafe-prod-actor",
+            }
+        )
+
+
+def test_settings_reject_invalid_api_version() -> None:
+    with pytest.raises(SettingsError, match="api_version"):
+        load_settings({"AAF_API_VERSION": "latest"})


### PR DESCRIPTION
## Scope
Implements approved M02/WP1 only.

## Changes
- add independent `apps/api` Python 3.12 package
- pin implementation FastAPI to current verified stable `0.141.1`
- add validated environment/settings boundary
- disallow internal dev identity in staging/production
- add lifespan-managed runtime readiness state
- add bounded/sanitized request correlation IDs
- add structured non-leaky error envelope for API/validation/HTTP/unexpected errors
- add versioned `/api/v1/health/live` and `/api/v1/health/ready`
- expose ASGI application entrypoint
- add deterministic OpenAPI export tooling
- add settings/API/OpenAPI tests
- add permanent `Durable Control Plane` CI that reruns M01 domain/PostgreSQL/schema gates as regressions

## Boundary
No Temporal integration yet (WP2), no durable jobs/background tasks, no provider calls/credentials/spend, no full auth/RBAC, no object storage, no media generation, no M03+ behavior.

## Verification
Merge only after Python 3.12 + PostgreSQL 18 CI passes Ruff, strict mypy, all existing M01 tests, API tests, schema sync, deterministic OpenAPI generation and compile checks.