### PR TITLE
M02 governance: reconcile fresh consent with WP1-WP5 history

### DIFF
--- a/checkpoints/2026-08-29-m02-development-approved-governance-reconciled.md
+++ b/checkpoints/2026-08-29-m02-development-approved-governance-reconciled.md
@@ -1,0 +1,112 @@
+# M02 Development Consent & Governance Reconciliation
+
+Date: 2026-08-29
+
+Status: **M02_DEVELOPMENT_APPROVED_CONTINUATION**
+
+## Fresh operator authorization
+
+Fresh explicit operator authorization was received on 2026-08-29:
+
+`Milestone 2 development approve — start.`
+
+This authorization permits executable work inside the existing M02 scope from this checkpoint forward. It does **not** retroactively claim that the earlier M02 executable merges were authorized by the stale pre-consent checkpoint.
+
+## Historical governance reconciliation
+
+Before this fresh authorization, `checkpoints/LATEST.md` still reported `M02_READY_FOR_CONSENT` while M02 WP1-WP5 executable pull requests had already merged to `main`. That contradiction is preserved as a historical governance defect rather than rewritten away.
+
+The already-merged WP1-WP5 trees are accepted as the current technical baseline because their exact PR heads were covered by green milestone CI before merge. This technical acceptance is distinct from, and does not fabricate, historical consent.
+
+### WP1 — FastAPI control-plane scaffold
+
+- PR: `#10`
+- exact verified PR head: `8ae05b18e42afcb7b008e9acffb235f7a084738f`
+- merge commit: `c8591278ed0fc5624e1bff6169d7684ad36e01dd`
+- Durable Control Plane run: `33223054566` / run `#1` — GREEN
+- the Durable workflow reran the required M01 regression gates for this stage
+
+### WP2 — Temporal durable-workflow foundation
+
+- PR: `#11`
+- exact verified PR head: `0a2278a4f5d86037923c7fe46e2d724f506280e9`
+- merge commit: `29a3432480027f63f9c572782297e8707c501730`
+- Core Domain Contracts run `#74` — GREEN
+- Durable Control Plane run `#10` — GREEN
+
+### WP3 — Job idempotency and transactional outbox control
+
+- PR: `#12`
+- exact verified PR head: `bb9c96dbf5d71c887ac5c14e72706394f58bcdfc`
+- merge commit: `0de15a90cff5f44eeccdaf1d667aba69b890bbcc`
+- Core Domain Contracts run `#79` — GREEN
+- Durable Control Plane run `#15` — GREEN
+
+### WP4 — Retry, circuit breaker and cancellation control
+
+- PR: `#13`
+- exact verified PR head: `461a37c512bb98bf223f0c57dec59a7bd05c00cd`
+- merge commit: `54c613a5adfa95c6ebc5d6699cf7dbafa140d68e`
+- Core Domain Contracts run `#82` — GREEN
+- Durable Control Plane run `#18` — GREEN
+
+### WP5 — Durable human approval waits and safe resume
+
+- PR: `#14`
+- exact verified PR head: `ea5f18424850cb85d98cc9f5231b73bb98b78804`
+- merge commit: `f1169d6a68b1a45248d343df58b882d8d15db7b6`
+- Core Domain Contracts run `#85` — GREEN
+- Durable Control Plane run `#21` — GREEN
+
+## Current executable baseline
+
+`main` baseline at reconciliation entry:
+
+`f1169d6a68b1a45248d343df58b882d8d15db7b6`
+
+WP1-WP5 remain in place. They are not reverted merely because the consent checkpoint was stale; instead, their technical evidence is explicitly reconciled here and fresh authorization governs all continuation/remediation from this point.
+
+## Immediate continuation target
+
+M02-WP6 / PR `#15` is the next executable work package.
+
+PR `#15` is **not accepted or mergeable by policy yet** despite GitHub reporting it mechanically mergeable, because Durable Control Plane CI is red on current head `39a1429002b64b68a96550b95ec1b4d5e6ed2876`.
+
+Known WP6 blocker:
+
+- workflow input reads `timeout_ms` / `poll_interval_ms`;
+- Temporal integration scenarios currently send `timeout_seconds` / `poll_interval_seconds`;
+- the resulting `KeyError: 'timeout_ms'` causes four integration scenarios to time out.
+
+WP6 must be remediated and pass exact-head Core + Durable CI before merge.
+
+## M02 remaining sequence
+
+1. WP6 — fake external async callback/reconciliation pattern;
+2. WP7 — job/control API + durable SSE progress;
+3. WP8 — replay/restart/synthetic 100-shot recovery acceptance;
+4. M02 closure checkpoint and a fresh M03 consent gate.
+
+## Scope boundary retained
+
+M02 still excludes:
+
+- real AI provider credentials/calls/spend;
+- production object storage/media generation;
+- content intelligence;
+- full web/mobile/auth/billing/social implementation;
+- public publishing/autonomous spend;
+- M03+ executable work.
+
+## Governance controls for continuation
+
+- GitHub remains canonical for implementation evidence/checkpoints.
+- Linear mirrors execution state only after canonical evidence is updated.
+- Do not merge a work package with red or unverified required CI.
+- Do not claim network/workflow exactly-once delivery; use durable at-least-once execution with idempotent side effects.
+- Preserve retained Temporal history replay compatibility across workflow changes.
+- Historical checkpoints remain immutable evidence; this checkpoint supersedes the stale consent state without rewriting history.
+
+## Repository protection risk
+
+`main` was previously observed as unprotected with no required-status-check enforcement. Until repository rules are hardened, M02 execution will enforce the equivalent process manually: exact-head required CI must be verified green before every merge.

