### PR TITLE
M02-WP7: job control API and durable SSE progress

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,9 @@ version = "0.1.0"
 description = "FastAPI control plane for AI Automation Force"
 requires-python = ">=3.12"
 dependencies = [
+  "ai-automation-force-core[persistence]==0.1.0",
   "fastapi==0.141.1",
+  "temporalio==1.32.0",
 ]
 
 [project.optional-dependencies]
@@ -17,6 +19,7 @@ dev = [
   "pytest>=8,<9",
   "ruff>=0.6,<1",
   "mypy>=1.11,<2",
+  "psycopg[binary]>=3.3.4,<4",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -25,6 +28,10 @@ packages = ["src/ai_automation_force_api"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+markers = [
+  "postgres: requires the DATABASE_URL PostgreSQL integration database",
+  "temporal: requires a Temporal dev/test server",
+]
 
 [tool.ruff]
 target-version = "py312"

--- a/apps/api/src/ai_automation_force_api/app.py
+++ b/apps/api/src/ai_automation_force_api/app.py
@@ -8,6 +8,7 @@ from typing import Final
 from fastapi import APIRouter, FastAPI, Request, status
 from pydantic import BaseModel, ConfigDict
 
+from .control import ControlService, control_router
 from .errors import APIError, ErrorEnvelope, install_error_handlers
 from .request_context import RequestContextMiddleware
 from .settings import Settings, load_settings
@@ -20,6 +21,8 @@ class RuntimeState(BaseModel):
 
     started_at: datetime
     ready: bool = False
+    control_ready: bool = False
+    control_error: str | None = None
 
 
 class HealthResponse(BaseModel):
@@ -36,9 +39,21 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         runtime = RuntimeState(started_at=datetime.now(UTC), ready=True)
         app.state.runtime = runtime
+        app.state.control_service = None
+        if resolved.control_surface_configured:
+            try:
+                app.state.control_service = ControlService(resolved)
+                runtime.control_ready = True
+            except Exception:
+                runtime.ready = False
+                runtime.control_error = "durable control dependencies are unavailable"
         try:
             yield
         finally:
+            service = getattr(app.state, "control_service", None)
+            if isinstance(service, ControlService):
+                service.close()
+            runtime.control_ready = False
             runtime.ready = False
 
     app = FastAPI(
@@ -85,4 +100,5 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
 
     app.include_router(router, prefix=resolved.api_prefix)
+    app.include_router(control_router(), prefix=resolved.api_prefix)
     return app

--- a/apps/api/src/ai_automation_force_api/control.py
+++ b/apps/api/src/ai_automation_force_api/control.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Annotated, Any, Literal
+from uuid import UUID, uuid4
+
+from ai_automation_force_core import (
+    AuditFields,
+    Job,
+    JobCommandConflictError,
+    JobCommandResult,
+    JobCommandVersionConflictError,
+    JobControlSnapshot,
+    JobEventRecord,
+    JobIdempotencyConflictError,
+    PersistenceConflictError,
+    PersistenceNotFoundError,
+    PersistenceReferenceError,
+    PostgresControlSurfaceRepository,
+    PostgresJobControlRepository,
+    PostgresWorkflowExecutionRepository,
+    ProjectJobRecord,
+    WorkflowExecutionRef,
+)
+from fastapi import APIRouter, Header, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from temporalio.client import Client
+from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
+
+from .errors import APIError
+from .settings import Settings
+
+JobIdValue = Annotated[str, Field(pattern=r"^JOB-[0-9]{6,20}$")]
+ProjectIdValue = Annotated[str, Field(pattern=r"^PRJ-[0-9]{6,20}$")]
+WorkflowIdValue = Annotated[str, Field(pattern=r"^WFX-[0-9]{6,20}$")]
+IdempotencyValue = Annotated[str, Field(min_length=8, max_length=200)]
+
+
+class StrictAPIModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class JobCreateRequest(StrictAPIModel):
+    project_id: ProjectIdValue
+    job_type: str = Field(min_length=1, max_length=120)
+    idempotency_key: IdempotencyValue
+    priority: int = Field(default=50, ge=0, le=100)
+    parent_job_id: JobIdValue | None = None
+    dependency_job_ids: list[JobIdValue] = Field(default_factory=list, max_length=500)
+    shot_id: str | None = Field(default=None, pattern=r"^SHT-[0-9]{6,20}$")
+    content_id: str | None = Field(default=None, pattern=r"^CNT-[0-9]{6,20}$")
+    retry_budget_remaining: int = Field(default=3, ge=0, le=100)
+
+
+class JobCreateResponse(StrictAPIModel):
+    action: Literal["created", "reused"]
+    job: JobControlSnapshot
+    event_cursor: str | None = None
+
+
+class JobCheckpointResponse(StrictAPIModel):
+    job: JobControlSnapshot
+    event_cursor: str | None = None
+
+
+class JobCommandRequest(StrictAPIModel):
+    idempotency_key: IdempotencyValue
+    expected_revision: int = Field(ge=1)
+
+
+class JobCommandResponse(StrictAPIModel):
+    command: JobCommandResult
+
+
+class ProjectJobsResponse(StrictAPIModel):
+    items: list[ProjectJobRecord]
+    next_cursor: str | None = None
+
+
+class JobEventsResponse(StrictAPIModel):
+    items: list[JobEventRecord]
+    next_cursor: str | None = None
+
+
+class WorkflowResponse(StrictAPIModel):
+    workflow: WorkflowExecutionRef
+
+
+class SSEEventEnvelope(StrictAPIModel):
+    schema_version: Literal[1] = 1
+    event: JobEventRecord
+
+
+class ControlDependencyError(RuntimeError):
+    """The durable control service cannot currently reach a required dependency."""
+
+
+def _numeric_external_id(prefix: str) -> str:
+    number = uuid4().int % (10**20)
+    return f"{prefix}-{number:020d}"
+
+
+def _workflow_id(job_id: str, revision: int) -> str:
+    digest = hashlib.sha256(f"{job_id}:{revision}".encode()).digest()
+    number = int.from_bytes(digest[:8], "big") % (10**20)
+    return f"WFX-{number:020d}"
+
+
+def encode_cursor(at: datetime, stable_id: str) -> str:
+    if at.tzinfo is None or at.utcoffset() is None:
+        raise ValueError("cursor time must be timezone-aware")
+    raw = json.dumps(
+        {"at": at.isoformat(), "id": stable_id},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def decode_cursor(value: str, *, uuid_id: bool) -> tuple[datetime, UUID | str]:
+    if not 1 <= len(value) <= 512:
+        raise ValueError("cursor length is invalid")
+    try:
+        padding = "=" * (-len(value) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(value + padding))
+        if not isinstance(payload, dict) or set(payload) != {"at", "id"}:
+            raise ValueError("cursor shape is invalid")
+        at = datetime.fromisoformat(str(payload["at"]))
+        if at.tzinfo is None or at.utcoffset() is None:
+            raise ValueError("cursor time must be timezone-aware")
+        stable_id = str(payload["id"])
+        return at, UUID(stable_id) if uuid_id else stable_id
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("cursor is invalid") from exc
+
+
+def event_cursor(event: JobEventRecord) -> str:
+    return encode_cursor(event.occurred_at, str(event.event_id))
+
+
+class ControlService:
+    def __init__(self, settings: Settings) -> None:
+        if settings.database_url is None:
+            raise ValueError("DATABASE_URL is required for the job control surface")
+        self.settings = settings
+        self.engine: Engine = create_engine(
+            settings.database_url.get_secret_value(),
+            pool_pre_ping=True,
+        )
+        self.jobs = PostgresJobControlRepository(self.engine)
+        self.control = PostgresControlSurfaceRepository(self.engine)
+        self.workflows = PostgresWorkflowExecutionRepository(self.engine)
+        self._temporal_client: Client | None = None
+
+    def close(self) -> None:
+        self.engine.dispose()
+
+    async def temporal_client(self) -> Client:
+        if self._temporal_client is None:
+            try:
+                self._temporal_client = await Client.connect(
+                    self.settings.temporal_target,
+                    namespace=self.settings.temporal_namespace,
+                )
+            except Exception as exc:  # normalized at the API boundary, never leaked
+                raise ControlDependencyError("Temporal is unavailable") from exc
+        return self._temporal_client
+
+    def create_job(self, request: JobCreateRequest) -> JobCreateResponse:
+        now = datetime.now(UTC)
+        operation = request.model_dump(mode="json")
+        job = Job(
+            job_id=_numeric_external_id("JOB"),
+            project_id=request.project_id,
+            job_type=request.job_type,
+            priority=request.priority,
+            idempotency_key=request.idempotency_key,
+            parent_job_id=request.parent_job_id,
+            dependency_job_ids=request.dependency_job_ids,
+            shot_id=request.shot_id,
+            content_id=request.content_id,
+            retry_budget_remaining=request.retry_budget_remaining,
+            audit=AuditFields(
+                created_at=now,
+                updated_at=now,
+                created_by=self.settings.internal_dev_identity or self.settings.service_name,
+                revision=1,
+            ),
+        )
+        result = self.jobs.submit(job, operation)
+        snapshot, high_water = self.control.load_job_checkpoint(result.job_id)
+        return JobCreateResponse(
+            action=result.action,
+            job=snapshot,
+            event_cursor=event_cursor(high_water) if high_water else None,
+        )
+
+    def checkpoint(self, job_id: str) -> JobCheckpointResponse:
+        snapshot, high_water = self.control.load_job_checkpoint(job_id)
+        return JobCheckpointResponse(
+            job=snapshot,
+            event_cursor=event_cursor(high_water) if high_water else None,
+        )
+
+    def project_jobs(
+        self,
+        project_id: str,
+        *,
+        cursor: str | None,
+        limit: int,
+    ) -> ProjectJobsResponse:
+        after: tuple[datetime, str] | None = None
+        if cursor:
+            at, stable_id = decode_cursor(cursor, uuid_id=False)
+            after = (at, str(stable_id))
+        rows = self.control.list_project_jobs(project_id, after=after, limit=limit + 1)
+        has_more = len(rows) > limit
+        items = rows[:limit]
+        next_cursor = None
+        if has_more and items:
+            last = items[-1]
+            next_cursor = encode_cursor(last.created_at, last.job_id)
+        return ProjectJobsResponse(items=items, next_cursor=next_cursor)
+
+    def events(
+        self,
+        job_id: str,
+        *,
+        cursor: str | None,
+        limit: int,
+    ) -> JobEventsResponse:
+        after: tuple[datetime, UUID] | None = None
+        if cursor:
+            at, stable_id = decode_cursor(cursor, uuid_id=True)
+            assert isinstance(stable_id, UUID)
+            after = (at, stable_id)
+        rows = self.control.list_job_events(job_id, after=after, limit=limit + 1)
+        has_more = len(rows) > limit
+        items = rows[:limit]
+        next_cursor = event_cursor(items[-1]) if has_more and items else None
+        return JobEventsResponse(items=items, next_cursor=next_cursor)
+
+    async def start_job(self, job_id: str, request: JobCommandRequest) -> JobCommandResult:
+        operation: dict[str, Any] = {
+            "expected_revision": request.expected_revision,
+            "workflow_kind": "synthetic-job-control",
+        }
+        existing = self.control.load_start_command(
+            job_id,
+            idempotency_key=request.idempotency_key,
+            operation=operation,
+        )
+        if existing is not None:
+            return existing
+
+        snapshot = self.control.load_job(job_id)
+        if snapshot.revision != request.expected_revision:
+            raise JobCommandVersionConflictError(
+                f"stale job revision: expected {request.expected_revision}, "
+                f"current {snapshot.revision}"
+            )
+        workflow_execution_id = _workflow_id(job_id, request.expected_revision)
+        workflow_type = (
+            "SyntheticCancellationWorkflow"
+            if snapshot.job_type == "synthetic-cancellable"
+            else "SyntheticControlWorkflow"
+        )
+        client = await self.temporal_client()
+        try:
+            handle = await client.start_workflow(
+                workflow_type,
+                job_id,
+                id=workflow_execution_id,
+                task_queue=self.settings.temporal_task_queue,
+                id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
+                id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+            )
+        except Exception as exc:
+            raise ControlDependencyError("Temporal workflow start failed") from exc
+        run_id = handle.result_run_id
+        if not run_id:
+            raise ControlDependencyError("Temporal did not return a workflow run ID")
+        now = datetime.now(UTC)
+        workflow_ref = WorkflowExecutionRef(
+            workflow_execution_id=workflow_execution_id,
+            workflow_type=workflow_type,
+            run_id=run_id,
+            namespace=self.settings.temporal_namespace,
+            task_queue=self.settings.temporal_task_queue,
+            project_id=snapshot.project_id,
+            job_id=job_id,
+            status="running",
+            started_at=now,
+            updated_at=now,
+        )
+        self.workflows.save(workflow_ref)
+        return self.control.record_start(
+            job_id,
+            idempotency_key=request.idempotency_key,
+            workflow_execution_id=workflow_execution_id,
+            operation=operation,
+            now=now,
+        )
+
+    async def cancel_job(self, job_id: str, request: JobCommandRequest) -> JobCommandResult:
+        result = self.control.cancel_job(
+            job_id,
+            idempotency_key=request.idempotency_key,
+            expected_revision=request.expected_revision,
+            now=datetime.now(UTC),
+        )
+        snapshot = self.control.load_job(job_id)
+        if snapshot.workflow_execution_id is not None:
+            client = await self.temporal_client()
+            try:
+                handle = client.get_workflow_handle(snapshot.workflow_execution_id)
+                await handle.cancel()
+            except Exception as exc:
+                raise ControlDependencyError("Temporal workflow cancellation failed") from exc
+        return result
+
+    def retry_job(self, job_id: str, request: JobCommandRequest) -> JobCommandResult:
+        return self.control.retry_job(
+            job_id,
+            idempotency_key=request.idempotency_key,
+            expected_revision=request.expected_revision,
+            now=datetime.now(UTC),
+        )
+
+    def workflow(self, workflow_execution_id: str) -> WorkflowExecutionRef:
+        return self.workflows.load(workflow_execution_id)
+
+    async def stream_events(
+        self,
+        request: Request,
+        job_id: str,
+        *,
+        last_event_id: str | None,
+    ) -> AsyncIterator[str]:
+        cursor = last_event_id
+        heartbeat_deadline = asyncio.get_running_loop().time() + self.settings.sse_heartbeat_seconds
+        while not await request.is_disconnected():
+            page = self.events(job_id, cursor=cursor, limit=100)
+            if page.items:
+                for item in page.items:
+                    cursor = event_cursor(item)
+                    envelope = SSEEventEnvelope(event=item)
+                    data = envelope.model_dump_json()
+                    yield f"id: {cursor}\nevent: {item.event_type}\ndata: {data}\n\n"
+                heartbeat_deadline = (
+                    asyncio.get_running_loop().time() + self.settings.sse_heartbeat_seconds
+                )
+                continue
+            now = asyncio.get_running_loop().time()
+            if now >= heartbeat_deadline:
+                yield ": keepalive\n\n"
+                heartbeat_deadline = now + self.settings.sse_heartbeat_seconds
+            await asyncio.sleep(self.settings.sse_poll_interval_ms / 1000)
+
+
+def _service(request: Request) -> ControlService:
+    service = getattr(request.app.state, "control_service", None)
+    if not isinstance(service, ControlService):
+        raise APIError(
+            "CONTROL_SURFACE_UNAVAILABLE",
+            "job control surface is not configured",
+            status_code=503,
+        )
+    return service
+
+
+def _translate_error(exc: Exception) -> APIError:
+    if isinstance(exc, PersistenceNotFoundError):
+        return APIError("NOT_FOUND", str(exc), status_code=404)
+    if isinstance(exc, JobCommandVersionConflictError):
+        return APIError("STALE_REVISION", str(exc), status_code=409)
+    if isinstance(
+        exc,
+        (
+            JobIdempotencyConflictError,
+            JobCommandConflictError,
+            PersistenceConflictError,
+            PersistenceReferenceError,
+        ),
+    ):
+        return APIError("CONTROL_CONFLICT", str(exc), status_code=409)
+    if isinstance(exc, ControlDependencyError):
+        return APIError("DEPENDENCY_UNAVAILABLE", str(exc), status_code=503)
+    if isinstance(exc, ValueError):
+        return APIError("INVALID_CONTROL_REQUEST", str(exc), status_code=400)
+    return APIError("CONTROL_FAILURE", "control operation failed", status_code=500)
+
+
+def control_router() -> APIRouter:
+    router = APIRouter(tags=["jobs"])
+
+    @router.post("/jobs", response_model=JobCreateResponse, status_code=201)
+    async def create_job(request: Request, body: JobCreateRequest) -> JobCreateResponse:
+        try:
+            return _service(request).create_job(body)
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
+    @router.get("/jobs/{job_id}", response_model=JobCheckpointResponse)
+    async def get_job(request: Request, job_id: JobIdValue) -> JobCheckpointResponse:
+        try:
+            return _service(request).checkpoint(job_id)
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
+    @router.get("/projects/{project_id}/jobs", response_model=ProjectJobsResponse)
+    async def list_project_jobs(
+        request: Request,
+        project_id: ProjectIdValue,
+        cursor: str | None = None,
+        limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    ) -> ProjectJobsResponse:
+        try:
+            return _service(request).project_jobs(project_id, cursor=cursor, limit=limit)
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
+    @router.get("/jobs/{job_id}/history", response_model=JobEventsResponse)
+    async def job_history(
+        request: Request,
+        job_id: JobIdValue,
+        cursor: str | None = None,
+        limit: Annotated[int, Query(ge=1, le=200)] = 100,
+    ) -> JobEventsResponse:
+        try:
+            return _service(request).events(job_id, cursor=cursor, limit=limit)
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
+    @router.post("/jobs/{job_id}/start", response_model=JobCommandResponse)
+    async def start_job(
+        request: Request,
+        job_id: JobIdValue,
+        body: JobCommandRequest,
+    ) -> JobCommandResponse:
+        try:
+            result = await _service(request).start_job(job_id, body)
+            return JobCommandResponse(command=result)
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
+    @router.post("/jobs/{job_id}/cancel", response_model=JobCommandResponse)
+    async def cancel_job(
+        request: Request,
+        job_id: JobIdValue,
+        body: JobCommandRequest,
+    ) -> JobCommandResponse:
+        try:
+            result = await _service(request).cancel_job(job_id, body)
+            return JobCommandResponse(command=result)
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
+    @router.post("/jobs/{job_id}/retry", response_model=JobCommandResponse)
+    async def retry_job(
+        request: Request,
+        job_id: JobIdValue,
+        body: JobCommandRequest,
+    ) -> JobCommandResponse:
+        try:
+            return JobCommandResponse(command=_service(request).retry_job(job_id, body))
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
+    @router.get("/workflows/{workflow_execution_id}", response_model=WorkflowResponse)
+    async def get_workflow(
+        request: Request,
+        workflow_execution_id: WorkflowIdValue,
+    ) -> WorkflowResponse:
+        try:
+            return WorkflowResponse(
+                workflow=_service(request).workflow(workflow_execution_id)
+            )
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
+    @router.get("/jobs/{job_id}/events")
+    async def job_events(
+        request: Request,
+        job_id: JobIdValue,
+        last_event_id: Annotated[str | None, Header(alias="Last-Event-ID")] = None,
+    ) -> StreamingResponse:
+        service = _service(request)
+        if last_event_id:
+            try:
+                decode_cursor(last_event_id, uuid_id=True)
+            except ValueError as exc:
+                raise _translate_error(exc) from exc
+        return StreamingResponse(
+            service.stream_events(request, job_id, last_event_id=last_event_id),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    return router

--- a/apps/api/src/ai_automation_force_api/control.py
+++ b/apps/api/src/ai_automation_force_api/control.py
@@ -24,6 +24,7 @@ from ai_automation_force_core import (
     PostgresControlSurfaceRepository,
     PostgresJobControlRepository,
     PostgresWorkflowExecutionRepository,
+    ProjectControlStatus,
     ProjectJobRecord,
     WorkflowExecutionRef,
 )
@@ -230,6 +231,9 @@ class ControlService:
             next_cursor = encode_cursor(last.created_at, last.job_id)
         return ProjectJobsResponse(items=items, next_cursor=next_cursor)
 
+    def project_status(self, project_id: str) -> ProjectControlStatus:
+        return self.control.project_status(project_id)
+
     def events(
         self,
         job_id: str,
@@ -248,18 +252,42 @@ class ControlService:
         next_cursor = event_cursor(items[-1]) if has_more and items else None
         return JobEventsResponse(items=items, next_cursor=next_cursor)
 
+    def _existing_workflow(
+        self,
+        workflow_execution_id: str,
+        *,
+        workflow_type: str,
+        project_id: str,
+        job_id: str,
+    ) -> WorkflowExecutionRef | None:
+        try:
+            existing = self.workflows.load(workflow_execution_id)
+        except PersistenceNotFoundError:
+            return None
+        if (
+            existing.workflow_type != workflow_type
+            or existing.project_id != project_id
+            or existing.job_id != job_id
+            or existing.namespace != self.settings.temporal_namespace
+            or existing.task_queue != self.settings.temporal_task_queue
+        ):
+            raise JobCommandConflictError(
+                f"workflow {workflow_execution_id} is bound to different execution semantics"
+            )
+        return existing
+
     async def start_job(self, job_id: str, request: JobCommandRequest) -> JobCommandResult:
         operation: dict[str, Any] = {
             "expected_revision": request.expected_revision,
             "workflow_kind": "synthetic-job-control",
         }
-        existing = self.control.load_start_command(
+        existing_command = self.control.load_start_command(
             job_id,
             idempotency_key=request.idempotency_key,
             operation=operation,
         )
-        if existing is not None:
-            return existing
+        if existing_command is not None:
+            return existing_command
 
         snapshot = self.control.load_job(job_id)
         if snapshot.revision != request.expected_revision:
@@ -273,39 +301,48 @@ class ControlService:
             if snapshot.job_type == "synthetic-cancellable"
             else "SyntheticControlWorkflow"
         )
-        client = await self.temporal_client()
-        try:
-            handle = await client.start_workflow(
-                workflow_type,
-                job_id,
-                id=workflow_execution_id,
-                task_queue=self.settings.temporal_task_queue,
-                id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
-                id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
-            )
-        except Exception as exc:
-            raise ControlDependencyError("Temporal workflow start failed") from exc
-        run_id = handle.result_run_id
-        if not run_id:
-            raise ControlDependencyError("Temporal did not return a workflow run ID")
-        now = datetime.now(UTC)
-        workflow_ref = WorkflowExecutionRef(
-            workflow_execution_id=workflow_execution_id,
+        workflow_ref = self._existing_workflow(
+            workflow_execution_id,
             workflow_type=workflow_type,
-            run_id=run_id,
-            namespace=self.settings.temporal_namespace,
-            task_queue=self.settings.temporal_task_queue,
             project_id=snapshot.project_id,
             job_id=job_id,
-            status="running",
-            started_at=now,
-            updated_at=now,
         )
-        self.workflows.save(workflow_ref)
+        if workflow_ref is None:
+            client = await self.temporal_client()
+            try:
+                handle = await client.start_workflow(
+                    workflow_type,
+                    job_id,
+                    id=workflow_execution_id,
+                    task_queue=self.settings.temporal_task_queue,
+                    id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
+                    id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+                )
+            except Exception as exc:
+                raise ControlDependencyError("Temporal workflow start failed") from exc
+            run_id = handle.result_run_id
+            if not run_id:
+                raise ControlDependencyError("Temporal did not return a workflow run ID")
+            now = datetime.now(UTC)
+            workflow_ref = WorkflowExecutionRef(
+                workflow_execution_id=workflow_execution_id,
+                workflow_type=workflow_type,
+                run_id=run_id,
+                namespace=self.settings.temporal_namespace,
+                task_queue=self.settings.temporal_task_queue,
+                project_id=snapshot.project_id,
+                job_id=job_id,
+                status="running",
+                started_at=now,
+                updated_at=now,
+            )
+            self.workflows.save(workflow_ref)
+        now = datetime.now(UTC)
         return self.control.record_start(
             job_id,
             idempotency_key=request.idempotency_key,
-            workflow_execution_id=workflow_execution_id,
+            expected_revision=request.expected_revision,
+            workflow_execution_id=workflow_ref.workflow_execution_id,
             operation=operation,
             now=now,
         )
@@ -344,6 +381,7 @@ class ControlService:
         job_id: str,
         *,
         last_event_id: str | None,
+        follow: bool,
     ) -> AsyncIterator[str]:
         cursor = last_event_id
         heartbeat_deadline = asyncio.get_running_loop().time() + self.settings.sse_heartbeat_seconds
@@ -359,6 +397,8 @@ class ControlService:
                     asyncio.get_running_loop().time() + self.settings.sse_heartbeat_seconds
                 )
                 continue
+            if not follow:
+                return
             now = asyncio.get_running_loop().time()
             if now >= heartbeat_deadline:
                 yield ": keepalive\n\n"
@@ -428,6 +468,16 @@ def control_router() -> APIRouter:
         except Exception as exc:
             raise _translate_error(exc) from exc
 
+    @router.get("/projects/{project_id}/status", response_model=ProjectControlStatus)
+    async def get_project_status(
+        request: Request,
+        project_id: ProjectIdValue,
+    ) -> ProjectControlStatus:
+        try:
+            return _service(request).project_status(project_id)
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
     @router.get("/jobs/{job_id}/history", response_model=JobEventsResponse)
     async def job_history(
         request: Request,
@@ -481,9 +531,7 @@ def control_router() -> APIRouter:
         workflow_execution_id: WorkflowIdValue,
     ) -> WorkflowResponse:
         try:
-            return WorkflowResponse(
-                workflow=_service(request).workflow(workflow_execution_id)
-            )
+            return WorkflowResponse(workflow=_service(request).workflow(workflow_execution_id))
         except Exception as exc:
             raise _translate_error(exc) from exc
 
@@ -492,15 +540,22 @@ def control_router() -> APIRouter:
         request: Request,
         job_id: JobIdValue,
         last_event_id: Annotated[str | None, Header(alias="Last-Event-ID")] = None,
+        follow: bool = True,
     ) -> StreamingResponse:
         service = _service(request)
-        if last_event_id:
-            try:
+        try:
+            service.checkpoint(job_id)
+            if last_event_id:
                 decode_cursor(last_event_id, uuid_id=True)
-            except ValueError as exc:
-                raise _translate_error(exc) from exc
+        except Exception as exc:
+            raise _translate_error(exc) from exc
         return StreamingResponse(
-            service.stream_events(request, job_id, last_event_id=last_event_id),
+            service.stream_events(
+                request,
+                job_id,
+                last_event_id=last_event_id,
+                follow=follow,
+            ),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",

--- a/apps/api/src/ai_automation_force_api/errors.py
+++ b/apps/api/src/ai_automation_force_api/errors.py
@@ -53,14 +53,24 @@ def _response(
     return JSONResponse(status_code=status_code, content=payload.model_dump(mode="json"))
 
 
+def _normalized_api_error(exc: APIError) -> APIError:
+    """Preserve an already-normalized API error wrapped by a route translation boundary."""
+
+    cause = exc.__cause__
+    if isinstance(cause, APIError):
+        return cause
+    return exc
+
+
 def install_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(APIError)
     async def api_error_handler(request: Request, exc: APIError) -> JSONResponse:
+        normalized = _normalized_api_error(exc)
         return _response(
             request,
-            code=exc.code,
-            message=exc.message,
-            status_code=exc.status_code,
+            code=normalized.code,
+            message=normalized.message,
+            status_code=normalized.status_code,
         )
 
     @app.exception_handler(RequestValidationError)

--- a/apps/api/src/ai_automation_force_api/settings.py
+++ b/apps/api/src/ai_automation_force_api/settings.py
@@ -4,7 +4,15 @@ from collections.abc import Mapping
 from os import environ
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 Environment = Literal["development", "test", "staging", "production"]
 
@@ -21,8 +29,21 @@ class Settings(BaseModel):
     api_version: str = Field(default="v1", pattern=r"^v[1-9][0-9]*$")
     build_revision: str = Field(default="dev", min_length=1, max_length=80)
     internal_dev_identity: str | None = Field(default=None, min_length=3, max_length=120)
+    database_url: SecretStr | None = None
+    temporal_target: str = Field(default="127.0.0.1:7233", min_length=3, max_length=255)
+    temporal_namespace: str = Field(default="default", min_length=1, max_length=160)
+    temporal_task_queue: str = Field(default="aaf-control-v1", min_length=1, max_length=160)
+    sse_poll_interval_ms: int = Field(default=250, ge=25, le=5_000)
+    sse_heartbeat_seconds: int = Field(default=15, ge=1, le=120)
 
-    @field_validator("service_name", "build_revision", "internal_dev_identity")
+    @field_validator(
+        "service_name",
+        "build_revision",
+        "internal_dev_identity",
+        "temporal_target",
+        "temporal_namespace",
+        "temporal_task_queue",
+    )
     @classmethod
     def reject_control_characters(cls, value: str | None) -> str | None:
         if value is None:
@@ -41,6 +62,10 @@ class Settings(BaseModel):
     def api_prefix(self) -> str:
         return f"/api/{self.api_version}"
 
+    @property
+    def control_surface_configured(self) -> bool:
+        return self.database_url is not None
+
 
 def load_settings(source: Mapping[str, str] | None = None) -> Settings:
     values = environ if source is None else source
@@ -51,6 +76,12 @@ def load_settings(source: Mapping[str, str] | None = None) -> Settings:
         "AAF_API_VERSION": "api_version",
         "AAF_BUILD_REVISION": "build_revision",
         "AAF_INTERNAL_DEV_IDENTITY": "internal_dev_identity",
+        "DATABASE_URL": "database_url",
+        "AAF_TEMPORAL_TARGET": "temporal_target",
+        "AAF_TEMPORAL_NAMESPACE": "temporal_namespace",
+        "AAF_TEMPORAL_TASK_QUEUE": "temporal_task_queue",
+        "AAF_SSE_POLL_INTERVAL_MS": "sse_poll_interval_ms",
+        "AAF_SSE_HEARTBEAT_SECONDS": "sse_heartbeat_seconds",
     }
     for environment_key, model_key in env_map.items():
         value = values.get(environment_key)

--- a/apps/api/tests/test_app.py
+++ b/apps/api/tests/test_app.py
@@ -65,11 +65,43 @@ def test_structured_api_error_contains_request_id() -> None:
     }
 
 
+def test_control_surface_fails_closed_when_database_is_not_configured() -> None:
+    app = create_app(Settings(environment="test"))
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/v1/jobs/JOB-000001",
+            headers={"X-Request-ID": "req-control-001"},
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "error": {
+            "code": "CONTROL_SURFACE_UNAVAILABLE",
+            "message": "job control surface is not configured",
+            "request_id": "req-control-001",
+            "details": [],
+        }
+    }
+
+
 def test_openapi_schema_is_deterministic_and_versioned() -> None:
     first = create_app(Settings(environment="test", build_revision="schema-export")).openapi()
     second = create_app(Settings(environment="test", build_revision="schema-export")).openapi()
 
     assert first == second
     assert first["openapi"] == "3.1.0"
-    assert "/api/v1/health/live" in first["paths"]
-    assert "/api/v1/health/ready" in first["paths"]
+    expected_paths = {
+        "/api/v1/health/live",
+        "/api/v1/health/ready",
+        "/api/v1/jobs",
+        "/api/v1/jobs/{job_id}",
+        "/api/v1/jobs/{job_id}/start",
+        "/api/v1/jobs/{job_id}/cancel",
+        "/api/v1/jobs/{job_id}/retry",
+        "/api/v1/jobs/{job_id}/history",
+        "/api/v1/jobs/{job_id}/events",
+        "/api/v1/projects/{project_id}/jobs",
+        "/api/v1/projects/{project_id}/status",
+        "/api/v1/workflows/{workflow_execution_id}",
+    }
+    assert expected_paths.issubset(first["paths"])

--- a/apps/api/tests/test_control_api_integration.py
+++ b/apps/api/tests/test_control_api_integration.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from ai_automation_force_core import JobStatus
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from ai_automation_force_api import Settings, create_app
+from ai_automation_force_api.control import ControlService
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+TEMPORAL_INTEGRATION = os.environ.get("AAF_TEMPORAL_INTEGRATION") == "1"
+ROOT = Path(__file__).resolve().parents[3]
+ALEMBIC_INI = ROOT / "packages" / "python-core" / "alembic.ini"
+
+
+def alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
+
+
+def insert_project(external_id: str) -> None:
+    assert DATABASE_URL is not None
+    engine = create_engine(DATABASE_URL)
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO core.projects (
+                        id, external_id, title, status, audience, "cast", content_format,
+                        language, target_duration_seconds, output, creative, provider_policy,
+                        created_at, updated_at
+                    ) VALUES (
+                        gen_random_uuid(), :external_id, :title, 'draft',
+                        '{}'::jsonb, '{}'::jsonb, 'song', 'en', 120,
+                        '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, now(), now()
+                    )
+                    """
+                ),
+                {"external_id": external_id, "title": f"API fixture {external_id}"},
+            )
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.postgres
+@pytest.mark.temporal
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+@pytest.mark.skipif(not TEMPORAL_INTEGRATION, reason="AAF_TEMPORAL_INTEGRATION=1 is required")
+def test_job_control_api_is_idempotent_paginated_streamable_and_temporal_linked() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    insert_project("PRJ-001200")
+    app = create_app(
+        Settings(
+            environment="test",
+            build_revision="wp7-integration",
+            database_url=DATABASE_URL,
+            sse_poll_interval_ms=25,
+            sse_heartbeat_seconds=1,
+        )
+    )
+
+    try:
+        with TestClient(app) as client:
+            body = {
+                "project_id": "PRJ-001200",
+                "job_type": "synthetic-cancellable",
+                "idempotency_key": "api-create-001200",
+                "priority": 70,
+            }
+            created = client.post("/api/v1/jobs", json=body)
+            assert created.status_code == 201
+            created_payload = created.json()
+            assert created_payload["action"] == "created"
+            job_id = created_payload["job"]["job_id"]
+            first_cursor = created_payload["event_cursor"]
+            assert first_cursor
+            assert created_payload["job"]["status"] == "queued"
+            assert created_payload["job"]["revision"] == 1
+
+            reused_create = client.post("/api/v1/jobs", json=body)
+            assert reused_create.status_code == 201
+            assert reused_create.json()["action"] == "reused"
+            assert reused_create.json()["job"]["job_id"] == job_id
+
+            checkpoint = client.get(f"/api/v1/jobs/{job_id}")
+            assert checkpoint.status_code == 200
+            assert checkpoint.json()["event_cursor"] == first_cursor
+
+            project_jobs = client.get("/api/v1/projects/PRJ-001200/jobs?limit=1")
+            assert project_jobs.status_code == 200
+            assert [item["job_id"] for item in project_jobs.json()["items"]] == [job_id]
+
+            project_status = client.get("/api/v1/projects/PRJ-001200/status")
+            assert project_status.status_code == 200
+            assert project_status.json()["total_jobs"] == 1
+            assert project_status.json()["job_status_counts"] == {"queued": 1}
+
+            history = client.get(f"/api/v1/jobs/{job_id}/history")
+            assert history.status_code == 200
+            assert [item["event_type"] for item in history.json()["items"]] == ["job.created"]
+
+            finite_stream = client.get(f"/api/v1/jobs/{job_id}/events?follow=false")
+            assert finite_stream.status_code == 200
+            assert finite_stream.headers["content-type"].startswith("text/event-stream")
+            assert "event: job.created" in finite_stream.text
+            assert "\"schema_version\":1" in finite_stream.text
+
+            resumed_stream = client.get(
+                f"/api/v1/jobs/{job_id}/events?follow=false",
+                headers={"Last-Event-ID": first_cursor},
+            )
+            assert resumed_stream.status_code == 200
+            assert resumed_stream.text == ""
+
+            started = client.post(
+                f"/api/v1/jobs/{job_id}/start",
+                json={"idempotency_key": "api-start-001200", "expected_revision": 1},
+            )
+            assert started.status_code == 200
+            start_command = started.json()["command"]
+            assert start_command["action"] == "applied"
+            assert start_command["status"] == "eligible"
+            assert start_command["revision"] == 2
+            workflow_id = start_command["workflow_execution_id"]
+            assert workflow_id.startswith("WFX-")
+
+            reused_start = client.post(
+                f"/api/v1/jobs/{job_id}/start",
+                json={"idempotency_key": "api-start-001200", "expected_revision": 1},
+            )
+            assert reused_start.status_code == 200
+            assert reused_start.json()["command"]["action"] == "reused"
+            assert reused_start.json()["command"]["workflow_execution_id"] == workflow_id
+
+            workflow = client.get(f"/api/v1/workflows/{workflow_id}")
+            assert workflow.status_code == 200
+            assert workflow.json()["workflow"]["job_id"] == job_id
+            assert workflow.json()["workflow"]["project_id"] == "PRJ-001200"
+
+            after_start = client.get(f"/api/v1/jobs/{job_id}/history")
+            assert [item["job_revision"] for item in after_start.json()["items"]] == [1, 2]
+            assert after_start.json()["items"][-1]["payload"]["command"] == "start"
+
+            status_after_start = client.get("/api/v1/projects/PRJ-001200/status")
+            assert status_after_start.json()["job_status_counts"] == {"eligible": 1}
+            assert status_after_start.json()["workflow_status_counts"] == {"running": 1}
+
+            stale_cancel = client.post(
+                f"/api/v1/jobs/{job_id}/cancel",
+                json={"idempotency_key": "api-cancel-stale-001200", "expected_revision": 1},
+            )
+            assert stale_cancel.status_code == 409
+            assert stale_cancel.json()["error"]["code"] == "STALE_REVISION"
+
+            cancelled = client.post(
+                f"/api/v1/jobs/{job_id}/cancel",
+                json={"idempotency_key": "api-cancel-001200", "expected_revision": 2},
+            )
+            assert cancelled.status_code == 200
+            assert cancelled.json()["command"]["status"] == "cancelled"
+            assert cancelled.json()["command"]["revision"] == 3
+
+            invalid_cursor = client.get(
+                f"/api/v1/jobs/{job_id}/history",
+                params={"cursor": "not-a-valid-cursor"},
+            )
+            assert invalid_cursor.status_code == 400
+            assert invalid_cursor.json()["error"]["code"] == "INVALID_CONTROL_REQUEST"
+
+            missing = client.get("/api/v1/jobs/JOB-999999")
+            assert missing.status_code == 404
+            assert missing.json()["error"]["code"] == "NOT_FOUND"
+    finally:
+        command.downgrade(config, "base")
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_retry_api_requeues_retryable_failure_once() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    insert_project("PRJ-001201")
+    app = create_app(Settings(environment="test", database_url=DATABASE_URL))
+
+    try:
+        with TestClient(app) as client:
+            created = client.post(
+                "/api/v1/jobs",
+                json={
+                    "project_id": "PRJ-001201",
+                    "job_type": "synthetic-control",
+                    "idempotency_key": "api-create-001201",
+                },
+            )
+            job_id = created.json()["job"]["job_id"]
+            service = app.state.control_service
+            assert isinstance(service, ControlService)
+            now = datetime.now(UTC)
+            service.jobs.transition(
+                job_id,
+                JobStatus.ELIGIBLE,
+                now=now,
+                expected_revision=1,
+            )
+            service.jobs.claim(
+                job_id,
+                owner="api-test-worker",
+                now=now + timedelta(seconds=1),
+                lease_for=timedelta(seconds=30),
+                expected_revision=2,
+            )
+            service.jobs.transition(
+                job_id,
+                JobStatus.RUNNING,
+                now=now + timedelta(seconds=2),
+                expected_revision=3,
+            )
+            service.jobs.transition(
+                job_id,
+                JobStatus.RETRYABLE_FAILED,
+                now=now + timedelta(seconds=3),
+                expected_revision=4,
+            )
+
+            retried = client.post(
+                f"/api/v1/jobs/{job_id}/retry",
+                json={"idempotency_key": "api-retry-001201", "expected_revision": 5},
+            )
+            assert retried.status_code == 200
+            assert retried.json()["command"]["action"] == "applied"
+            assert retried.json()["command"]["status"] == "eligible"
+            assert retried.json()["command"]["revision"] == 6
+
+            reused = client.post(
+                f"/api/v1/jobs/{job_id}/retry",
+                json={"idempotency_key": "api-retry-001201", "expected_revision": 5},
+            )
+            assert reused.status_code == 200
+            assert reused.json()["command"]["action"] == "reused"
+            checkpoint = client.get(f"/api/v1/jobs/{job_id}").json()["job"]
+            assert checkpoint["retry_budget_remaining"] == 2
+    finally:
+        command.downgrade(config, "base")

--- a/packages/python-core/migrations/sql/0007_job_commands_down.sql
+++ b/packages/python-core/migrations/sql/0007_job_commands_down.sql
@@ -1,0 +1,1 @@
+DROP TABLE core.job_commands;

--- a/packages/python-core/migrations/sql/0007_job_commands_up.sql
+++ b/packages/python-core/migrations/sql/0007_job_commands_up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE core.job_commands (
+    id uuid PRIMARY KEY,
+    job_id uuid NOT NULL,
+    command_type text NOT NULL,
+    idempotency_key text NOT NULL,
+    operation_fingerprint text NOT NULL,
+    result jsonb NOT NULL DEFAULT '{}',
+    occurred_at timestamptz NOT NULL,
+    CONSTRAINT fk_job_commands_job FOREIGN KEY (job_id)
+        REFERENCES core.jobs(id) ON DELETE RESTRICT,
+    CONSTRAINT uq_job_commands_idempotency UNIQUE (job_id, idempotency_key),
+    CONSTRAINT ck_job_commands_type CHECK (length(command_type) BETWEEN 1 AND 80),
+    CONSTRAINT ck_job_commands_idempotency_key CHECK (length(idempotency_key) BETWEEN 8 AND 200),
+    CONSTRAINT ck_job_commands_fingerprint CHECK (operation_fingerprint ~ '^[a-f0-9]{64}$')
+);
+
+CREATE INDEX idx_job_commands_job_time
+    ON core.job_commands (job_id, occurred_at, id);

--- a/packages/python-core/migrations/versions/20260829_0007_job_commands.py
+++ b/packages/python-core/migrations/versions/20260829_0007_job_commands.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "20260829_0007"
+down_revision = "20260829_0006"
+branch_labels = None
+depends_on = None
+
+_SQL_DIR = Path(__file__).resolve().parents[1] / "sql"
+
+
+def _statements(filename: str) -> list[str]:
+    text = (_SQL_DIR / filename).read_text(encoding="utf-8")
+    return [statement.strip() for statement in text.split(";\n") if statement.strip()]
+
+
+def _execute(filename: str) -> None:
+    for statement in _statements(filename):
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute("0007_job_commands_up.sql")
+
+
+def downgrade() -> None:
+    _execute("0007_job_commands_down.sql")

--- a/packages/python-core/src/lullabies_core/__init__.py
+++ b/packages/python-core/src/lullabies_core/__init__.py
@@ -36,6 +36,7 @@ from .control_surface import (
     JobCommandVersionConflictError,
     JobControlSnapshot,
     JobEventRecord,
+    ProjectControlStatus,
     ProjectJobRecord,
     control_cursor_key,
 )
@@ -236,6 +237,7 @@ __all__ = [
     "ProductionLineageBundle",
     "Project",
     "ProjectBundle",
+    "ProjectControlStatus",
     "ProjectJobRecord",
     "ProjectStatus",
     "Prop",

--- a/packages/python-core/src/lullabies_core/__init__.py
+++ b/packages/python-core/src/lullabies_core/__init__.py
@@ -30,6 +30,15 @@ from .common import (
     TimeRange,
 )
 from .content import Content, ContentObjective, ContentVersion
+from .control_surface import (
+    JobCommandConflictError,
+    JobCommandResult,
+    JobCommandVersionConflictError,
+    JobControlSnapshot,
+    JobEventRecord,
+    ProjectJobRecord,
+    control_cursor_key,
+)
 from .entities import Location, Prop, StyleProfile, VoiceProfile, World
 from .job_control import (
     JOB_STATUS_TRANSITIONS,
@@ -69,6 +78,7 @@ from .persistence import (
     PersistResult,
     PostgresApprovalWaitRepository,
     PostgresCircuitBreakerRepository,
+    PostgresControlSurfaceRepository,
     PostgresJobControlRepository,
     PostgresProductionRepository,
     PostgresProviderAsyncRepository,
@@ -189,6 +199,11 @@ __all__ = [
     "GenerationRequest",
     "InvalidJobTransitionError",
     "Job",
+    "JobCommandConflictError",
+    "JobCommandResult",
+    "JobCommandVersionConflictError",
+    "JobControlSnapshot",
+    "JobEventRecord",
     "JobIdempotencyConflictError",
     "JobLeaseConflictError",
     "JobLeaseResult",
@@ -213,6 +228,7 @@ __all__ = [
     "PersistenceShapeError",
     "PostgresApprovalWaitRepository",
     "PostgresCircuitBreakerRepository",
+    "PostgresControlSurfaceRepository",
     "PostgresJobControlRepository",
     "PostgresProductionRepository",
     "PostgresProviderAsyncRepository",
@@ -220,6 +236,7 @@ __all__ = [
     "ProductionLineageBundle",
     "Project",
     "ProjectBundle",
+    "ProjectJobRecord",
     "ProjectStatus",
     "Prop",
     "ProviderAsyncConflictError",
@@ -251,6 +268,7 @@ __all__ = [
     "World",
     "assert_job_transition",
     "assert_provider_async_transition",
+    "control_cursor_key",
     "expected_wait_status",
     "expired_job_status",
     "import_legacy_content_package",

--- a/packages/python-core/src/lullabies_core/control_surface.py
+++ b/packages/python-core/src/lullabies_core/control_surface.py
@@ -51,6 +51,14 @@ class ProjectJobRecord(StrictModel):
     updated_at: AwareDatetime
 
 
+class ProjectControlStatus(StrictModel):
+    project_id: str = Field(pattern=r"^PRJ-[0-9]{6,20}$")
+    total_jobs: int = Field(ge=0)
+    job_status_counts: dict[str, int] = Field(default_factory=dict)
+    workflow_status_counts: dict[str, int] = Field(default_factory=dict)
+    latest_job_updated_at: AwareDatetime | None = None
+
+
 class JobCommandResult(StrictModel):
     action: Literal["applied", "reused", "noop"]
     command_type: Literal["start", "cancel", "retry"]

--- a/packages/python-core/src/lullabies_core/control_surface.py
+++ b/packages/python-core/src/lullabies_core/control_surface.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field
+
+from .common import JobStatus, StrictModel
+
+
+class JobControlSnapshot(StrictModel):
+    job_id: str = Field(pattern=r"^JOB-[0-9]{6,20}$")
+    project_id: str = Field(pattern=r"^PRJ-[0-9]{6,20}$")
+    job_type: str = Field(min_length=1, max_length=120)
+    status: JobStatus
+    priority: int = Field(ge=0, le=100)
+    idempotency_key: str = Field(min_length=8, max_length=200)
+    operation_fingerprint: str | None = Field(default=None, pattern=r"^[a-f0-9]{64}$")
+    parent_job_id: str | None = None
+    dependency_job_ids: list[str] = Field(default_factory=list)
+    shot_id: str | None = None
+    content_id: str | None = None
+    retry_budget_remaining: int = Field(ge=0)
+    blocked_reason: str | None = None
+    claimed_by: str | None = None
+    lease_expires_at: AwareDatetime | None = None
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+    revision: int = Field(ge=1)
+    workflow_execution_id: str | None = Field(default=None, pattern=r"^WFX-[0-9]{6,20}$")
+
+
+class JobEventRecord(StrictModel):
+    event_id: UUID
+    job_id: str = Field(pattern=r"^JOB-[0-9]{6,20}$")
+    job_revision: int = Field(ge=1)
+    event_type: str = Field(min_length=1, max_length=160)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    occurred_at: AwareDatetime
+    published_at: AwareDatetime | None = None
+
+
+class ProjectJobRecord(StrictModel):
+    job_id: str = Field(pattern=r"^JOB-[0-9]{6,20}$")
+    status: JobStatus
+    job_type: str
+    priority: int
+    revision: int = Field(ge=1)
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+
+
+class JobCommandResult(StrictModel):
+    action: Literal["applied", "reused", "noop"]
+    command_type: Literal["start", "cancel", "retry"]
+    job_id: str = Field(pattern=r"^JOB-[0-9]{6,20}$")
+    status: JobStatus
+    revision: int = Field(ge=1)
+    operation_fingerprint: str = Field(pattern=r"^[a-f0-9]{64}$")
+    workflow_execution_id: str | None = Field(default=None, pattern=r"^WFX-[0-9]{6,20}$")
+    occurred_at: AwareDatetime
+
+
+class JobCommandConflictError(RuntimeError):
+    """A control command conflicts with persisted idempotency or job state."""
+
+
+class JobCommandVersionConflictError(JobCommandConflictError):
+    """The caller supplied a stale expected job revision."""
+
+
+def control_cursor_key(occurred_at: datetime, event_id: UUID) -> tuple[datetime, UUID]:
+    """Return the stable total-order key used by durable event pagination/SSE replay."""
+
+    return occurred_at, event_id

--- a/packages/python-core/src/lullabies_core/persistence/__init__.py
+++ b/packages/python-core/src/lullabies_core/persistence/__init__.py
@@ -13,6 +13,7 @@ from .approval_wait import (
     PostgresApprovalWaitRepository,
 )
 from .circuit_breaker import CircuitBreakerConflictError, PostgresCircuitBreakerRepository
+from .control_surface import PostgresControlSurfaceRepository
 from .job_control import (
     JobIdempotencyConflictError,
     JobLeaseConflictError,
@@ -46,6 +47,7 @@ __all__ = [
     "PersistenceShapeError",
     "PostgresApprovalWaitRepository",
     "PostgresCircuitBreakerRepository",
+    "PostgresControlSurfaceRepository",
     "PostgresJobControlRepository",
     "PostgresProductionRepository",
     "PostgresProviderAsyncRepository",

--- a/packages/python-core/src/lullabies_core/persistence/control_surface.py
+++ b/packages/python-core/src/lullabies_core/persistence/control_surface.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+from sqlalchemy import MetaData, and_, insert, or_, select, update
+from sqlalchemy.engine import Connection, Engine, RowMapping
+from sqlalchemy.exc import IntegrityError
+
+from ..common import JobStatus
+from ..control_surface import (
+    JobCommandConflictError,
+    JobCommandResult,
+    JobCommandVersionConflictError,
+    JobControlSnapshot,
+    JobEventRecord,
+    ProjectJobRecord,
+)
+from ..job_control import TERMINAL_JOB_STATUSES, assert_job_transition, operation_fingerprint
+from ._db import PersistenceNotFoundError, PersistenceReferenceError
+
+
+class PostgresControlSurfaceRepository:
+    """Provider-neutral read/control boundary for the M02 job API and durable SSE feed."""
+
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+        metadata = MetaData()
+        metadata.reflect(bind=engine, schema="core")
+        required = {
+            "jobs",
+            "projects",
+            "shots",
+            "contents",
+            "job_dependencies",
+            "outbox_messages",
+            "workflow_executions",
+            "job_commands",
+        }
+        missing = [name for name in required if f"core.{name}" not in metadata.tables]
+        if missing:
+            raise PersistenceReferenceError(
+                "control-surface persistence tables are not migrated: "
+                + ", ".join(sorted(missing))
+            )
+        self.jobs = metadata.tables["core.jobs"]
+        self.projects = metadata.tables["core.projects"]
+        self.shots = metadata.tables["core.shots"]
+        self.contents = metadata.tables["core.contents"]
+        self.dependencies = metadata.tables["core.job_dependencies"]
+        self.outbox = metadata.tables["core.outbox_messages"]
+        self.workflows = metadata.tables["core.workflow_executions"]
+        self.commands = metadata.tables["core.job_commands"]
+
+    def load_job(self, job_id: str) -> JobControlSnapshot:
+        with self.engine.connect() as connection:
+            row = self._require_job(connection, job_id)
+            return self._snapshot(connection, row)
+
+    def list_project_jobs(
+        self,
+        project_id: str,
+        *,
+        after: tuple[datetime, UUID] | None = None,
+        limit: int = 50,
+    ) -> list[ProjectJobRecord]:
+        if limit < 1 or limit > 500:
+            raise ValueError("project job limit must be between 1 and 500")
+        with self.engine.connect() as connection:
+            project_internal = connection.execute(
+                select(self.projects.c.id).where(self.projects.c.external_id == project_id)
+            ).scalar_one_or_none()
+            if project_internal is None:
+                raise PersistenceNotFoundError(f"project {project_id} was not found")
+            statement = select(self.jobs).where(self.jobs.c.project_id == project_internal)
+            if after is not None:
+                after_time, after_id = after
+                statement = statement.where(
+                    or_(
+                        self.jobs.c.created_at > after_time,
+                        and_(
+                            self.jobs.c.created_at == after_time,
+                            self.jobs.c.id > after_id,
+                        ),
+                    )
+                )
+            rows = connection.execute(
+                statement.order_by(self.jobs.c.created_at, self.jobs.c.id).limit(limit)
+            ).mappings()
+            return [
+                ProjectJobRecord(
+                    job_id=str(row["external_id"]),
+                    status=JobStatus(str(row["status"])),
+                    job_type=str(row["job_type"]),
+                    priority=int(row["priority"]),
+                    revision=int(row["revision"]),
+                    created_at=row["created_at"],
+                    updated_at=row["updated_at"],
+                )
+                for row in rows
+            ]
+
+    def list_job_events(
+        self,
+        job_id: str,
+        *,
+        after: tuple[datetime, UUID] | None = None,
+        limit: int = 100,
+    ) -> list[JobEventRecord]:
+        if limit < 1 or limit > 500:
+            raise ValueError("event limit must be between 1 and 500")
+        with self.engine.connect() as connection:
+            job = self._require_job(connection, job_id)
+            statement = select(self.outbox).where(self.outbox.c.job_id == job["id"])
+            if after is not None:
+                after_time, after_id = after
+                statement = statement.where(
+                    or_(
+                        self.outbox.c.occurred_at > after_time,
+                        and_(
+                            self.outbox.c.occurred_at == after_time,
+                            self.outbox.c.id > after_id,
+                        ),
+                    )
+                )
+            rows = connection.execute(
+                statement.order_by(self.outbox.c.occurred_at, self.outbox.c.id).limit(limit)
+            ).mappings()
+            return [self._event(job_id, row) for row in rows]
+
+    def cancel_job(
+        self,
+        job_id: str,
+        *,
+        idempotency_key: str,
+        expected_revision: int,
+        now: datetime,
+    ) -> JobCommandResult:
+        return self._mutate_job(
+            job_id,
+            command_type="cancel",
+            idempotency_key=idempotency_key,
+            expected_revision=expected_revision,
+            now=now,
+        )
+
+    def retry_job(
+        self,
+        job_id: str,
+        *,
+        idempotency_key: str,
+        expected_revision: int,
+        now: datetime,
+    ) -> JobCommandResult:
+        return self._mutate_job(
+            job_id,
+            command_type="retry",
+            idempotency_key=idempotency_key,
+            expected_revision=expected_revision,
+            now=now,
+        )
+
+    def record_start(
+        self,
+        job_id: str,
+        *,
+        idempotency_key: str,
+        workflow_execution_id: str,
+        now: datetime,
+    ) -> JobCommandResult:
+        self._validate_idempotency_key(idempotency_key)
+        fingerprint = operation_fingerprint(
+            {
+                "command": "start",
+                "job_id": job_id,
+                "workflow_execution_id": workflow_execution_id,
+            }
+        )
+        try:
+            with self.engine.begin() as connection:
+                job = self._require_job_for_update(connection, job_id)
+                existing = self._command_by_key(connection, job["id"], idempotency_key)
+                if existing is not None:
+                    return self._reuse_command(existing, "start", fingerprint)
+                current = JobStatus(str(job["status"]))
+                if current in TERMINAL_JOB_STATUSES:
+                    raise JobCommandConflictError(
+                        f"job {job_id} cannot start from terminal state {current.value}"
+                    )
+                result = JobCommandResult(
+                    action="applied",
+                    command_type="start",
+                    job_id=job_id,
+                    status=current,
+                    revision=int(job["revision"]),
+                    operation_fingerprint=fingerprint,
+                    workflow_execution_id=workflow_execution_id,
+                    occurred_at=now,
+                )
+                self._insert_command(connection, job["id"], idempotency_key, result)
+                return result
+        except IntegrityError as exc:
+            raise JobCommandConflictError(f"database rejected start command: {exc.orig}") from exc
+
+    def _mutate_job(
+        self,
+        job_id: str,
+        *,
+        command_type: str,
+        idempotency_key: str,
+        expected_revision: int,
+        now: datetime,
+    ) -> JobCommandResult:
+        if command_type not in {"cancel", "retry"}:
+            raise ValueError("unsupported control command")
+        self._validate_idempotency_key(idempotency_key)
+        if expected_revision < 1:
+            raise ValueError("expected_revision must be at least 1")
+        fingerprint = operation_fingerprint(
+            {
+                "command": command_type,
+                "job_id": job_id,
+                "expected_revision": expected_revision,
+            }
+        )
+        try:
+            with self.engine.begin() as connection:
+                job = self._require_job_for_update(connection, job_id)
+                existing = self._command_by_key(connection, job["id"], idempotency_key)
+                if existing is not None:
+                    return self._reuse_command(existing, command_type, fingerprint)
+
+                current_revision = int(job["revision"])
+                current = JobStatus(str(job["status"]))
+                if command_type == "cancel" and current is JobStatus.CANCELLED:
+                    result = JobCommandResult(
+                        action="noop",
+                        command_type="cancel",
+                        job_id=job_id,
+                        status=current,
+                        revision=current_revision,
+                        operation_fingerprint=fingerprint,
+                        occurred_at=now,
+                    )
+                    self._insert_command(connection, job["id"], idempotency_key, result)
+                    return result
+
+                if current_revision != expected_revision:
+                    raise JobCommandVersionConflictError(
+                        f"stale job revision: expected {expected_revision}, current {current_revision}"
+                    )
+
+                if command_type == "cancel":
+                    if current in TERMINAL_JOB_STATUSES:
+                        raise JobCommandConflictError(
+                            f"job {job_id} cannot cancel from terminal state {current.value}"
+                        )
+                    target = JobStatus.CANCELLED
+                    assert_job_transition(current, target)
+                    retry_budget = int(job["retry_budget_remaining"])
+                    event_type = "job.status.changed"
+                else:
+                    if current is not JobStatus.RETRYABLE_FAILED:
+                        raise JobCommandConflictError(
+                            f"job {job_id} cannot retry from state {current.value}"
+                        )
+                    retry_budget = int(job["retry_budget_remaining"])
+                    if retry_budget < 1:
+                        raise JobCommandConflictError(f"job {job_id} retry budget is exhausted")
+                    target = JobStatus.ELIGIBLE
+                    assert_job_transition(current, target)
+                    retry_budget -= 1
+                    event_type = "job.retry.requested"
+
+                new_revision = current_revision + 1
+                update_result = connection.execute(
+                    update(self.jobs)
+                    .where(
+                        self.jobs.c.id == job["id"],
+                        self.jobs.c.revision == current_revision,
+                    )
+                    .values(
+                        status=target.value,
+                        retry_budget_remaining=retry_budget,
+                        blocked_reason=None,
+                        claimed_by=None,
+                        lease_expires_at=None,
+                        updated_at=now,
+                        revision=new_revision,
+                    )
+                )
+                if update_result.rowcount != 1:
+                    raise JobCommandVersionConflictError(
+                        "job revision changed during control command"
+                    )
+                self._insert_outbox(
+                    connection,
+                    job["id"],
+                    job_id,
+                    new_revision,
+                    event_type,
+                    now,
+                    {
+                        "job_id": job_id,
+                        "previous_status": current.value,
+                        "status": target.value,
+                        "revision": new_revision,
+                        "command": command_type,
+                    },
+                )
+                result = JobCommandResult(
+                    action="applied",
+                    command_type=cast(Any, command_type),
+                    job_id=job_id,
+                    status=target,
+                    revision=new_revision,
+                    operation_fingerprint=fingerprint,
+                    occurred_at=now,
+                )
+                self._insert_command(connection, job["id"], idempotency_key, result)
+                return result
+        except IntegrityError as exc:
+            raise JobCommandConflictError(
+                f"database rejected {command_type} command: {exc.orig}"
+            ) from exc
+
+    def _snapshot(self, connection: Connection, row: RowMapping) -> JobControlSnapshot:
+        project_id = self._external_for_internal(connection, self.projects, row["project_id"])
+        assert project_id is not None
+        dependencies = list(
+            connection.execute(
+                select(self.jobs.c.external_id)
+                .select_from(
+                    self.dependencies.join(
+                        self.jobs,
+                        self.dependencies.c.dependency_job_id == self.jobs.c.id,
+                    )
+                )
+                .where(self.dependencies.c.job_id == row["id"])
+                .order_by(self.dependencies.c.position)
+            ).scalars()
+        )
+        workflow_execution_id = connection.execute(
+            select(self.workflows.c.external_id)
+            .where(self.workflows.c.job_id == row["id"])
+            .order_by(self.workflows.c.started_at.desc(), self.workflows.c.id.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+        return JobControlSnapshot(
+            job_id=str(row["external_id"]),
+            project_id=project_id,
+            job_type=str(row["job_type"]),
+            status=JobStatus(str(row["status"])),
+            priority=int(row["priority"]),
+            idempotency_key=str(row["idempotency_key"]),
+            operation_fingerprint=(
+                str(row["operation_fingerprint"])
+                if row["operation_fingerprint"] is not None
+                else None
+            ),
+            parent_job_id=self._external_for_internal(connection, self.jobs, row["parent_job_id"]),
+            dependency_job_ids=[str(value) for value in dependencies],
+            shot_id=self._external_for_internal(connection, self.shots, row["shot_id"]),
+            content_id=self._external_for_internal(connection, self.contents, row["content_id"]),
+            retry_budget_remaining=int(row["retry_budget_remaining"]),
+            blocked_reason=(str(row["blocked_reason"]) if row["blocked_reason"] else None),
+            claimed_by=(str(row["claimed_by"]) if row["claimed_by"] else None),
+            lease_expires_at=row["lease_expires_at"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            revision=int(row["revision"]),
+            workflow_execution_id=(
+                str(workflow_execution_id) if workflow_execution_id is not None else None
+            ),
+        )
+
+    @staticmethod
+    def _event(job_id: str, row: RowMapping) -> JobEventRecord:
+        payload = row["payload"]
+        if not isinstance(payload, dict):
+            payload = dict(payload)
+        return JobEventRecord(
+            event_id=row["id"],
+            job_id=job_id,
+            job_revision=int(row["job_revision"]),
+            event_type=str(row["event_type"]),
+            payload=cast(dict[str, Any], payload),
+            occurred_at=row["occurred_at"],
+            published_at=row["published_at"],
+        )
+
+    def _require_job(self, connection: Connection, job_id: str) -> RowMapping:
+        row = connection.execute(
+            select(self.jobs).where(self.jobs.c.external_id == job_id)
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceNotFoundError(f"job {job_id} was not found")
+        return row
+
+    def _require_job_for_update(self, connection: Connection, job_id: str) -> RowMapping:
+        row = connection.execute(
+            select(self.jobs)
+            .where(self.jobs.c.external_id == job_id)
+            .with_for_update()
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceNotFoundError(f"job {job_id} was not found")
+        return row
+
+    def _command_by_key(
+        self,
+        connection: Connection,
+        job_internal_id: UUID,
+        idempotency_key: str,
+    ) -> RowMapping | None:
+        return connection.execute(
+            select(self.commands).where(
+                self.commands.c.job_id == job_internal_id,
+                self.commands.c.idempotency_key == idempotency_key,
+            )
+        ).mappings().one_or_none()
+
+    @staticmethod
+    def _reuse_command(
+        row: RowMapping,
+        command_type: str,
+        fingerprint: str,
+    ) -> JobCommandResult:
+        if row["command_type"] != command_type or row["operation_fingerprint"] != fingerprint:
+            raise JobCommandConflictError(
+                "idempotency key is already bound to different control-command semantics"
+            )
+        payload = row["result"]
+        if not isinstance(payload, Mapping):
+            raise JobCommandConflictError("persisted command result is malformed")
+        restored = dict(payload)
+        restored["action"] = "reused"
+        restored["occurred_at"] = row["occurred_at"]
+        return JobCommandResult.model_validate(restored)
+
+    def _insert_command(
+        self,
+        connection: Connection,
+        job_internal_id: UUID,
+        idempotency_key: str,
+        result: JobCommandResult,
+    ) -> None:
+        stored = result.model_dump(mode="json")
+        stored.pop("action", None)
+        stored.pop("occurred_at", None)
+        connection.execute(
+            insert(self.commands).values(
+                id=uuid4(),
+                job_id=job_internal_id,
+                command_type=result.command_type,
+                idempotency_key=idempotency_key,
+                operation_fingerprint=result.operation_fingerprint,
+                result=stored,
+                occurred_at=result.occurred_at,
+            )
+        )
+
+    def _insert_outbox(
+        self,
+        connection: Connection,
+        job_internal_id: UUID,
+        job_external_id: str,
+        revision: int,
+        event_type: str,
+        occurred_at: datetime,
+        payload: dict[str, Any],
+    ) -> None:
+        connection.execute(
+            insert(self.outbox).values(
+                id=uuid4(),
+                job_id=job_internal_id,
+                job_revision=revision,
+                event_type=event_type,
+                dedupe_key=f"job:{job_external_id}:revision:{revision}:{event_type}",
+                payload=payload,
+                occurred_at=occurred_at,
+                published_at=None,
+            )
+        )
+
+    @staticmethod
+    def _validate_idempotency_key(value: str) -> None:
+        if not 8 <= len(value) <= 200:
+            raise ValueError("idempotency key length must be between 8 and 200")
+        if any(ord(character) < 32 or ord(character) == 127 for character in value):
+            raise ValueError("idempotency key must not contain control characters")
+
+    @staticmethod
+    def _external_for_internal(
+        connection: Connection,
+        table: Any,
+        internal_id: UUID | None,
+    ) -> str | None:
+        if internal_id is None:
+            return None
+        value = connection.execute(
+            select(table.c.external_id).where(table.c.id == internal_id)
+        ).scalar_one_or_none()
+        if value is None:
+            raise PersistenceReferenceError(
+                f"missing external identity for internal row {internal_id}"
+            )
+        return str(value)

--- a/packages/python-core/src/lullabies_core/persistence/control_surface.py
+++ b/packages/python-core/src/lullabies_core/persistence/control_surface.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Any, Literal, cast
 from uuid import UUID, uuid4
 
-from sqlalchemy import MetaData, and_, insert, or_, select, update
+from sqlalchemy import MetaData, and_, func, insert, or_, select, update
 from sqlalchemy.engine import Connection, Engine, RowMapping
 from sqlalchemy.exc import IntegrityError
 
@@ -16,6 +16,7 @@ from ..control_surface import (
     JobCommandVersionConflictError,
     JobControlSnapshot,
     JobEventRecord,
+    ProjectControlStatus,
     ProjectJobRecord,
 )
 from ..job_control import TERMINAL_JOB_STATUSES, assert_job_transition, operation_fingerprint
@@ -92,11 +93,7 @@ class PostgresControlSurfaceRepository:
         if limit < 1 or limit > 500:
             raise ValueError("project job limit must be between 1 and 500")
         with self.engine.connect() as connection:
-            project_internal = connection.execute(
-                select(self.projects.c.id).where(self.projects.c.external_id == project_id)
-            ).scalar_one_or_none()
-            if project_internal is None:
-                raise PersistenceNotFoundError(f"project {project_id} was not found")
+            project_internal = self._require_project_internal(connection, project_id)
             statement = select(self.jobs).where(self.jobs.c.project_id == project_internal)
             if after is not None:
                 after_time, after_job_id = after
@@ -124,6 +121,36 @@ class PostgresControlSurfaceRepository:
                 )
                 for row in rows
             ]
+
+    def project_status(self, project_id: str) -> ProjectControlStatus:
+        with self.engine.connect() as connection:
+            project_internal = self._require_project_internal(connection, project_id)
+            job_counts = connection.execute(
+                select(self.jobs.c.status, func.count())
+                .where(self.jobs.c.project_id == project_internal)
+                .group_by(self.jobs.c.status)
+            ).all()
+            workflow_counts = connection.execute(
+                select(self.workflows.c.status, func.count())
+                .where(self.workflows.c.project_id == project_internal)
+                .group_by(self.workflows.c.status)
+            ).all()
+            latest_job_updated_at = connection.execute(
+                select(func.max(self.jobs.c.updated_at)).where(
+                    self.jobs.c.project_id == project_internal
+                )
+            ).scalar_one()
+            job_status_counts = {str(status): int(count) for status, count in job_counts}
+            workflow_status_counts = {
+                str(status): int(count) for status, count in workflow_counts
+            }
+            return ProjectControlStatus(
+                project_id=project_id,
+                total_jobs=sum(job_status_counts.values()),
+                job_status_counts=job_status_counts,
+                workflow_status_counts=workflow_status_counts,
+                latest_job_updated_at=latest_job_updated_at,
+            )
 
     def list_job_events(
         self,
@@ -208,6 +235,7 @@ class PostgresControlSurfaceRepository:
         job_id: str,
         *,
         idempotency_key: str,
+        expected_revision: int,
         workflow_execution_id: str,
         operation: Mapping[str, Any],
         now: datetime,
@@ -220,17 +248,59 @@ class PostgresControlSurfaceRepository:
                 existing = self._command_by_key(connection, job["id"], idempotency_key)
                 if existing is not None:
                     return self._reuse_command(existing, "start", fingerprint)
+                current_revision = int(job["revision"])
                 current = JobStatus(str(job["status"]))
-                if current in TERMINAL_JOB_STATUSES:
-                    raise JobCommandConflictError(
-                        f"job {job_id} cannot start from terminal state {current.value}"
+                if current_revision != expected_revision:
+                    message = (
+                        f"stale job revision: expected {expected_revision}, "
+                        f"current {current_revision}"
                     )
+                    raise JobCommandVersionConflictError(message)
+                if current is not JobStatus.QUEUED:
+                    raise JobCommandConflictError(
+                        f"job {job_id} cannot start from state {current.value}"
+                    )
+                target = JobStatus.ELIGIBLE
+                assert_job_transition(current, target)
+                new_revision = current_revision + 1
+                update_result = connection.execute(
+                    update(self.jobs)
+                    .where(
+                        self.jobs.c.id == job["id"],
+                        self.jobs.c.revision == current_revision,
+                    )
+                    .values(
+                        status=target.value,
+                        updated_at=now,
+                        revision=new_revision,
+                    )
+                )
+                if update_result.rowcount != 1:
+                    raise JobCommandVersionConflictError(
+                        "job revision changed while recording workflow start"
+                    )
+                self._insert_outbox(
+                    connection,
+                    job["id"],
+                    job_id,
+                    new_revision,
+                    "job.status.changed",
+                    now,
+                    {
+                        "job_id": job_id,
+                        "previous_status": current.value,
+                        "status": target.value,
+                        "revision": new_revision,
+                        "command": "start",
+                        "workflow_execution_id": workflow_execution_id,
+                    },
+                )
                 result = JobCommandResult(
                     action="applied",
                     command_type="start",
                     job_id=job_id,
-                    status=current,
-                    revision=int(job["revision"]),
+                    status=target,
+                    revision=new_revision,
                     operation_fingerprint=fingerprint,
                     workflow_execution_id=workflow_execution_id,
                     occurred_at=now,
@@ -444,6 +514,14 @@ class PostgresControlSurfaceRepository:
         if row is None:
             raise PersistenceNotFoundError(f"job {job_id} was not found")
         return row
+
+    def _require_project_internal(self, connection: Connection, project_id: str) -> UUID:
+        value = connection.execute(
+            select(self.projects.c.id).where(self.projects.c.external_id == project_id)
+        ).scalar_one_or_none()
+        if value is None:
+            raise PersistenceNotFoundError(f"project {project_id} was not found")
+        return cast(UUID, value)
 
     def _command_by_key(
         self,

--- a/packages/python-core/src/lullabies_core/persistence/control_surface.py
+++ b/packages/python-core/src/lullabies_core/persistence/control_surface.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, Literal, cast
 from uuid import UUID, uuid4
 
 from sqlalchemy import MetaData, and_, insert, or_, select, update
@@ -20,6 +20,8 @@ from ..control_surface import (
 )
 from ..job_control import TERMINAL_JOB_STATUSES, assert_job_transition, operation_fingerprint
 from ._db import PersistenceNotFoundError, PersistenceReferenceError
+
+MutatingCommand = Literal["cancel", "retry"]
 
 
 class PostgresControlSurfaceRepository:
@@ -59,11 +61,32 @@ class PostgresControlSurfaceRepository:
             row = self._require_job(connection, job_id)
             return self._snapshot(connection, row)
 
+    def load_job_checkpoint(
+        self,
+        job_id: str,
+    ) -> tuple[JobControlSnapshot, JobEventRecord | None]:
+        """Read a job plus an event high-water that cannot skip a newer job revision."""
+
+        with self.engine.connect() as connection:
+            row = self._require_job(connection, job_id)
+            snapshot = self._snapshot(connection, row)
+            event_row = connection.execute(
+                select(self.outbox)
+                .where(
+                    self.outbox.c.job_id == row["id"],
+                    self.outbox.c.job_revision <= int(row["revision"]),
+                )
+                .order_by(self.outbox.c.occurred_at.desc(), self.outbox.c.id.desc())
+                .limit(1)
+            ).mappings().one_or_none()
+            event = self._event(job_id, event_row) if event_row is not None else None
+            return snapshot, event
+
     def list_project_jobs(
         self,
         project_id: str,
         *,
-        after: tuple[datetime, UUID] | None = None,
+        after: tuple[datetime, str] | None = None,
         limit: int = 50,
     ) -> list[ProjectJobRecord]:
         if limit < 1 or limit > 500:
@@ -76,18 +99,18 @@ class PostgresControlSurfaceRepository:
                 raise PersistenceNotFoundError(f"project {project_id} was not found")
             statement = select(self.jobs).where(self.jobs.c.project_id == project_internal)
             if after is not None:
-                after_time, after_id = after
+                after_time, after_job_id = after
                 statement = statement.where(
                     or_(
                         self.jobs.c.created_at > after_time,
                         and_(
                             self.jobs.c.created_at == after_time,
-                            self.jobs.c.id > after_id,
+                            self.jobs.c.external_id > after_job_id,
                         ),
                     )
                 )
             rows = connection.execute(
-                statement.order_by(self.jobs.c.created_at, self.jobs.c.id).limit(limit)
+                statement.order_by(self.jobs.c.created_at, self.jobs.c.external_id).limit(limit)
             ).mappings()
             return [
                 ProjectJobRecord(
@@ -162,22 +185,35 @@ class PostgresControlSurfaceRepository:
             now=now,
         )
 
+    def load_start_command(
+        self,
+        job_id: str,
+        *,
+        idempotency_key: str,
+        operation: Mapping[str, Any],
+    ) -> JobCommandResult | None:
+        """Return an existing semantically identical start before touching Temporal."""
+
+        self._validate_idempotency_key(idempotency_key)
+        fingerprint = self._command_fingerprint("start", job_id, operation)
+        with self.engine.connect() as connection:
+            job = self._require_job(connection, job_id)
+            existing = self._command_by_key(connection, job["id"], idempotency_key)
+            if existing is None:
+                return None
+            return self._reuse_command(existing, "start", fingerprint)
+
     def record_start(
         self,
         job_id: str,
         *,
         idempotency_key: str,
         workflow_execution_id: str,
+        operation: Mapping[str, Any],
         now: datetime,
     ) -> JobCommandResult:
         self._validate_idempotency_key(idempotency_key)
-        fingerprint = operation_fingerprint(
-            {
-                "command": "start",
-                "job_id": job_id,
-                "workflow_execution_id": workflow_execution_id,
-            }
-        )
+        fingerprint = self._command_fingerprint("start", job_id, operation)
         try:
             with self.engine.begin() as connection:
                 job = self._require_job_for_update(connection, job_id)
@@ -208,13 +244,11 @@ class PostgresControlSurfaceRepository:
         self,
         job_id: str,
         *,
-        command_type: str,
+        command_type: MutatingCommand,
         idempotency_key: str,
         expected_revision: int,
         now: datetime,
     ) -> JobCommandResult:
-        if command_type not in {"cancel", "retry"}:
-            raise ValueError("unsupported control command")
         self._validate_idempotency_key(idempotency_key)
         if expected_revision < 1:
             raise ValueError("expected_revision must be at least 1")
@@ -248,9 +282,11 @@ class PostgresControlSurfaceRepository:
                     return result
 
                 if current_revision != expected_revision:
-                    raise JobCommandVersionConflictError(
-                        f"stale job revision: expected {expected_revision}, current {current_revision}"
+                    message = (
+                        f"stale job revision: expected {expected_revision}, "
+                        f"current {current_revision}"
                     )
+                    raise JobCommandVersionConflictError(message)
 
                 if command_type == "cancel":
                     if current in TERMINAL_JOB_STATUSES:
@@ -312,7 +348,7 @@ class PostgresControlSurfaceRepository:
                 )
                 result = JobCommandResult(
                     action="applied",
-                    command_type=cast(Any, command_type),
+                    command_type=command_type,
                     job_id=job_id,
                     status=target,
                     revision=new_revision,
@@ -425,7 +461,7 @@ class PostgresControlSurfaceRepository:
     @staticmethod
     def _reuse_command(
         row: RowMapping,
-        command_type: str,
+        command_type: Literal["start", "cancel", "retry"],
         fingerprint: str,
     ) -> JobCommandResult:
         if row["command_type"] != command_type or row["operation_fingerprint"] != fingerprint:
@@ -483,6 +519,20 @@ class PostgresControlSurfaceRepository:
                 occurred_at=occurred_at,
                 published_at=None,
             )
+        )
+
+    @staticmethod
+    def _command_fingerprint(
+        command_type: Literal["start"],
+        job_id: str,
+        operation: Mapping[str, Any],
+    ) -> str:
+        return operation_fingerprint(
+            {
+                "command": command_type,
+                "job_id": job_id,
+                "operation": dict(operation),
+            }
         )
 
     @staticmethod

--- a/packages/python-core/tests/test_control_surface_persistence.py
+++ b/packages/python-core/tests/test_control_surface_persistence.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from ai_automation_force_core import (
+    AuditFields,
+    Job,
+    JobCommandConflictError,
+    JobCommandVersionConflictError,
+    JobStatus,
+    PostgresControlSurfaceRepository,
+    PostgresJobControlRepository,
+)
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+ALEMBIC_INI = Path(__file__).parents[1] / "alembic.ini"
+
+
+def alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
+
+
+def insert_project(engine: object, external_id: str) -> None:
+    with engine.begin() as connection:  # type: ignore[attr-defined]
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.projects (
+                    id, external_id, title, status, audience, "cast", content_format,
+                    language, target_duration_seconds, output, creative, provider_policy,
+                    created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :external_id, :title, 'draft',
+                    '{}'::jsonb, '{}'::jsonb, 'song', 'en', 120,
+                    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, now(), now()
+                )
+                """
+            ),
+            {"external_id": external_id, "title": f"Fixture {external_id}"},
+        )
+
+
+def queued_job(job_id: str, project_id: str, key: str, now: datetime) -> Job:
+    return Job(
+        job_id=job_id,
+        project_id=project_id,
+        job_type="synthetic-control",
+        idempotency_key=key,
+        audit=AuditFields(created_at=now, updated_at=now, revision=1),
+    )
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_control_surface_reads_events_and_idempotently_cancels() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    now = datetime.now(UTC)
+
+    try:
+        insert_project(engine, "PRJ-001100")
+        jobs = PostgresJobControlRepository(engine)
+        control = PostgresControlSurfaceRepository(engine)
+        job = queued_job("JOB-001100", "PRJ-001100", "create-001100", now)
+        created = jobs.submit(job, {"kind": "synthetic-control", "value": "one"})
+        assert created.action == "created"
+
+        snapshot = control.load_job(job.job_id)
+        assert snapshot.status is JobStatus.QUEUED
+        assert snapshot.revision == 1
+        assert snapshot.project_id == job.project_id
+        assert snapshot.operation_fingerprint == created.operation_fingerprint
+
+        events = control.list_job_events(job.job_id)
+        assert [event.event_type for event in events] == ["job.created"]
+        after = (events[0].occurred_at, events[0].event_id)
+        assert control.list_job_events(job.job_id, after=after) == []
+
+        applied = control.cancel_job(
+            job.job_id,
+            idempotency_key="cancel-001100",
+            expected_revision=1,
+            now=now + timedelta(seconds=1),
+        )
+        assert applied.action == "applied"
+        assert applied.status is JobStatus.CANCELLED
+        assert applied.revision == 2
+
+        reused = control.cancel_job(
+            job.job_id,
+            idempotency_key="cancel-001100",
+            expected_revision=1,
+            now=now + timedelta(seconds=2),
+        )
+        assert reused.action == "reused"
+        assert reused.revision == 2
+
+        noop = control.cancel_job(
+            job.job_id,
+            idempotency_key="cancel-001100-new",
+            expected_revision=1,
+            now=now + timedelta(seconds=3),
+        )
+        assert noop.action == "noop"
+        assert noop.revision == 2
+
+        with pytest.raises(JobCommandConflictError, match="different control-command"):
+            control.retry_job(
+                job.job_id,
+                idempotency_key="cancel-001100",
+                expected_revision=1,
+                now=now + timedelta(seconds=4),
+            )
+
+        all_events = control.list_job_events(job.job_id)
+        assert [event.event_type for event in all_events] == [
+            "job.created",
+            "job.status.changed",
+        ]
+        page = control.list_project_jobs(job.project_id)
+        assert len(page) == 1
+        assert page[0].job_id == job.job_id
+        assert page[0].status is JobStatus.CANCELLED
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_retry_command_decrements_budget_once_and_rejects_stale_or_wrong_state() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    now = datetime.now(UTC)
+
+    try:
+        insert_project(engine, "PRJ-001101")
+        jobs = PostgresJobControlRepository(engine)
+        control = PostgresControlSurfaceRepository(engine)
+        job = queued_job("JOB-001101", "PRJ-001101", "create-001101", now)
+        jobs.submit(job, {"kind": "synthetic-control", "value": "retry"})
+        jobs.transition(
+            job.job_id,
+            JobStatus.ELIGIBLE,
+            now=now + timedelta(seconds=1),
+            expected_revision=1,
+        )
+        jobs.claim(
+            job.job_id,
+            owner="worker-wp7",
+            now=now + timedelta(seconds=2),
+            lease_for=timedelta(seconds=30),
+            expected_revision=2,
+        )
+        jobs.transition(
+            job.job_id,
+            JobStatus.RUNNING,
+            now=now + timedelta(seconds=3),
+            expected_revision=3,
+        )
+        jobs.transition(
+            job.job_id,
+            JobStatus.RETRYABLE_FAILED,
+            now=now + timedelta(seconds=4),
+            expected_revision=4,
+        )
+
+        with pytest.raises(JobCommandVersionConflictError, match="stale"):
+            control.retry_job(
+                job.job_id,
+                idempotency_key="retry-stale-001101",
+                expected_revision=4,
+                now=now + timedelta(seconds=5),
+            )
+
+        applied = control.retry_job(
+            job.job_id,
+            idempotency_key="retry-001101",
+            expected_revision=5,
+            now=now + timedelta(seconds=6),
+        )
+        assert applied.action == "applied"
+        assert applied.status is JobStatus.ELIGIBLE
+        assert applied.revision == 6
+        snapshot = control.load_job(job.job_id)
+        assert snapshot.retry_budget_remaining == 2
+
+        reused = control.retry_job(
+            job.job_id,
+            idempotency_key="retry-001101",
+            expected_revision=5,
+            now=now + timedelta(seconds=7),
+        )
+        assert reused.action == "reused"
+        assert control.load_job(job.job_id).retry_budget_remaining == 2
+
+        with pytest.raises(JobCommandConflictError, match="cannot retry"):
+            control.retry_job(
+                job.job_id,
+                idempotency_key="retry-again-001101",
+                expected_revision=6,
+                now=now + timedelta(seconds=8),
+            )
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")

--- a/packages/python-core/tests/test_control_surface_persistence.py
+++ b/packages/python-core/tests/test_control_surface_persistence.py
@@ -131,6 +131,84 @@ def test_control_surface_reads_events_and_idempotently_cancels() -> None:
         assert len(page) == 1
         assert page[0].job_id == job.job_id
         assert page[0].status is JobStatus.CANCELLED
+        project_status = control.project_status(job.project_id)
+        assert project_status.total_jobs == 1
+        assert project_status.job_status_counts == {"cancelled": 1}
+        assert project_status.workflow_status_counts == {}
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_start_command_is_atomic_versioned_idempotent_and_outboxed() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    now = datetime.now(UTC)
+
+    try:
+        insert_project(engine, "PRJ-001102")
+        jobs = PostgresJobControlRepository(engine)
+        control = PostgresControlSurfaceRepository(engine)
+        job = queued_job("JOB-001102", "PRJ-001102", "create-001102", now)
+        jobs.submit(job, {"kind": "synthetic-control", "value": "start"})
+        operation = {"expected_revision": 1, "workflow_kind": "synthetic-job-control"}
+
+        assert (
+            control.load_start_command(
+                job.job_id,
+                idempotency_key="start-001102",
+                operation=operation,
+            )
+            is None
+        )
+        applied = control.record_start(
+            job.job_id,
+            idempotency_key="start-001102",
+            expected_revision=1,
+            workflow_execution_id="WFX-001102",
+            operation=operation,
+            now=now + timedelta(seconds=1),
+        )
+        assert applied.action == "applied"
+        assert applied.status is JobStatus.ELIGIBLE
+        assert applied.revision == 2
+        assert applied.workflow_execution_id == "WFX-001102"
+
+        reused = control.load_start_command(
+            job.job_id,
+            idempotency_key="start-001102",
+            operation=operation,
+        )
+        assert reused is not None
+        assert reused.action == "reused"
+        assert reused.revision == 2
+        assert control.load_job(job.job_id).status is JobStatus.ELIGIBLE
+
+        events = control.list_job_events(job.job_id)
+        assert [event.job_revision for event in events] == [1, 2]
+        assert events[-1].payload["command"] == "start"
+        assert events[-1].payload["workflow_execution_id"] == "WFX-001102"
+
+        with pytest.raises(JobCommandConflictError, match="different control-command"):
+            control.load_start_command(
+                job.job_id,
+                idempotency_key="start-001102",
+                operation={"expected_revision": 2, "workflow_kind": "synthetic-job-control"},
+            )
+        with pytest.raises(JobCommandVersionConflictError, match="stale"):
+            control.record_start(
+                job.job_id,
+                idempotency_key="start-stale-001102",
+                expected_revision=1,
+                workflow_execution_id="WFX-001103",
+                operation=operation,
+                now=now + timedelta(seconds=2),
+            )
     finally:
         engine.dispose()
         command.downgrade(config, "base")

--- a/packages/python-core/tests/test_migrations.py
+++ b/packages/python-core/tests/test_migrations.py
@@ -38,6 +38,7 @@ EXPECTED_CORE_TABLES = {
     "assets",
     "jobs",
     "job_dependencies",
+    "job_commands",
     "generation_attempts",
     "generation_attempt_input_assets",
     "generation_attempt_qa_records",
@@ -73,6 +74,7 @@ EXPECTED_CORE_TABLES = {
 }
 
 PROVIDER_ASYNC_TABLES = {"provider_async_states", "provider_callback_events"}
+WP7_TABLES = {"job_commands"}
 
 
 def alembic_config() -> Config:
@@ -94,6 +96,16 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         assert set(db_inspector.get_table_names(schema="core")) == EXPECTED_CORE_TABLES
         job_columns = {column["name"] for column in db_inspector.get_columns("jobs", schema="core")}
         assert "operation_fingerprint" in job_columns
+        command_columns = {
+            column["name"] for column in db_inspector.get_columns("job_commands", schema="core")
+        }
+        assert {
+            "command_type",
+            "idempotency_key",
+            "operation_fingerprint",
+            "result",
+            "occurred_at",
+        }.issubset(command_columns)
         approval_request_columns = {
             column["name"]
             for column in db_inspector.get_columns("approval_requests", schema="core")
@@ -127,7 +139,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         with engine.connect() as connection:
             result = connection.execute(text("SELECT version_num FROM alembic_version"))
             revision = result.scalar_one()
-        assert revision == "20260829_0006"
+        assert revision == "20260829_0007"
 
         project_id = uuid4()
         with engine.begin() as connection:
@@ -232,7 +244,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
 
         command.downgrade(config, "20260829_0005")
         m05_tables = set(inspect(engine).get_table_names(schema="core"))
-        assert m05_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES
+        assert m05_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES - WP7_TABLES
         assert "approval_requests" in m05_tables
         assert "circuit_breakers" in m05_tables
 
@@ -240,7 +252,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         m04_tables = set(inspect(engine).get_table_names(schema="core"))
         assert "approval_requests" not in m04_tables
         assert "circuit_breakers" in m04_tables
-        assert m04_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES - {
+        assert m04_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES - WP7_TABLES - {
             "approval_requests"
         }
 
@@ -248,7 +260,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         m03_inspector = inspect(engine)
         m03_tables = set(m03_inspector.get_table_names(schema="core"))
         assert "circuit_breakers" not in m03_tables
-        assert m03_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES - {
+        assert m03_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES - WP7_TABLES - {
             "approval_requests",
             "circuit_breakers",
         }
@@ -263,7 +275,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         m02_inspector = inspect(engine)
         m02_tables = set(m02_inspector.get_table_names(schema="core"))
         assert "outbox_messages" not in m02_tables
-        assert m02_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES - {
+        assert m02_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES - WP7_TABLES - {
             "approval_requests",
             "circuit_breakers",
             "outbox_messages",
@@ -277,7 +289,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         command.downgrade(config, "20260829_0001")
         m01_tables = set(inspect(engine).get_table_names(schema="core"))
         assert "workflow_executions" not in m01_tables
-        assert m01_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES - {
+        assert m01_tables == EXPECTED_CORE_TABLES - PROVIDER_ASYNC_TABLES - WP7_TABLES - {
             "approval_requests",
             "circuit_breakers",
             "workflow_executions",


### PR DESCRIPTION
## Scope
Implements M02-WP7 only: provider-neutral job/control REST APIs, durable command idempotency, workflow/project status, deterministic history pagination, and durable SSE progress replay from transactional outbox evidence.

## Delivered
- migration `0007` durable post-create `start` / `cancel` / `retry` command idempotency ledger
- provider-neutral job snapshot, event, command and project-status contracts
- PostgreSQL control/read repository with optimistic revisions and retry-budget enforcement
- deterministic workflow IDs and persisted Temporal execution references
- crash-recovery-aware start handling and idempotent command reuse
- REST create / inspect / start / cancel / retry / history / workflow / project status surfaces
- opaque deterministic pagination cursors
- SSE `Last-Event-ID` replay over the existing transactional outbox; no duplicate event store
- fail-closed control-service readiness and normalized error envelopes
- migration upgrade/downgrade through `0007`
- PostgreSQL + Temporal API integration coverage and deterministic OpenAPI acceptance

## Exact-head acceptance
Candidate head: `81489ce89290dc05e1b14784d174247ac31701ba`
- Core Domain Contracts: run `33257982999` / job `99114915153` — GREEN
- Durable Control Plane: run `33257983006` / job `99114915213` — GREEN

## Safety boundary
No real provider endpoint/credential/spend, no media generation/object storage, no WebSocket, no M03+, no full product auth/UI/billing/social implementation.

## Superseded without code change
This PR is closed only because the connected GitHub ready-for-review mutation failed on a connector GraphQL schema field (`Repository.fullDatabaseId`), and GitHub correctly refuses to merge a draft PR. The exact same branch/head is being reopened as a non-draft replacement PR. No executable code or candidate SHA changed.