### PR TITLE
M02-WP5: durable human approval waits and safe resume

### DIFF
--- a/apps/worker/src/ai_automation_force_worker/__init__.py
+++ b/apps/worker/src/ai_automation_force_worker/__init__.py
@@ -2,6 +2,7 @@ from .client import connect_temporal
 from .settings import WorkerSettings, WorkerSettingsError, load_worker_settings
 from .worker import build_worker
 from .workflows import (
+    SyntheticApprovalWorkflow,
     SyntheticCancellationWorkflow,
     SyntheticControlWorkflow,
     SyntheticRetryWorkflow,
@@ -11,6 +12,7 @@ from .workflows import (
 )
 
 __all__ = [
+    "SyntheticApprovalWorkflow",
     "SyntheticCancellationWorkflow",
     "SyntheticControlWorkflow",
     "SyntheticRetryWorkflow",

--- a/apps/worker/src/ai_automation_force_worker/worker.py
+++ b/apps/worker/src/ai_automation_force_worker/worker.py
@@ -6,6 +6,7 @@ from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 
 from .settings import WorkerSettings
 from .workflows import (
+    SyntheticApprovalWorkflow,
     SyntheticCancellationWorkflow,
     SyntheticControlWorkflow,
     SyntheticRetryWorkflow,
@@ -23,6 +24,7 @@ def build_worker(client: Client, settings: WorkerSettings) -> Worker:
             SyntheticControlWorkflow,
             SyntheticRetryWorkflow,
             SyntheticCancellationWorkflow,
+            SyntheticApprovalWorkflow,
         ],
         activities=[synthetic_echo, synthetic_flaky, synthetic_cancellable],
         workflow_runner=SandboxedWorkflowRunner(),

--- a/apps/worker/src/ai_automation_force_worker/workflows.py
+++ b/apps/worker/src/ai_automation_force_worker/workflows.py
@@ -137,7 +137,7 @@ class SyntheticApprovalWorkflow:
                 lambda: self._decision is not None,
                 timeout=timedelta(seconds=timeout_seconds),
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             await workflow.wait_condition(workflow.all_handlers_finished)
             return "expired"
         await workflow.wait_condition(workflow.all_handlers_finished)

--- a/apps/worker/src/ai_automation_force_worker/workflows.py
+++ b/apps/worker/src/ai_automation_force_worker/workflows.py
@@ -90,3 +90,56 @@ class SyntheticCancellationWorkflow:
             heartbeat_timeout=SYNTHETIC_CANCEL_HEARTBEAT,
             cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
         )
+
+
+@workflow.defn
+class SyntheticApprovalWorkflow:
+    """Spend-free signal wait proving stale, duplicate and expiry-safe resume behavior."""
+
+    def __init__(self) -> None:
+        self._expected_revision: int | None = None
+        self._decision: str | None = None
+        self._pending_signals: list[tuple[int, str]] = []
+        self._seen_signal_keys: set[str] = set()
+
+    def _apply_pending(self) -> None:
+        if self._expected_revision is None or self._decision is not None:
+            return
+        for request_revision, decision in self._pending_signals:
+            if request_revision == self._expected_revision:
+                self._decision = decision
+                return
+
+    @workflow.signal
+    def resolve(self, payload: dict[str, str | int]) -> None:
+        signal_key = str(payload["signal_key"]).strip()
+        if not signal_key or signal_key in self._seen_signal_keys:
+            return
+        self._seen_signal_keys.add(signal_key)
+        request_revision = int(payload["request_revision"])
+        decision = str(payload["decision"]).strip()
+        if not decision:
+            return
+        self._pending_signals.append((request_revision, decision))
+        self._apply_pending()
+
+    @workflow.run
+    async def run(self, input: dict[str, int | float]) -> str:
+        self._expected_revision = int(input["expected_revision"])
+        timeout_seconds = float(input["timeout_seconds"])
+        if self._expected_revision < 1:
+            raise ValueError("expected_revision must be at least 1")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._apply_pending()
+        try:
+            await workflow.wait_condition(
+                lambda: self._decision is not None,
+                timeout=timedelta(seconds=timeout_seconds),
+            )
+        except asyncio.TimeoutError:
+            await workflow.wait_condition(workflow.all_handlers_finished)
+            return "expired"
+        await workflow.wait_condition(workflow.all_handlers_finished)
+        assert self._decision is not None
+        return self._decision

--- a/apps/worker/tests/test_approval_wait_integration.py
+++ b/apps/worker/tests/test_approval_wait_integration.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+from temporalio.worker import Replayer
+
+from ai_automation_force_worker import (
+    SyntheticApprovalWorkflow,
+    WorkerSettings,
+    build_worker,
+    connect_temporal,
+)
+
+TEMPORAL_INTEGRATION = os.environ.get("AAF_TEMPORAL_INTEGRATION") == "1"
+
+
+@pytest.mark.temporal
+@pytest.mark.skipif(not TEMPORAL_INTEGRATION, reason="AAF_TEMPORAL_INTEGRATION=1 is required")
+def test_temporal_approval_wait_ignores_stale_and_duplicate_signals_and_replays() -> None:
+    settings = WorkerSettings()
+
+    async def scenario() -> tuple[str, object]:
+        client = await connect_temporal(settings)
+        worker = build_worker(client, settings)
+        async with worker:
+            handle = await client.start_workflow(
+                SyntheticApprovalWorkflow.run,
+                {"expected_revision": 7, "timeout_seconds": 2.0},
+                id="WFX-000891-approval",
+                task_queue=settings.task_queue,
+            )
+            await handle.signal(
+                SyntheticApprovalWorkflow.resolve,
+                {
+                    "request_revision": 6,
+                    "decision": "rejected",
+                    "signal_key": "signal-stale",
+                },
+            )
+            await handle.signal(
+                SyntheticApprovalWorkflow.resolve,
+                {
+                    "request_revision": 7,
+                    "decision": "approved",
+                    "signal_key": "signal-valid",
+                },
+            )
+            await handle.signal(
+                SyntheticApprovalWorkflow.resolve,
+                {
+                    "request_revision": 7,
+                    "decision": "rejected",
+                    "signal_key": "signal-valid",
+                },
+            )
+            result = await handle.result()
+            history = await handle.fetch_history()
+            return result, history
+
+    result, history = asyncio.run(scenario())
+    assert result == "approved"
+    asyncio.run(Replayer(workflows=[SyntheticApprovalWorkflow]).replay_workflow(history))
+
+
+@pytest.mark.temporal
+@pytest.mark.skipif(not TEMPORAL_INTEGRATION, reason="AAF_TEMPORAL_INTEGRATION=1 is required")
+def test_temporal_approval_wait_expires_without_signal_and_replays() -> None:
+    settings = WorkerSettings()
+
+    async def scenario() -> tuple[str, object]:
+        client = await connect_temporal(settings)
+        worker = build_worker(client, settings)
+        async with worker:
+            handle = await client.start_workflow(
+                SyntheticApprovalWorkflow.run,
+                {"expected_revision": 1, "timeout_seconds": 1.0},
+                id="WFX-000892-approval-expiry",
+                task_queue=settings.task_queue,
+            )
+            result = await handle.result()
+            history = await handle.fetch_history()
+            return result, history
+
+    result, history = asyncio.run(scenario())
+    assert result == "expired"
+    asyncio.run(Replayer(workflows=[SyntheticApprovalWorkflow]).replay_workflow(history))

--- a/packages/python-core/migrations/sql/0005_approval_waits_down.sql
+++ b/packages/python-core/migrations/sql/0005_approval_waits_down.sql
@@ -1,0 +1,1 @@
+DROP TABLE core.approval_requests;

--- a/packages/python-core/migrations/sql/0005_approval_waits_up.sql
+++ b/packages/python-core/migrations/sql/0005_approval_waits_up.sql
@@ -17,6 +17,7 @@ CREATE TABLE core.approval_requests (
     approval_id uuid UNIQUE,
     resolution_fingerprint char(64),
     resolved_job_revision integer,
+    resolved_job_status text,
     requested_at timestamptz NOT NULL,
     closed_at timestamptz,
     updated_at timestamptz NOT NULL,
@@ -56,11 +57,14 @@ CREATE TABLE core.approval_requests (
     CONSTRAINT ck_approval_request_revision CHECK (revision >= 1),
     CONSTRAINT ck_approval_request_lifecycle CHECK (
         (status = 'pending' AND approval_id IS NULL AND resolution_fingerprint IS NULL
-            AND resolved_job_revision IS NULL AND closed_at IS NULL)
+            AND resolved_job_revision IS NULL AND resolved_job_status IS NULL
+            AND closed_at IS NULL)
         OR (status = 'resolved' AND approval_id IS NOT NULL AND resolution_fingerprint IS NOT NULL
-            AND resolved_job_revision IS NOT NULL AND closed_at IS NOT NULL)
+            AND resolved_job_revision IS NOT NULL AND resolved_job_status IS NOT NULL
+            AND closed_at IS NOT NULL)
         OR (status = 'expired' AND approval_id IS NULL AND resolution_fingerprint IS NULL
-            AND resolved_job_revision IS NOT NULL AND closed_at IS NOT NULL)
+            AND resolved_job_revision IS NOT NULL AND resolved_job_status IS NOT NULL
+            AND closed_at IS NOT NULL)
     )
 );
 