--- a/checkpoints/2026-08-29-m02-governance-reconciliation-ready.md
+++ b/checkpoints/2026-08-29-m02-governance-reconciliation-ready.md
@@ -1,0 +1,7 @@
+# M02 Governance Reconciliation Ready
+
+Fresh M02 executable consent has been captured and the WP1-WP5 historical merge/CI evidence has been reconciled without retroactive consent claims.
+
+This branch is documentation/governance only. No executable runtime, dependency, migration, workflow or API behavior is changed here.
+
+After this documentation PR is merged, WP6 remediation proceeds on PR #15 under the exact-head green-CI merge gate.

--- a/checkpoints/LATEST.md
+++ b/checkpoints/LATEST.md
@@ -1,11 +1,31 @@
 # Latest Checkpoint
 
 Current checkpoint:
-`checkpoints/2026-08-29-m02-ready-for-consent.md`
+`checkpoints/2026-08-29-m02-development-approved-governance-reconciled.md`
 
 Current phase: **M02 — Durable Workflow Control Plane**
 
-Status: **M02_READY_FOR_CONSENT**
+Status: **M02_DEVELOPMENT_APPROVED_CONTINUATION**
+
+## Fresh development consent
+
+Explicit operator authorization received on 2026-08-29:
+
+`Milestone 2 development approve — start.`
+
+This authorization governs M02 executable continuation from this checkpoint forward. It does not fabricate retroactive approval for historical WP1-WP5 merges.
+
+## Historical governance reconciliation
+
+The previous `M02_READY_FOR_CONSENT` checkpoint remained stale while M02 WP1-WP5 executable PRs merged. The contradiction is recorded truthfully in:
+
+`checkpoints/2026-08-29-m02-development-approved-governance-reconciled.md`
+
+WP1-WP5 are accepted as the current technical baseline based on their exact-head green CI evidence; historical consent is not retroactively asserted.
+
+Current accepted `main` executable baseline before WP6 continuation:
+
+`f1169d6a68b1a45248d343df58b882d8d15db7b6`
 
 ## Previous completed milestone
 
@@ -30,60 +50,37 @@ Checkpoint:
 Status:
 `FULL_PROJECT_PLANNING_READY_FOR_CONSENT`
 
-## M02 readiness
+## Canonical M02 plan
 
-Canonical milestone plan:
 `docs/milestones/M02/PLAN.md`
 
-Development Consent Brief:
-`docs/architecture/M02-DEVELOPMENT-CONSENT-BRIEF.md`
-
-Current stack revalidation:
-`docs/architecture/M02-CURRENT-STACK-REVALIDATION-2026-08-29.md`
-
-Readiness checkpoint:
-`checkpoints/2026-08-29-m02-ready-for-consent.md`
-
 M02 work-package sequence:
-1. WP1 — FastAPI application/control scaffold;
-2. WP2 — Temporal foundation;
-3. WP3 — job/idempotency/DB↔Temporal durability boundary;
-4. WP4 — retry/backoff/circuit/cancellation;
-5. WP5 — durable human/approval waits;
-6. WP6 — fake external async callback/reconciliation pattern;
-7. WP7 — job/control API + SSE progress;
+1. WP1 — FastAPI application/control scaffold — merged/technical baseline accepted;
+2. WP2 — Temporal foundation — merged/technical baseline accepted;
+3. WP3 — job/idempotency/DB↔Temporal durability boundary — merged/technical baseline accepted;
+4. WP4 — retry/backoff/circuit/cancellation — merged/technical baseline accepted;
+5. WP5 — durable human/approval waits — merged/technical baseline accepted;
+6. WP6 — fake external async callback/reconciliation pattern — **current executable target**;
+7. WP7 — job/control API + durable SSE progress;
 8. WP8 — replay/restart/100-shot recovery acceptance.
 
-## Current mutable-stack evidence
+## Current WP6 state
 
-Planning-time current stable versions observed on 2026-08-29:
-- FastAPI `0.141.1`;
-- Temporal Python SDK `1.30.0`;
-- Temporal CLI `1.8.1`;
-- Temporal Server `1.31.2`.
+PR `#15` / head `39a1429002b64b68a96550b95ec1b4d5e6ed2876` is open.
 
-These are not runtime pins yet. They must be revalidated immediately before dependency/runtime changes.
+Current evidence before remediation:
+- Core Domain Contracts: GREEN;
+- Durable Control Plane: RED;
+- four Temporal integration scenarios fail because workflow input expects `timeout_ms` while tests send `timeout_seconds`.
 
-## Consent state
-
-**M02 executable development is blocked pending fresh explicit operator approval.**
-
-The prior M01 approval has been consumed and does not authorize M02.
-
-A valid explicit authorization may be:
-
-`Milestone 2 development approve — start.`
-
-Generic `continue`, `next`, `resume`, `audit`, or planning instructions remain non-authorizing.
+WP6 must not merge until the exact candidate head has both required workflows green and retained-history replay acceptance passes.
 
 ## M02 scope boundary
 
 M02 excludes real provider execution/credentials/spend, object storage/media generation, content intelligence, full web/mobile/auth/billing/social implementation, production Temporal HA/DR rollout, public publishing, autonomous spend and M03+ development.
 
-## Known governance risk
+## Merge governance
 
-GitHub currently reports `main` as unprotected with no required-status-check enforcement. No branch-protection setting was changed during planning. Early approved M02 execution should either harden this through a reviewed repository-governance change or explicitly record temporary acceptance.
+GitHub `main` was previously observed as unprotected. Until repository protection is hardened, exact-head Core Domain Contracts + Durable Control Plane verification is a mandatory manual merge gate for executable M02 PRs.
 
-## GitHub ↔ Linear
-
-GitHub remains canonical for engineering contracts, implementation evidence and checkpoints. Linear mirrors milestone/work-package readiness and execution status.
+GitHub remains canonical for engineering contracts, implementation evidence and checkpoints. Linear mirrors verified execution state.

--- a/docs/architecture/M02-CONSENT-EVIDENCE-2026-08-29.md
+++ b/docs/architecture/M02-CONSENT-EVIDENCE-2026-08-29.md
@@ -1,0 +1,9 @@
+# M02 Consent Evidence — 2026-08-29
+
+The operator supplied the exact authorization phrase:
+
+`Milestone 2 development approve — start.`
+
+This evidence is recorded prospectively. It authorizes M02 executable continuation from the governance-reconciliation checkpoint onward and does not alter the historical status of already-merged WP1-WP5 changes.
+
+M03 and later executable work remain outside this authorization.

--- a/docs/architecture/M02-GOVERNANCE-RECONCILIATION-2026-08-29.md
+++ b/docs/architecture/M02-GOVERNANCE-RECONCILIATION-2026-08-29.md
@@ -1,0 +1,37 @@
+# M02 Governance Reconciliation — 2026-08-29
+
+## Decision
+
+M02 executable continuation is authorized from the fresh operator instruction:
+
+`Milestone 2 development approve — start.`
+
+Historical WP1-WP5 executable merges remain historical facts. No prior checkpoint or PR is rewritten to claim retroactive consent.
+
+## Technical baseline decision
+
+WP1-WP5 remain the accepted technical baseline because each work package was merged only after its scoped implementation had green CI evidence on the exact PR head. A fresh regression will continue to run as part of subsequent M02 candidate heads, beginning with WP6.
+
+If later regression evidence finds a defect in an already-merged work package, it will be remediated normally; governance reconciliation is not a waiver of technical correctness.
+
+## Manual merge gate while `main` is unprotected
+
+Until repository protection/rulesets enforce equivalent requirements automatically, every executable M02 merge requires:
+
+1. exact candidate head identified;
+2. Core Domain Contracts GREEN when applicable;
+3. Durable Control Plane GREEN;
+4. migration upgrade/downgrade acceptance when schema changes;
+5. retained Temporal history replay for workflow changes;
+6. no real provider credential/network/spend outside explicitly approved future scope;
+7. checkpoint/evidence update after merge.
+
+A mechanically mergeable GitHub PR is not sufficient evidence for merge.
+
+## Delivery semantics
+
+M02 does not claim exactly-once network/workflow delivery. The durable contract is at-least-once execution plus idempotency, immutable evidence, stale/duplicate suppression and transactional persistence boundaries.
+
+## Remaining milestone boundary
+
+WP6 -> WP7 -> WP8 remains the required order. M03 executable development still requires a fresh explicit consent checkpoint after M02 closure.


### PR DESCRIPTION
## Scope
Documentation/governance only.

Records the fresh explicit M02 authorization received on 2026-08-29, preserves the stale historical consent checkpoint as historical evidence, and reconciles already-merged WP1-WP5 as the current technical baseline using their exact PR heads and green CI evidence.

## Important distinction
This PR does **not** retroactively claim that WP1-WP5 had canonical consent at merge time. It records that governance inconsistency truthfully and applies fresh authorization prospectively from this checkpoint onward.

## Changes
- add M02 development-approved governance reconciliation checkpoint
- advance `checkpoints/LATEST.md` to `M02_DEVELOPMENT_APPROVED_CONTINUATION`
- record exact WP1-WP5 PR heads, merge commits and CI evidence
- document manual exact-head merge gate while `main` remains unprotected
- preserve at-least-once + idempotent-side-effect delivery semantics
- preserve M03+ fresh-consent boundary

## Executable impact
None. No runtime code, dependency, migration, workflow, API or provider behavior changes.

## Next
After merge, PR #15/WP6 is remediated and may merge only after exact-head Core Domain Contracts + Durable Control Plane are green.