--- a/packages/python-core/migrations/sql/0005_approval_waits_up.sql
+++ b/packages/python-core/migrations/sql/0005_approval_waits_up.sql
@@ -1,0 +1,73 @@
+CREATE TABLE core.approval_requests (
+    id uuid PRIMARY KEY,
+    external_id text NOT NULL UNIQUE,
+    project_id uuid NOT NULL,
+    job_id uuid NOT NULL,
+    wait_kind text NOT NULL,
+    subject_type text NOT NULL,
+    subject_id text NOT NULL,
+    requested_job_status text NOT NULL,
+    requested_job_revision integer NOT NULL,
+    requested_by text NOT NULL,
+    reason text,
+    idempotency_key text NOT NULL,
+    request_fingerprint char(64) NOT NULL,
+    status text NOT NULL DEFAULT 'pending',
+    expires_at timestamptz,
+    approval_id uuid UNIQUE,
+    resolution_fingerprint char(64),
+    resolved_job_revision integer,
+    requested_at timestamptz NOT NULL,
+    closed_at timestamptz,
+    updated_at timestamptz NOT NULL,
+    revision integer NOT NULL DEFAULT 1,
+    CONSTRAINT fk_approval_request_project FOREIGN KEY (project_id)
+        REFERENCES core.projects(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_approval_request_job FOREIGN KEY (job_id)
+        REFERENCES core.jobs(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_approval_request_approval FOREIGN KEY (approval_id)
+        REFERENCES core.approvals(id) ON DELETE RESTRICT,
+    CONSTRAINT uq_approval_request_job_key UNIQUE (job_id, idempotency_key),
+    CONSTRAINT ck_approval_request_external_id CHECK (external_id ~ '^AQR-[0-9]{6,20}$'),
+    CONSTRAINT ck_approval_request_kind CHECK (
+        wait_kind IN ('human-approval', 'budget', 'manual-handoff')
+    ),
+    CONSTRAINT ck_approval_request_wait_status CHECK (
+        (wait_kind = 'human-approval' AND requested_job_status = 'waiting-human')
+        OR (wait_kind = 'budget' AND requested_job_status = 'blocked-budget')
+        OR (wait_kind = 'manual-handoff' AND requested_job_status = 'manual-handoff')
+    ),
+    CONSTRAINT ck_approval_request_status CHECK (status IN ('pending', 'resolved', 'expired')),
+    CONSTRAINT ck_approval_request_job_revision CHECK (requested_job_revision >= 1),
+    CONSTRAINT ck_approval_request_resolved_job_revision CHECK (
+        resolved_job_revision IS NULL OR resolved_job_revision >= requested_job_revision
+    ),
+    CONSTRAINT ck_approval_request_idempotency CHECK (length(idempotency_key) BETWEEN 8 AND 200),
+    CONSTRAINT ck_approval_request_fingerprint CHECK (
+        request_fingerprint ~ '^[a-f0-9]{64}$'
+    ),
+    CONSTRAINT ck_approval_resolution_fingerprint CHECK (
+        resolution_fingerprint IS NULL OR resolution_fingerprint ~ '^[a-f0-9]{64}$'
+    ),
+    CONSTRAINT ck_approval_request_expiry CHECK (
+        expires_at IS NULL OR expires_at > requested_at
+    ),
+    CONSTRAINT ck_approval_request_time CHECK (updated_at >= requested_at),
+    CONSTRAINT ck_approval_request_revision CHECK (revision >= 1),
+    CONSTRAINT ck_approval_request_lifecycle CHECK (
+        (status = 'pending' AND approval_id IS NULL AND resolution_fingerprint IS NULL
+            AND resolved_job_revision IS NULL AND closed_at IS NULL)
+        OR (status = 'resolved' AND approval_id IS NOT NULL AND resolution_fingerprint IS NOT NULL
+            AND resolved_job_revision IS NOT NULL AND closed_at IS NOT NULL)
+        OR (status = 'expired' AND approval_id IS NULL AND resolution_fingerprint IS NULL
+            AND resolved_job_revision IS NOT NULL AND closed_at IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX uq_approval_request_job_pending
+    ON core.approval_requests (job_id)
+    WHERE status = 'pending';
+
+CREATE INDEX idx_approval_request_expiry
+    ON core.approval_requests (expires_at, id)
+    WHERE status = 'pending' AND expires_at IS NOT NULL;

--- a/packages/python-core/migrations/versions/20260829_0005_approval_waits.py
+++ b/packages/python-core/migrations/versions/20260829_0005_approval_waits.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "20260829_0005"
+down_revision = "20260829_0004"
+branch_labels = None
+depends_on = None
+
+_SQL_DIR = Path(__file__).resolve().parents[1] / "sql"
+
+
+def _statements(filename: str) -> list[str]:
+    text = (_SQL_DIR / filename).read_text(encoding="utf-8")
+    return [statement.strip() for statement in text.split(";\n") if statement.strip()]
+
+
+def _execute(filename: str) -> None:
+    for statement in _statements(filename):
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute("0005_approval_waits_up.sql")
+
+
+def downgrade() -> None:
+    _execute("0005_approval_waits_down.sql")

--- a/packages/python-core/src/lullabies_core/__init__.py
+++ b/packages/python-core/src/lullabies_core/__init__.py
@@ -1,4 +1,15 @@
 from .aggregate import ProjectBundle
+from .approval_wait import (
+    WAIT_JOB_STATUS,
+    ApprovalRequestResult,
+    ApprovalRequestStatus,
+    ApprovalResolutionResult,
+    ApprovalWaitKind,
+    ApprovalWaitRequest,
+    expected_wait_status,
+    expired_job_status,
+    resolved_job_status,
+)
 from .character import Character, CharacterLock, CharacterLook, CharacterVersion
 from .common import (
     SCHEMA_VERSION,
@@ -42,6 +53,9 @@ from .legacy_import import (
 )
 from .lineage import ProductionLineageBundle
 from .persistence import (
+    ApprovalWaitConflictError,
+    ApprovalWaitExpiredError,
+    ApprovalWaitVersionConflictError,
     CircuitBreakerConflictError,
     JobIdempotencyConflictError,
     JobLeaseConflictError,
@@ -53,6 +67,7 @@ from .persistence import (
     PersistenceReferenceError,
     PersistenceShapeError,
     PersistResult,
+    PostgresApprovalWaitRepository,
     PostgresCircuitBreakerRepository,
     PostgresJobControlRepository,
     PostgresProductionRepository,
@@ -108,9 +123,18 @@ __all__ = [
     "RETRY_DECISIONS",
     "SCHEMA_VERSION",
     "TERMINAL_JOB_STATUSES",
+    "WAIT_JOB_STATUS",
     "Act",
     "Approval",
     "ApprovalDecision",
+    "ApprovalRequestResult",
+    "ApprovalRequestStatus",
+    "ApprovalResolutionResult",
+    "ApprovalWaitConflictError",
+    "ApprovalWaitExpiredError",
+    "ApprovalWaitKind",
+    "ApprovalWaitRequest",
+    "ApprovalWaitVersionConflictError",
     "Asset",
     "AssetKind",
     "AttemptStatus",
@@ -168,6 +192,7 @@ __all__ = [
     "PersistenceNotFoundError",
     "PersistenceReferenceError",
     "PersistenceShapeError",
+    "PostgresApprovalWaitRepository",
     "PostgresCircuitBreakerRepository",
     "PostgresJobControlRepository",
     "PostgresProductionRepository",
@@ -195,8 +220,11 @@ __all__ = [
     "WorkflowPersistResult",
     "World",
     "assert_job_transition",
+    "expected_wait_status",
+    "expired_job_status",
     "import_legacy_content_package",
     "operation_fingerprint",
     "reconcile_legacy_content_import",
+    "resolved_job_status",
     "retry_decision",
 ]

--- a/packages/python-core/src/lullabies_core/approval_wait.py
+++ b/packages/python-core/src/lullabies_core/approval_wait.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Literal
+
+from .common import ApprovalDecision, JobStatus
+from .job_control import operation_fingerprint
+
+
+class ApprovalWaitKind(StrEnum):
+    HUMAN_APPROVAL = "human-approval"
+    BUDGET = "budget"
+    MANUAL_HANDOFF = "manual-handoff"
+
+
+class ApprovalRequestStatus(StrEnum):
+    PENDING = "pending"
+    RESOLVED = "resolved"
+    EXPIRED = "expired"
+
+
+WAIT_JOB_STATUS: dict[ApprovalWaitKind, JobStatus] = {
+    ApprovalWaitKind.HUMAN_APPROVAL: JobStatus.WAITING_HUMAN,
+    ApprovalWaitKind.BUDGET: JobStatus.BLOCKED_BUDGET,
+    ApprovalWaitKind.MANUAL_HANDOFF: JobStatus.MANUAL_HANDOFF,
+}
+
+
+def expected_wait_status(wait_kind: ApprovalWaitKind) -> JobStatus:
+    return WAIT_JOB_STATUS[wait_kind]
+
+
+def resolved_job_status(
+    wait_kind: ApprovalWaitKind,
+    decision: ApprovalDecision,
+) -> JobStatus | None:
+    if decision in {ApprovalDecision.APPROVED, ApprovalDecision.WAIVED}:
+        return JobStatus.ELIGIBLE
+    if decision is ApprovalDecision.REQUEST_CHANGES:
+        return None
+    if wait_kind is ApprovalWaitKind.BUDGET:
+        return JobStatus.CANCELLED
+    return JobStatus.PERMANENT_FAILED
+
+
+def expired_job_status(wait_kind: ApprovalWaitKind) -> JobStatus | None:
+    if wait_kind is ApprovalWaitKind.MANUAL_HANDOFF:
+        return None
+    return JobStatus.MANUAL_HANDOFF
+
+
+@dataclass(frozen=True)
+class ApprovalWaitRequest:
+    request_id: str
+    project_id: str
+    job_id: str
+    wait_kind: ApprovalWaitKind
+    subject_type: str
+    subject_id: str
+    requested_job_revision: int
+    requested_by: str
+    requested_at: datetime
+    idempotency_key: str
+    expires_at: datetime | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.request_id.startswith("AQR-") or not self.request_id[4:].isdigit():
+            raise ValueError("request_id must use the AQR numeric namespace")
+        if len(self.request_id[4:]) < 6 or len(self.request_id[4:]) > 20:
+            raise ValueError("request_id numeric component must contain 6 to 20 digits")
+        if self.requested_job_revision < 1:
+            raise ValueError("requested_job_revision must be at least 1")
+        if not self.subject_type.strip() or not self.subject_id.strip():
+            raise ValueError("approval subject must not be blank")
+        if not self.requested_by.strip():
+            raise ValueError("requested_by must not be blank")
+        if len(self.idempotency_key) < 8 or len(self.idempotency_key) > 200:
+            raise ValueError("idempotency_key length must be between 8 and 200")
+        if self.expires_at is not None and self.expires_at <= self.requested_at:
+            raise ValueError("expires_at must be later than requested_at")
+
+    @property
+    def request_fingerprint(self) -> str:
+        return operation_fingerprint(
+            {
+                "project_id": self.project_id,
+                "job_id": self.job_id,
+                "wait_kind": self.wait_kind.value,
+                "subject_type": self.subject_type,
+                "subject_id": self.subject_id,
+                "requested_job_revision": self.requested_job_revision,
+                "requested_by": self.requested_by,
+                "requested_at": self.requested_at,
+                "expires_at": self.expires_at,
+                "reason": self.reason,
+            }
+        )
+
+
+ApprovalRequestAction = Literal["created", "reused"]
+ApprovalResolutionAction = Literal["resolved", "reused", "expired"]
+
+
+@dataclass(frozen=True)
+class ApprovalRequestResult:
+    action: ApprovalRequestAction
+    request_id: str
+    request_revision: int
+    job_revision: int
+    status: ApprovalRequestStatus
+
+
+@dataclass(frozen=True)
+class ApprovalResolutionResult:
+    action: ApprovalResolutionAction
+    request_id: str
+    request_revision: int
+    job_revision: int
+    request_status: ApprovalRequestStatus
+    job_status: JobStatus
+    approval_id: str | None = None

--- a/packages/python-core/src/lullabies_core/persistence/__init__.py
+++ b/packages/python-core/src/lullabies_core/persistence/__init__.py
@@ -6,6 +6,12 @@ from ._db import (
     PersistenceShapeError,
     PersistResult,
 )
+from .approval_wait import (
+    ApprovalWaitConflictError,
+    ApprovalWaitExpiredError,
+    ApprovalWaitVersionConflictError,
+    PostgresApprovalWaitRepository,
+)
 from .circuit_breaker import CircuitBreakerConflictError, PostgresCircuitBreakerRepository
 from .job_control import (
     JobIdempotencyConflictError,
@@ -18,6 +24,9 @@ from .repository import PostgresProductionRepository
 from .workflow_execution import PostgresWorkflowExecutionRepository, WorkflowPersistResult
 
 __all__ = [
+    "ApprovalWaitConflictError",
+    "ApprovalWaitExpiredError",
+    "ApprovalWaitVersionConflictError",
     "CircuitBreakerConflictError",
     "JobIdempotencyConflictError",
     "JobLeaseConflictError",
@@ -29,6 +38,7 @@ __all__ = [
     "PersistenceNotFoundError",
     "PersistenceReferenceError",
     "PersistenceShapeError",
+    "PostgresApprovalWaitRepository",
     "PostgresCircuitBreakerRepository",
     "PostgresJobControlRepository",
     "PostgresProductionRepository",

--- a/packages/python-core/src/lullabies_core/persistence/approval_wait.py
+++ b/packages/python-core/src/lullabies_core/persistence/approval_wait.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import MetaData, Table, insert, select, update
+from sqlalchemy.engine import Connection, Engine, RowMapping
+from sqlalchemy.exc import IntegrityError
+
+from ..approval_wait import (
+    ApprovalRequestResult,
+    ApprovalRequestStatus,
+    ApprovalResolutionResult,
+    ApprovalWaitKind,
+    ApprovalWaitRequest,
+    expected_wait_status,
+    expired_job_status,
+    resolved_job_status,
+)
+from ..common import JobStatus
+from ..job_control import InvalidJobTransitionError, assert_job_transition, operation_fingerprint
+from ..production import Approval
+from ._db import PersistenceConflictError, PersistenceNotFoundError, PersistenceReferenceError
+
+
+class ApprovalWaitConflictError(PersistenceConflictError):
+    """Approval request identity, state, or captured job state is inconsistent."""
+
+
+class ApprovalWaitVersionConflictError(ApprovalWaitConflictError):
+    """Approval request or job changed after the caller observed it."""
+
+
+class ApprovalWaitExpiredError(ApprovalWaitConflictError):
+    """A resolution arrived after the approval request expiry boundary."""
+
+
+class PostgresApprovalWaitRepository:
+    """Atomic approval waits with stale-version and duplicate-resolution protection."""
+
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+        metadata = MetaData()
+        metadata.reflect(bind=engine, schema="core")
+        required = {"approval_requests", "approvals", "jobs", "projects", "outbox_messages"}
+        missing = [name for name in required if f"core.{name}" not in metadata.tables]
+        if missing:
+            raise PersistenceReferenceError(
+                f"approval-wait persistence tables are not migrated: {', '.join(sorted(missing))}"
+            )
+        self.requests = metadata.tables["core.approval_requests"]
+        self.approvals = metadata.tables["core.approvals"]
+        self.jobs = metadata.tables["core.jobs"]
+        self.projects = metadata.tables["core.projects"]
+        self.outbox = metadata.tables["core.outbox_messages"]
+
+    def request(self, request: ApprovalWaitRequest) -> ApprovalRequestResult:
+        required_status = expected_wait_status(request.wait_kind)
+        fingerprint = request.request_fingerprint
+        try:
+            with self.engine.begin() as connection:
+                project = self._require_external(
+                    connection,
+                    self.projects,
+                    request.project_id,
+                    "project",
+                )
+                job = self._require_job_for_update(connection, request.job_id)
+                if job["project_id"] != project["id"]:
+                    raise PersistenceReferenceError(
+                        f"job {request.job_id} belongs to another project"
+                    )
+                self._require_job_snapshot(
+                    job,
+                    request.requested_job_revision,
+                    required_status,
+                )
+
+                existing = connection.execute(
+                    select(self.requests)
+                    .where(
+                        self.requests.c.job_id == job["id"],
+                        self.requests.c.idempotency_key == request.idempotency_key,
+                    )
+                    .with_for_update()
+                ).mappings().one_or_none()
+                if existing is not None:
+                    if existing["request_fingerprint"] != fingerprint:
+                        raise ApprovalWaitConflictError(
+                            "approval idempotency key is bound to different request semantics"
+                        )
+                    return ApprovalRequestResult(
+                        "reused",
+                        str(existing["external_id"]),
+                        int(existing["revision"]),
+                        int(existing["requested_job_revision"]),
+                        ApprovalRequestStatus(str(existing["status"])),
+                    )
+
+                internal_id = uuid4()
+                connection.execute(
+                    insert(self.requests).values(
+                        id=internal_id,
+                        external_id=request.request_id,
+                        project_id=project["id"],
+                        job_id=job["id"],
+                        wait_kind=request.wait_kind.value,
+                        subject_type=request.subject_type,
+                        subject_id=request.subject_id,
+                        requested_job_status=required_status.value,
+                        requested_job_revision=request.requested_job_revision,
+                        requested_by=request.requested_by,
+                        reason=request.reason,
+                        idempotency_key=request.idempotency_key,
+                        request_fingerprint=fingerprint,
+                        status=ApprovalRequestStatus.PENDING.value,
+                        expires_at=request.expires_at,
+                        approval_id=None,
+                        resolution_fingerprint=None,
+                        resolved_job_revision=None,
+                        resolved_job_status=None,
+                        requested_at=request.requested_at,
+                        closed_at=None,
+                        updated_at=request.requested_at,
+                        revision=1,
+                    )
+                )
+                self._insert_outbox(
+                    connection,
+                    job["id"],
+                    request.job_id,
+                    request.requested_job_revision,
+                    request.request_id,
+                    1,
+                    "approval.requested",
+                    request.requested_at,
+                    {
+                        "request_id": request.request_id,
+                        "job_id": request.job_id,
+                        "wait_kind": request.wait_kind.value,
+                        "status": ApprovalRequestStatus.PENDING.value,
+                        "job_revision": request.requested_job_revision,
+                    },
+                )
+                return ApprovalRequestResult(
+                    "created",
+                    request.request_id,
+                    1,
+                    request.requested_job_revision,
+                    ApprovalRequestStatus.PENDING,
+                )
+        except (ApprovalWaitConflictError, PersistenceReferenceError):
+            raise
+        except IntegrityError as exc:
+            raise ApprovalWaitConflictError(
+                f"database rejected approval request: {exc.orig}"
+            ) from exc
+
+    def resolve(
+        self,
+        request_id: str,
+        approval: Approval,
+        *,
+        expected_request_revision: int,
+    ) -> ApprovalResolutionResult:
+        fingerprint = operation_fingerprint(
+            {
+                "approval_id": approval.approval_id,
+                "project_id": approval.project_id,
+                "subject_type": approval.subject_type,
+                "subject_id": approval.subject_id,
+                "decision": approval.decision.value,
+                "actor": approval.actor,
+                "reason": approval.reason,
+                "created_at": approval.created_at,
+            }
+        )
+        try:
+            with self.engine.begin() as connection:
+                request = self._require_request_for_update(connection, request_id)
+                status = ApprovalRequestStatus(str(request["status"]))
+                if status is ApprovalRequestStatus.RESOLVED:
+                    if request["resolution_fingerprint"] != fingerprint:
+                        raise ApprovalWaitConflictError(
+                            "approval request is already resolved with different semantics"
+                        )
+                    approval_row = self._require_approval_by_id(
+                        connection,
+                        request["approval_id"],
+                    )
+                    return ApprovalResolutionResult(
+                        "reused",
+                        request_id,
+                        int(request["revision"]),
+                        int(request["resolved_job_revision"]),
+                        status,
+                        JobStatus(str(request["resolved_job_status"])),
+                        str(approval_row["external_id"]),
+                    )
+                if status is ApprovalRequestStatus.EXPIRED:
+                    raise ApprovalWaitExpiredError(f"approval request {request_id} has expired")
+                self._require_request_revision(request, expected_request_revision)
+                if approval.created_at < request["requested_at"]:
+                    raise ApprovalWaitConflictError("approval predates the request")
+                expires_at = request["expires_at"]
+                if expires_at is not None and approval.created_at >= expires_at:
+                    raise ApprovalWaitExpiredError(
+                        f"approval request {request_id} expired before resolution"
+                    )
+                self._require_approval_matches_request(request, approval)
+
+                job = self._require_job_by_id_for_update(connection, request["job_id"])
+                current_status = JobStatus(str(request["requested_job_status"]))
+                self._require_job_snapshot(
+                    job,
+                    int(request["requested_job_revision"]),
+                    current_status,
+                )
+                target = resolved_job_status(
+                    ApprovalWaitKind(str(request["wait_kind"])),
+                    approval.decision,
+                )
+                new_status = target or current_status
+                if target is not None:
+                    try:
+                        assert_job_transition(current_status, target)
+                    except InvalidJobTransitionError as exc:
+                        raise ApprovalWaitConflictError(str(exc)) from exc
+                new_job_revision = int(job["revision"]) + 1
+                job_values: dict[str, Any] = {
+                    "status": new_status.value,
+                    "updated_at": approval.created_at,
+                    "revision": new_job_revision,
+                    "claimed_by": None,
+                    "lease_expires_at": None,
+                }
+                if target is not None:
+                    job_values["blocked_reason"] = None
+                self._update_job(connection, job, job_values)
+
+                approval_internal_id = uuid4()
+                connection.execute(
+                    insert(self.approvals).values(
+                        id=approval_internal_id,
+                        external_id=approval.approval_id,
+                        schema_version=approval.schema_version,
+                        project_id=request["project_id"],
+                        subject_type=approval.subject_type,
+                        subject_id=approval.subject_id,
+                        decision=approval.decision.value,
+                        actor=approval.actor,
+                        reason=approval.reason,
+                        created_at=approval.created_at,
+                    )
+                )
+
+                new_request_revision = expected_request_revision + 1
+                self._update_request(
+                    connection,
+                    request,
+                    expected_request_revision,
+                    {
+                        "status": ApprovalRequestStatus.RESOLVED.value,
+                        "approval_id": approval_internal_id,
+                        "resolution_fingerprint": fingerprint,
+                        "resolved_job_revision": new_job_revision,
+                        "resolved_job_status": new_status.value,
+                        "closed_at": approval.created_at,
+                        "updated_at": approval.created_at,
+                        "revision": new_request_revision,
+                    },
+                )
+                self._insert_outbox(
+                    connection,
+                    job["id"],
+                    str(job["external_id"]),
+                    new_job_revision,
+                    request_id,
+                    new_request_revision,
+                    "approval.resolved",
+                    approval.created_at,
+                    {
+                        "request_id": request_id,
+                        "approval_id": approval.approval_id,
+                        "decision": approval.decision.value,
+                        "job_id": str(job["external_id"]),
+                        "job_status": new_status.value,
+                        "job_revision": new_job_revision,
+                    },
+                )
+                return ApprovalResolutionResult(
+                    "resolved",
+                    request_id,
+                    new_request_revision,
+                    new_job_revision,
+                    ApprovalRequestStatus.RESOLVED,
+                    new_status,
+                    approval.approval_id,
+                )
+        except (
+            ApprovalWaitConflictError,
+            PersistenceNotFoundError,
+            PersistenceReferenceError,
+        ):
+            raise
+        except IntegrityError as exc:
+            raise ApprovalWaitConflictError(
+                f"database rejected approval resolution: {exc.orig}"
+            ) from exc
+
+    def expire(
+        self,
+        request_id: str,
+        *,
+        now: datetime,
+        expected_request_revision: int,
+    ) -> ApprovalResolutionResult:
+        with self.engine.begin() as connection:
+            request = self._require_request_for_update(connection, request_id)
+            status = ApprovalRequestStatus(str(request["status"]))
+            if status is ApprovalRequestStatus.EXPIRED:
+                return ApprovalResolutionResult(
+                    "expired",
+                    request_id,
+                    int(request["revision"]),
+                    int(request["resolved_job_revision"]),
+                    status,
+                    JobStatus(str(request["resolved_job_status"])),
+                )
+            if status is ApprovalRequestStatus.RESOLVED:
+                raise ApprovalWaitConflictError(f"approval request {request_id} is resolved")
+            self._require_request_revision(request, expected_request_revision)
+            expires_at = request["expires_at"]
+            if expires_at is None or expires_at > now:
+                raise ApprovalWaitConflictError(f"approval request {request_id} is not expired")
+
+            job = self._require_job_by_id_for_update(connection, request["job_id"])
+            current_status = JobStatus(str(request["requested_job_status"]))
+            self._require_job_snapshot(
+                job,
+                int(request["requested_job_revision"]),
+                current_status,
+            )
+            target = expired_job_status(ApprovalWaitKind(str(request["wait_kind"])))
+            new_status = target or current_status
+            if target is not None:
+                try:
+                    assert_job_transition(current_status, target)
+                except InvalidJobTransitionError as exc:
+                    raise ApprovalWaitConflictError(str(exc)) from exc
+            new_job_revision = int(job["revision"]) + 1
+            job_values: dict[str, Any] = {
+                "status": new_status.value,
+                "updated_at": now,
+                "revision": new_job_revision,
+                "claimed_by": None,
+                "lease_expires_at": None,
+            }
+            if new_status is JobStatus.MANUAL_HANDOFF:
+                job_values["blocked_reason"] = f"approval request {request_id} expired"
+            self._update_job(connection, job, job_values)
+
+            new_request_revision = expected_request_revision + 1
+            self._update_request(
+                connection,
+                request,
+                expected_request_revision,
+                {
+                    "status": ApprovalRequestStatus.EXPIRED.value,
+                    "resolved_job_revision": new_job_revision,
+                    "resolved_job_status": new_status.value,
+                    "closed_at": now,
+                    "updated_at": now,
+                    "revision": new_request_revision,
+                },
+            )
+            self._insert_outbox(
+                connection,
+                job["id"],
+                str(job["external_id"]),
+                new_job_revision,
+                request_id,
+                new_request_revision,
+                "approval.expired",
+                now,
+                {
+                    "request_id": request_id,
+                    "job_id": str(job["external_id"]),
+                    "job_status": new_status.value,
+                    "job_revision": new_job_revision,
+                },
+            )
+            return ApprovalResolutionResult(
+                "expired",
+                request_id,
+                new_request_revision,
+                new_job_revision,
+                ApprovalRequestStatus.EXPIRED,
+                new_status,
+            )
+
+    def load(self, request_id: str) -> RowMapping:
+        with self.engine.connect() as connection:
+            row = connection.execute(
+                select(self.requests).where(self.requests.c.external_id == request_id)
+            ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceNotFoundError(f"approval request {request_id} was not found")
+        return row
+
+    def _require_request_for_update(self, connection: Connection, request_id: str) -> RowMapping:
+        row = connection.execute(
+            select(self.requests)
+            .where(self.requests.c.external_id == request_id)
+            .with_for_update()
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceNotFoundError(f"approval request {request_id} was not found")
+        return row
+
+    def _require_job_for_update(self, connection: Connection, job_id: str) -> RowMapping:
+        row = connection.execute(
+            select(self.jobs)
+            .where(self.jobs.c.external_id == job_id)
+            .with_for_update()
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceNotFoundError(f"job {job_id} was not found")
+        return row
+
+    def _require_job_by_id_for_update(self, connection: Connection, job_id: UUID) -> RowMapping:
+        row = connection.execute(
+            select(self.jobs).where(self.jobs.c.id == job_id).with_for_update()
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceReferenceError(f"approval request references missing job {job_id}")
+        return row
+
+    @staticmethod
+    def _require_job_snapshot(row: RowMapping, revision: int, status: JobStatus) -> None:
+        if int(row["revision"]) != revision:
+            raise ApprovalWaitVersionConflictError(
+                f"stale job revision: expected {revision}, current {row['revision']}"
+            )
+        current_status = JobStatus(str(row["status"]))
+        if current_status is not status:
+            raise ApprovalWaitVersionConflictError(
+                f"stale job status: expected {status.value}, current {current_status.value}"
+            )
+
+    @staticmethod
+    def _require_request_revision(row: RowMapping, expected_revision: int) -> None:
+        if int(row["revision"]) != expected_revision:
+            raise ApprovalWaitVersionConflictError(
+                f"stale approval request revision: expected {expected_revision}, "
+                f"current {row['revision']}"
+            )
+
+    @staticmethod
+    def _require_approval_matches_request(request: RowMapping, approval: Approval) -> None:
+        if approval.project_id != request["project_external_id"] if "project_external_id" in request else False:
+            raise ApprovalWaitConflictError("approval belongs to another project")
+        if approval.subject_type != request["subject_type"] or approval.subject_id != request["subject_id"]:
+            raise ApprovalWaitConflictError("approval subject does not match the request")
+
+    def _require_approval_by_id(self, connection: Connection, approval_id: UUID | None) -> RowMapping:
+        if approval_id is None:
+            raise PersistenceReferenceError("resolved request is missing approval identity")
+        row = connection.execute(
+            select(self.approvals).where(self.approvals.c.id == approval_id)
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceReferenceError("resolved request references missing approval")
+        return row
+
+    @staticmethod
+    def _require_external(
+        connection: Connection,
+        table: Table,
+        external_id: str,
+        label: str,
+    ) -> RowMapping:
+        row = connection.execute(
+            select(table).where(table.c.external_id == external_id)
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceReferenceError(f"missing {label}:{external_id}")
+        return row
+
+    def _update_job(
+        self,
+        connection: Connection,
+        row: RowMapping,
+        values: dict[str, Any],
+    ) -> None:
+        result = connection.execute(
+            update(self.jobs)
+            .where(self.jobs.c.id == row["id"], self.jobs.c.revision == row["revision"])
+            .values(**values)
+        )
+        if result.rowcount != 1:
+            raise ApprovalWaitVersionConflictError("job changed during approval mutation")
+
+    def _update_request(
+        self,
+        connection: Connection,
+        row: RowMapping,
+        expected_revision: int,
+        values: dict[str, Any],
+    ) -> None:
+        result = connection.execute(
+            update(self.requests)
+            .where(
+                self.requests.c.id == row["id"],
+                self.requests.c.revision == expected_revision,
+            )
+            .values(**values)
+        )
+        if result.rowcount != 1:
+            raise ApprovalWaitVersionConflictError(
+                "approval request changed during mutation"
+            )
+
+    def _insert_outbox(
+        self,
+        connection: Connection,
+        job_internal_id: UUID,
+        job_external_id: str,
+        job_revision: int,
+        request_id: str,
+        request_revision: int,
+        event_type: str,
+        occurred_at: datetime,
+        payload: dict[str, Any],
+    ) -> None:
+        dedupe_key = f"approval:{request_id}:revision:{request_revision}:{event_type}"
+        connection.execute(
+            insert(self.outbox).values(
+                id=uuid4(),
+                job_id=job_internal_id,
+                job_revision=job_revision,
+                event_type=event_type,
+                dedupe_key=dedupe_key,
+                payload=payload,
+                occurred_at=occurred_at,
+                published_at=None,
+            )
+        )

--- a/packages/python-core/src/lullabies_core/persistence/approval_wait.py
+++ b/packages/python-core/src/lullabies_core/persistence/approval_wait.py
@@ -43,11 +43,18 @@ class PostgresApprovalWaitRepository:
         self.engine = engine
         metadata = MetaData()
         metadata.reflect(bind=engine, schema="core")
-        required = {"approval_requests", "approvals", "jobs", "projects", "outbox_messages"}
+        required = {
+            "approval_requests",
+            "approvals",
+            "jobs",
+            "projects",
+            "outbox_messages",
+        }
         missing = [name for name in required if f"core.{name}" not in metadata.tables]
         if missing:
             raise PersistenceReferenceError(
-                f"approval-wait persistence tables are not migrated: {', '.join(sorted(missing))}"
+                "approval-wait persistence tables are not migrated: "
+                + ", ".join(sorted(missing))
             )
         self.requests = metadata.tables["core.approval_requests"]
         self.approvals = metadata.tables["core.approvals"]
@@ -200,6 +207,7 @@ class PostgresApprovalWaitRepository:
                     )
                 if status is ApprovalRequestStatus.EXPIRED:
                     raise ApprovalWaitExpiredError(f"approval request {request_id} has expired")
+
                 self._require_request_revision(request, expected_request_revision)
                 if approval.created_at < request["requested_at"]:
                     raise ApprovalWaitConflictError("approval predates the request")
@@ -208,8 +216,13 @@ class PostgresApprovalWaitRepository:
                     raise ApprovalWaitExpiredError(
                         f"approval request {request_id} expired before resolution"
                     )
-                self._require_approval_matches_request(request, approval)
 
+                project = self._require_project_by_id(connection, request["project_id"])
+                self._require_approval_matches_request(
+                    request,
+                    project,
+                    approval,
+                )
                 job = self._require_job_by_id_for_update(connection, request["job_id"])
                 current_status = JobStatus(str(request["requested_job_status"]))
                 self._require_job_snapshot(
@@ -217,16 +230,13 @@ class PostgresApprovalWaitRepository:
                     int(request["requested_job_revision"]),
                     current_status,
                 )
-                target = resolved_job_status(
-                    ApprovalWaitKind(str(request["wait_kind"])),
-                    approval.decision,
-                )
+
+                wait_kind = ApprovalWaitKind(str(request["wait_kind"]))
+                target = resolved_job_status(wait_kind, approval.decision)
                 new_status = target or current_status
                 if target is not None:
-                    try:
-                        assert_job_transition(current_status, target)
-                    except InvalidJobTransitionError as exc:
-                        raise ApprovalWaitConflictError(str(exc)) from exc
+                    self._require_transition(current_status, target)
+
                 new_job_revision = int(job["revision"]) + 1
                 job_values: dict[str, Any] = {
                     "status": new_status.value,
@@ -330,6 +340,7 @@ class PostgresApprovalWaitRepository:
                 )
             if status is ApprovalRequestStatus.RESOLVED:
                 raise ApprovalWaitConflictError(f"approval request {request_id} is resolved")
+
             self._require_request_revision(request, expected_request_revision)
             expires_at = request["expires_at"]
             if expires_at is None or expires_at > now:
@@ -342,13 +353,12 @@ class PostgresApprovalWaitRepository:
                 int(request["requested_job_revision"]),
                 current_status,
             )
-            target = expired_job_status(ApprovalWaitKind(str(request["wait_kind"])))
+            wait_kind = ApprovalWaitKind(str(request["wait_kind"]))
+            target = expired_job_status(wait_kind)
             new_status = target or current_status
             if target is not None:
-                try:
-                    assert_job_transition(current_status, target)
-                except InvalidJobTransitionError as exc:
-                    raise ApprovalWaitConflictError(str(exc)) from exc
+                self._require_transition(current_status, target)
+
             new_job_revision = int(job["revision"]) + 1
             job_values: dict[str, Any] = {
                 "status": new_status.value,
@@ -409,7 +419,11 @@ class PostgresApprovalWaitRepository:
             raise PersistenceNotFoundError(f"approval request {request_id} was not found")
         return row
 
-    def _require_request_for_update(self, connection: Connection, request_id: str) -> RowMapping:
+    def _require_request_for_update(
+        self,
+        connection: Connection,
+        request_id: str,
+    ) -> RowMapping:
         row = connection.execute(
             select(self.requests)
             .where(self.requests.c.external_id == request_id)
@@ -429,12 +443,32 @@ class PostgresApprovalWaitRepository:
             raise PersistenceNotFoundError(f"job {job_id} was not found")
         return row
 
-    def _require_job_by_id_for_update(self, connection: Connection, job_id: UUID) -> RowMapping:
+    def _require_job_by_id_for_update(
+        self,
+        connection: Connection,
+        job_id: UUID,
+    ) -> RowMapping:
         row = connection.execute(
             select(self.jobs).where(self.jobs.c.id == job_id).with_for_update()
         ).mappings().one_or_none()
         if row is None:
-            raise PersistenceReferenceError(f"approval request references missing job {job_id}")
+            raise PersistenceReferenceError(
+                f"approval request references missing job {job_id}"
+            )
+        return row
+
+    def _require_project_by_id(
+        self,
+        connection: Connection,
+        project_id: UUID,
+    ) -> RowMapping:
+        row = connection.execute(
+            select(self.projects).where(self.projects.c.id == project_id)
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceReferenceError(
+                f"approval request references missing project {project_id}"
+            )
         return row
 
     @staticmethod
@@ -458,13 +492,24 @@ class PostgresApprovalWaitRepository:
             )
 
     @staticmethod
-    def _require_approval_matches_request(request: RowMapping, approval: Approval) -> None:
-        if approval.project_id != request["project_external_id"] if "project_external_id" in request else False:
+    def _require_approval_matches_request(
+        request: RowMapping,
+        project: RowMapping,
+        approval: Approval,
+    ) -> None:
+        if approval.project_id != str(project["external_id"]):
             raise ApprovalWaitConflictError("approval belongs to another project")
-        if approval.subject_type != request["subject_type"] or approval.subject_id != request["subject_id"]:
+        if (
+            approval.subject_type != request["subject_type"]
+            or approval.subject_id != request["subject_id"]
+        ):
             raise ApprovalWaitConflictError("approval subject does not match the request")
 
-    def _require_approval_by_id(self, connection: Connection, approval_id: UUID | None) -> RowMapping:
+    def _require_approval_by_id(
+        self,
+        connection: Connection,
+        approval_id: UUID | None,
+    ) -> RowMapping:
         if approval_id is None:
             raise PersistenceReferenceError("resolved request is missing approval identity")
         row = connection.execute(
@@ -488,6 +533,13 @@ class PostgresApprovalWaitRepository:
             raise PersistenceReferenceError(f"missing {label}:{external_id}")
         return row
 
+    @staticmethod
+    def _require_transition(current: JobStatus, target: JobStatus) -> None:
+        try:
+            assert_job_transition(current, target)
+        except InvalidJobTransitionError as exc:
+            raise ApprovalWaitConflictError(str(exc)) from exc
+
     def _update_job(
         self,
         connection: Connection,
@@ -496,7 +548,10 @@ class PostgresApprovalWaitRepository:
     ) -> None:
         result = connection.execute(
             update(self.jobs)
-            .where(self.jobs.c.id == row["id"], self.jobs.c.revision == row["revision"])
+            .where(
+                self.jobs.c.id == row["id"],
+                self.jobs.c.revision == row["revision"],
+            )
             .values(**values)
         )
         if result.rowcount != 1:

--- a/packages/python-core/tests/test_approval_wait.py
+++ b/packages/python-core/tests/test_approval_wait.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ai_automation_force_core import (
+    ApprovalDecision,
+    ApprovalWaitKind,
+    ApprovalWaitRequest,
+    JobStatus,
+    expected_wait_status,
+    expired_job_status,
+    resolved_job_status,
+)
+
+
+def test_approval_wait_state_matrix_is_explicit() -> None:
+    assert expected_wait_status(ApprovalWaitKind.HUMAN_APPROVAL) is JobStatus.WAITING_HUMAN
+    assert expected_wait_status(ApprovalWaitKind.BUDGET) is JobStatus.BLOCKED_BUDGET
+    assert expected_wait_status(ApprovalWaitKind.MANUAL_HANDOFF) is JobStatus.MANUAL_HANDOFF
+
+    for wait_kind in ApprovalWaitKind:
+        assert resolved_job_status(wait_kind, ApprovalDecision.APPROVED) is JobStatus.ELIGIBLE
+        assert resolved_job_status(wait_kind, ApprovalDecision.WAIVED) is JobStatus.ELIGIBLE
+        assert resolved_job_status(wait_kind, ApprovalDecision.REQUEST_CHANGES) is None
+
+    assert (
+        resolved_job_status(ApprovalWaitKind.BUDGET, ApprovalDecision.REJECTED)
+        is JobStatus.CANCELLED
+    )
+    assert (
+        resolved_job_status(ApprovalWaitKind.HUMAN_APPROVAL, ApprovalDecision.REJECTED)
+        is JobStatus.PERMANENT_FAILED
+    )
+    assert (
+        resolved_job_status(ApprovalWaitKind.MANUAL_HANDOFF, ApprovalDecision.REJECTED)
+        is JobStatus.PERMANENT_FAILED
+    )
+
+    assert expired_job_status(ApprovalWaitKind.HUMAN_APPROVAL) is JobStatus.MANUAL_HANDOFF
+    assert expired_job_status(ApprovalWaitKind.BUDGET) is JobStatus.MANUAL_HANDOFF
+    assert expired_job_status(ApprovalWaitKind.MANUAL_HANDOFF) is None
+
+
+def test_approval_wait_request_fingerprint_is_stable_and_semantic() -> None:
+    now = datetime(2026, 8, 29, 9, 0, tzinfo=UTC)
+    request = ApprovalWaitRequest(
+        request_id="AQR-000001",
+        project_id="PRJ-000001",
+        job_id="JOB-000001",
+        wait_kind=ApprovalWaitKind.HUMAN_APPROVAL,
+        subject_type="job",
+        subject_id="JOB-000001",
+        requested_job_revision=5,
+        requested_by="workflow",
+        requested_at=now,
+        idempotency_key="approval-000001",
+        expires_at=now + timedelta(minutes=10),
+        reason="human review",
+    )
+    same = ApprovalWaitRequest(**request.__dict__)
+    changed = ApprovalWaitRequest(
+        **{**request.__dict__, "reason": "budget review"}
+    )
+
+    assert request.request_fingerprint == same.request_fingerprint
+    assert request.request_fingerprint != changed.request_fingerprint
+    assert len(request.request_fingerprint) == 64
+
+
+def test_approval_wait_request_rejects_invalid_identity_and_expiry() -> None:
+    now = datetime(2026, 8, 29, 9, 0, tzinfo=UTC)
+    common = {
+        "project_id": "PRJ-000001",
+        "job_id": "JOB-000001",
+        "wait_kind": ApprovalWaitKind.HUMAN_APPROVAL,
+        "subject_type": "job",
+        "subject_id": "JOB-000001",
+        "requested_job_revision": 1,
+        "requested_by": "workflow",
+        "requested_at": now,
+        "idempotency_key": "approval-000001",
+    }
+
+    with pytest.raises(ValueError, match="AQR"):
+        ApprovalWaitRequest(request_id="APR-000001", **common)
+    with pytest.raises(ValueError, match="later"):
+        ApprovalWaitRequest(request_id="AQR-000001", expires_at=now, **common)

--- a/packages/python-core/tests/test_approval_wait_persistence.py
+++ b/packages/python-core/tests/test_approval_wait_persistence.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import Engine, create_engine, func, select, text
+
+from ai_automation_force_core import (
+    Approval,
+    ApprovalDecision,
+    ApprovalWaitConflictError,
+    ApprovalWaitKind,
+    ApprovalWaitRequest,
+    ApprovalWaitVersionConflictError,
+    JobStatus,
+    PostgresApprovalWaitRepository,
+)
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+ALEMBIC_INI = Path(__file__).parents[1] / "alembic.ini"
+
+
+def alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
+
+
+def insert_project(engine: Engine, external_id: str) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.projects (
+                    id, external_id, title, status, audience, "cast", content_format,
+                    language, target_duration_seconds, output, creative, provider_policy,
+                    created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :external_id, :title, 'draft',
+                    '{}'::jsonb, '{}'::jsonb, 'song', 'en', 120,
+                    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, :now, :now
+                )
+                """
+            ),
+            {
+                "external_id": external_id,
+                "title": f"Fixture {external_id}",
+                "now": datetime(2026, 8, 29, 9, 0, tzinfo=UTC),
+            },
+        )
+
+
+def insert_wait_job(
+    engine: Engine,
+    *,
+    external_id: str,
+    project_id: str,
+    status: JobStatus,
+    revision: int,
+    now: datetime,
+) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.jobs (
+                    id, external_id, project_id, job_type, status, priority,
+                    idempotency_key, retry_budget_remaining, blocked_reason,
+                    created_at, updated_at, revision
+                )
+                SELECT
+                    gen_random_uuid(), :external_id, p.id, 'synthetic-approval', :status, 50,
+                    :idempotency_key, 3, :blocked_reason, :now, :now, :revision
+                FROM core.projects p
+                WHERE p.external_id = :project_id
+                """
+            ),
+            {
+                "external_id": external_id,
+                "project_id": project_id,
+                "status": status.value,
+                "idempotency_key": f"job-{external_id.lower()}",
+                "blocked_reason": (
+                    "approval required"
+                    if status in {JobStatus.BLOCKED_BUDGET, JobStatus.MANUAL_HANDOFF}
+                    else None
+                ),
+                "now": now,
+                "revision": revision,
+            },
+        )
+
+
+def approval_request(
+    *,
+    request_id: str,
+    project_id: str,
+    job_id: str,
+    wait_kind: ApprovalWaitKind,
+    job_revision: int,
+    now: datetime,
+    idempotency_key: str,
+    expires_at: datetime | None = None,
+    reason: str = "review required",
+) -> ApprovalWaitRequest:
+    return ApprovalWaitRequest(
+        request_id=request_id,
+        project_id=project_id,
+        job_id=job_id,
+        wait_kind=wait_kind,
+        subject_type="job",
+        subject_id=job_id,
+        requested_job_revision=job_revision,
+        requested_by="workflow",
+        requested_at=now,
+        idempotency_key=idempotency_key,
+        expires_at=expires_at,
+        reason=reason,
+    )
+
+
+def approval(
+    *,
+    approval_id: str,
+    project_id: str,
+    job_id: str,
+    decision: ApprovalDecision,
+    now: datetime,
+) -> Approval:
+    return Approval(
+        approval_id=approval_id,
+        project_id=project_id,
+        subject_type="job",
+        subject_id=job_id,
+        decision=decision,
+        actor="reviewer@example.invalid",
+        reason="synthetic decision",
+        created_at=now,
+    )
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_human_approval_wait_is_idempotent_atomic_and_outboxed() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    now = datetime(2026, 8, 29, 9, 0, tzinfo=UTC)
+
+    try:
+        insert_project(engine, "PRJ-000950")
+        insert_wait_job(
+            engine,
+            external_id="JOB-000950",
+            project_id="PRJ-000950",
+            status=JobStatus.WAITING_HUMAN,
+            revision=5,
+            now=now,
+        )
+        repository = PostgresApprovalWaitRepository(engine)
+        request = approval_request(
+            request_id="AQR-000950",
+            project_id="PRJ-000950",
+            job_id="JOB-000950",
+            wait_kind=ApprovalWaitKind.HUMAN_APPROVAL,
+            job_revision=5,
+            now=now,
+            idempotency_key="approval-000950",
+            expires_at=now + timedelta(minutes=10),
+        )
+
+        created = repository.request(request)
+        assert created.action == "created"
+        assert created.request_revision == 1
+        assert repository.request(request).action == "reused"
+
+        changed = approval_request(
+            request_id="AQR-000950",
+            project_id="PRJ-000950",
+            job_id="JOB-000950",
+            wait_kind=ApprovalWaitKind.HUMAN_APPROVAL,
+            job_revision=5,
+            now=now,
+            idempotency_key="approval-000950",
+            expires_at=now + timedelta(minutes=10),
+            reason="different semantics",
+        )
+        with pytest.raises(ApprovalWaitConflictError, match="different request semantics"):
+            repository.request(changed)
+
+        second_pending = approval_request(
+            request_id="AQR-000951",
+            project_id="PRJ-000950",
+            job_id="JOB-000950",
+            wait_kind=ApprovalWaitKind.HUMAN_APPROVAL,
+            job_revision=5,
+            now=now,
+            idempotency_key="approval-000951",
+            expires_at=now + timedelta(minutes=10),
+        )
+        with pytest.raises(ApprovalWaitConflictError, match="database rejected"):
+            repository.request(second_pending)
+
+        decision = approval(
+            approval_id="APR-000950",
+            project_id="PRJ-000950",
+            job_id="JOB-000950",
+            decision=ApprovalDecision.APPROVED,
+            now=now + timedelta(minutes=1),
+        )
+        resolved = repository.resolve(
+            request.request_id,
+            decision,
+            expected_request_revision=1,
+        )
+        assert resolved.action == "resolved"
+        assert resolved.job_status is JobStatus.ELIGIBLE
+        assert resolved.job_revision == 6
+        assert resolved.request_revision == 2
+
+        reused = repository.resolve(
+            request.request_id,
+            decision,
+            expected_request_revision=1,
+        )
+        assert reused.action == "reused"
+        assert reused.job_revision == 6
+        assert reused.approval_id == decision.approval_id
+
+        with engine.connect() as connection:
+            job = connection.execute(
+                text(
+                    "SELECT status, revision, blocked_reason FROM core.jobs "
+                    "WHERE external_id = 'JOB-000950'"
+                )
+            ).mappings().one()
+            request_row = repository.load(request.request_id)
+            approval_count = connection.execute(
+                select(func.count()).select_from(repository.approvals)
+            ).scalar_one()
+            outbox_count = connection.execute(
+                select(func.count())
+                .select_from(repository.outbox)
+                .where(repository.outbox.c.event_type.like("approval.%"))
+            ).scalar_one()
+
+        assert job["status"] == JobStatus.ELIGIBLE.value
+        assert job["revision"] == 6
+        assert job["blocked_reason"] is None
+        assert request_row["status"] == "resolved"
+        assert request_row["resolved_job_status"] == JobStatus.ELIGIBLE.value
+        assert request_row["resolved_job_revision"] == 6
+        assert approval_count == 1
+        assert outbox_count == 2
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_approval_wait_rejects_stale_job_and_expires_idempotently() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    now = datetime(2026, 8, 29, 10, 0, tzinfo=UTC)
+
+    try:
+        insert_project(engine, "PRJ-000952")
+        insert_wait_job(
+            engine,
+            external_id="JOB-000952",
+            project_id="PRJ-000952",
+            status=JobStatus.WAITING_HUMAN,
+            revision=3,
+            now=now,
+        )
+        insert_wait_job(
+            engine,
+            external_id="JOB-000953",
+            project_id="PRJ-000952",
+            status=JobStatus.WAITING_HUMAN,
+            revision=7,
+            now=now,
+        )
+        repository = PostgresApprovalWaitRepository(engine)
+
+        stale_request = approval_request(
+            request_id="AQR-000952",
+            project_id="PRJ-000952",
+            job_id="JOB-000952",
+            wait_kind=ApprovalWaitKind.HUMAN_APPROVAL,
+            job_revision=3,
+            now=now,
+            idempotency_key="approval-000952",
+            expires_at=now + timedelta(minutes=5),
+        )
+        repository.request(stale_request)
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    "UPDATE core.jobs SET revision = 4, updated_at = :updated_at "
+                    "WHERE external_id = 'JOB-000952'"
+                ),
+                {"updated_at": now + timedelta(seconds=1)},
+            )
+
+        with pytest.raises(ApprovalWaitVersionConflictError, match="stale job revision"):
+            repository.resolve(
+                stale_request.request_id,
+                approval(
+                    approval_id="APR-000952",
+                    project_id="PRJ-000952",
+                    job_id="JOB-000952",
+                    decision=ApprovalDecision.APPROVED,
+                    now=now + timedelta(minutes=1),
+                ),
+                expected_request_revision=1,
+            )
+
+        expiring = approval_request(
+            request_id="AQR-000953",
+            project_id="PRJ-000952",
+            job_id="JOB-000953",
+            wait_kind=ApprovalWaitKind.HUMAN_APPROVAL,
+            job_revision=7,
+            now=now,
+            idempotency_key="approval-000953",
+            expires_at=now + timedelta(minutes=1),
+        )
+        repository.request(expiring)
+        expired = repository.expire(
+            expiring.request_id,
+            now=now + timedelta(minutes=2),
+            expected_request_revision=1,
+        )
+        assert expired.action == "expired"
+        assert expired.job_status is JobStatus.MANUAL_HANDOFF
+        assert expired.job_revision == 8
+        assert expired.request_revision == 2
+
+        duplicate = repository.expire(
+            expiring.request_id,
+            now=now + timedelta(minutes=3),
+            expected_request_revision=1,
+        )
+        assert duplicate.action == "expired"
+        assert duplicate.job_revision == 8
+
+        with engine.connect() as connection:
+            job = connection.execute(
+                text(
+                    "SELECT status, revision, blocked_reason FROM core.jobs "
+                    "WHERE external_id = 'JOB-000953'"
+                )
+            ).mappings().one()
+        assert job["status"] == JobStatus.MANUAL_HANDOFF.value
+        assert job["revision"] == 8
+        assert "AQR-000953" in job["blocked_reason"]
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")
+
+
+@pytest.mark.parametrize(
+    ("wait_kind", "job_status", "job_id", "request_id", "approval_id"),
+    [
+        (
+            ApprovalWaitKind.BUDGET,
+            JobStatus.BLOCKED_BUDGET,
+            "JOB-000954",
+            "AQR-000954",
+            "APR-000954",
+        ),
+        (
+            ApprovalWaitKind.MANUAL_HANDOFF,
+            JobStatus.MANUAL_HANDOFF,
+            "JOB-000955",
+            "AQR-000955",
+            "APR-000955",
+        ),
+    ],
+)
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_budget_and_manual_waits_resume_safely_when_approved(
+    wait_kind: ApprovalWaitKind,
+    job_status: JobStatus,
+    job_id: str,
+    request_id: str,
+    approval_id: str,
+) -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    now = datetime(2026, 8, 29, 11, 0, tzinfo=UTC)
+
+    try:
+        insert_project(engine, "PRJ-000954")
+        insert_wait_job(
+            engine,
+            external_id=job_id,
+            project_id="PRJ-000954",
+            status=job_status,
+            revision=2,
+            now=now,
+        )
+        repository = PostgresApprovalWaitRepository(engine)
+        request = approval_request(
+            request_id=request_id,
+            project_id="PRJ-000954",
+            job_id=job_id,
+            wait_kind=wait_kind,
+            job_revision=2,
+            now=now,
+            idempotency_key=f"approval-{request_id.lower()}",
+        )
+        repository.request(request)
+        result = repository.resolve(
+            request_id,
+            approval(
+                approval_id=approval_id,
+                project_id="PRJ-000954",
+                job_id=job_id,
+                decision=ApprovalDecision.APPROVED,
+                now=now + timedelta(seconds=1),
+            ),
+            expected_request_revision=1,
+        )
+        assert result.job_status is JobStatus.ELIGIBLE
+        assert result.job_revision == 3
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")

--- a/packages/python-core/tests/test_migrations.py
+++ b/packages/python-core/tests/test_migrations.py
@@ -45,6 +45,7 @@ EXPECTED_CORE_TABLES = {
     "take_qa_records",
     "cost_records",
     "approvals",
+    "approval_requests",
     "legacy_content_imports",
     "project_characters",
     "project_worlds",
@@ -89,11 +90,21 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         assert set(db_inspector.get_table_names(schema="core")) == EXPECTED_CORE_TABLES
         job_columns = {column["name"] for column in db_inspector.get_columns("jobs", schema="core")}
         assert "operation_fingerprint" in job_columns
+        approval_request_columns = {
+            column["name"]
+            for column in db_inspector.get_columns("approval_requests", schema="core")
+        }
+        assert {
+            "request_fingerprint",
+            "resolution_fingerprint",
+            "resolved_job_revision",
+            "resolved_job_status",
+        }.issubset(approval_request_columns)
 
         with engine.connect() as connection:
             result = connection.execute(text("SELECT version_num FROM alembic_version"))
             revision = result.scalar_one()
-        assert revision == "20260829_0004"
+        assert revision == "20260829_0005"
 
         project_id = uuid4()
         with engine.begin() as connection:
@@ -196,11 +207,20 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         command.upgrade(config, "head")
         assert set(inspect(engine).get_table_names(schema="core")) == EXPECTED_CORE_TABLES
 
+        command.downgrade(config, "20260829_0004")
+        m04_tables = set(inspect(engine).get_table_names(schema="core"))
+        assert "approval_requests" not in m04_tables
+        assert "circuit_breakers" in m04_tables
+        assert m04_tables == EXPECTED_CORE_TABLES - {"approval_requests"}
+
         command.downgrade(config, "20260829_0003")
         m03_inspector = inspect(engine)
         m03_tables = set(m03_inspector.get_table_names(schema="core"))
         assert "circuit_breakers" not in m03_tables
-        assert m03_tables == EXPECTED_CORE_TABLES - {"circuit_breakers"}
+        assert m03_tables == EXPECTED_CORE_TABLES - {
+            "approval_requests",
+            "circuit_breakers",
+        }
         m03_job_columns = {
             column["name"] for column in m03_inspector.get_columns("jobs", schema="core")
         }
@@ -212,7 +232,11 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         m02_inspector = inspect(engine)
         m02_tables = set(m02_inspector.get_table_names(schema="core"))
         assert "outbox_messages" not in m02_tables
-        assert m02_tables == EXPECTED_CORE_TABLES - {"circuit_breakers", "outbox_messages"}
+        assert m02_tables == EXPECTED_CORE_TABLES - {
+            "approval_requests",
+            "circuit_breakers",
+            "outbox_messages",
+        }
         m02_job_columns = {
             column["name"] for column in m02_inspector.get_columns("jobs", schema="core")
         }
@@ -223,6 +247,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         m01_tables = set(inspect(engine).get_table_names(schema="core"))
         assert "workflow_executions" not in m01_tables
         assert m01_tables == EXPECTED_CORE_TABLES - {
+            "approval_requests",
             "circuit_breakers",
             "workflow_executions",
             "outbox_messages",


### PR DESCRIPTION
## Scope
Implements M02-WP5 only: durable approval requests, human/budget/manual wait kinds, expiry, stale job/request revision protection, immutable approval decisions, idempotent resolution, Temporal signal waits, duplicate/stale signal suppression, and safe resume.

## Data impact
- additive `core.approval_requests`
- existing `core.approvals` remains immutable final-decision evidence
- one pending approval request per job
- reversible migration 0005 -> 0004

## Workflow impact
- spend-free `SyntheticApprovalWorkflow`
- stale request revisions ignored
- duplicate signal keys ignored
- Temporal timer expiry
- replay coverage

## Safety
- no real providers or spend
- no auth/UI/M03+ work
- late approvals cannot advance jobs whose captured status/revision changed

## Acceptance
- approval wait state matrix and request validation
- PostgreSQL request idempotency and semantic conflict handling
- one-pending constraint
- atomic job + approval + request + outbox resolution
- stale job rejection
- idempotent expiry
- budget/manual approved resume
- migration upgrade/downgrade through 0005
- live Temporal signal, stale/duplicate suppression, expiry and replay
- Core and Durable CI green on exact head before merge