### PR TITLE
M02-WP8: replay restart and synthetic 100-shot recovery acceptance

### DIFF
--- a/apps/api/tests/test_api_restart_acceptance.py
+++ b/apps/api/tests/test_api_restart_acceptance.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from ai_automation_force_api import Settings, create_app
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+TEMPORAL_INTEGRATION = os.environ.get("AAF_TEMPORAL_INTEGRATION") == "1"
+ROOT = Path(__file__).resolve().parents[3]
+ALEMBIC_INI = ROOT / "packages" / "python-core" / "alembic.ini"
+
+
+def alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
+
+
+def insert_project(external_id: str) -> None:
+    assert DATABASE_URL is not None
+    engine = create_engine(DATABASE_URL)
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO core.projects (
+                        id, external_id, title, status, audience, "cast", content_format,
+                        language, target_duration_seconds, output, creative, provider_policy,
+                        created_at, updated_at
+                    ) VALUES (
+                        gen_random_uuid(), :external_id, :title, 'draft',
+                        '{}'::jsonb, '{}'::jsonb, 'song', 'en', 120,
+                        '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, now(), now()
+                    )
+                    """
+                ),
+                {"external_id": external_id, "title": f"Restart fixture {external_id}"},
+            )
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.postgres
+@pytest.mark.temporal
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+@pytest.mark.skipif(not TEMPORAL_INTEGRATION, reason="AAF_TEMPORAL_INTEGRATION=1 is required")
+def test_api_restart_does_not_own_or_lose_temporal_workflow_reference() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    insert_project("PRJ-001280")
+    settings = Settings(
+        environment="test",
+        build_revision="wp8-api-restart",
+        database_url=DATABASE_URL,
+    )
+
+    try:
+        first_app = create_app(settings)
+        with TestClient(first_app) as first_client:
+            created = first_client.post(
+                "/api/v1/jobs",
+                json={
+                    "project_id": "PRJ-001280",
+                    "job_type": "synthetic-cancellable",
+                    "idempotency_key": "wp8-create-restart",
+                },
+            )
+            assert created.status_code == 201
+            job_id = created.json()["job"]["job_id"]
+            started = first_client.post(
+                f"/api/v1/jobs/{job_id}/start",
+                json={
+                    "idempotency_key": "wp8-start-restart",
+                    "expected_revision": 1,
+                },
+            )
+            assert started.status_code == 200
+            workflow_id = started.json()["command"]["workflow_execution_id"]
+            assert workflow_id
+
+        # The first API lifespan is fully closed here; durable state must remain external.
+        second_app = create_app(settings)
+        with TestClient(second_app) as second_client:
+            checkpoint = second_client.get(f"/api/v1/jobs/{job_id}")
+            assert checkpoint.status_code == 200
+            assert checkpoint.json()["job"]["workflow_execution_id"] == workflow_id
+            assert checkpoint.json()["job"]["status"] == "eligible"
+
+            workflow = second_client.get(f"/api/v1/workflows/{workflow_id}")
+            assert workflow.status_code == 200
+            assert workflow.json()["workflow"]["job_id"] == job_id
+            assert workflow.json()["workflow"]["project_id"] == "PRJ-001280"
+
+            cancelled = second_client.post(
+                f"/api/v1/jobs/{job_id}/cancel",
+                json={
+                    "idempotency_key": "wp8-cancel-restart",
+                    "expected_revision": 2,
+                },
+            )
+            assert cancelled.status_code == 200
+            assert cancelled.json()["command"]["status"] == "cancelled"
+            assert cancelled.json()["command"]["revision"] == 3
+    finally:
+        command.downgrade(config, "base")

--- a/apps/worker/src/ai_automation_force_worker/__init__.py
+++ b/apps/worker/src/ai_automation_force_worker/__init__.py
@@ -1,4 +1,5 @@
 from .client import connect_temporal
+from .recovery import SyntheticRecoveryWorkflow, synthetic_recovery_shot
 from .settings import WorkerSettings, WorkerSettingsError, load_worker_settings
 from .worker import build_worker
 from .workflows import (
@@ -19,6 +20,7 @@ __all__ = [
     "SyntheticCancellationWorkflow",
     "SyntheticControlWorkflow",
     "SyntheticProviderAsyncWorkflow",
+    "SyntheticRecoveryWorkflow",
     "SyntheticRetryWorkflow",
     "WorkerSettings",
     "WorkerSettingsError",
@@ -30,4 +32,5 @@ __all__ = [
     "synthetic_flaky",
     "synthetic_provider_poll",
     "synthetic_provider_submit",
+    "synthetic_recovery_shot",
 ]

--- a/apps/worker/src/ai_automation_force_worker/recovery.py
+++ b/apps/worker/src/ai_automation_force_worker/recovery.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from typing import Any
+
+from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
+from temporalio.exceptions import ApplicationError
+
+RECOVERY_ACTIVITY_START_TO_CLOSE = timedelta(seconds=5)
+RECOVERY_ACTIVITY_SCHEDULE_TO_CLOSE = timedelta(seconds=20)
+RECOVERY_MAX_SHOTS = 1000
+RECOVERY_INPUT_KEYS = frozenset(
+    {
+        "project_key",
+        "shot_count",
+        "fail_first_indexes",
+        "approval_after",
+        "expected_approval_revision",
+        "completed_results",
+        "approval_received",
+        "seen_signal_keys",
+    }
+)
+
+
+@activity.defn
+async def synthetic_recovery_shot(payload: dict[str, Any]) -> dict[str, Any]:
+    """Spend-free shot Activity with deterministic retry injection and stable terminal identity."""
+
+    shot_index = int(payload["shot_index"])
+    project_key = str(payload["project_key"]).strip()
+    fail_first = bool(payload["fail_first"])
+    if not project_key:
+        raise ApplicationError(
+            "project key is blank",
+            type="SyntheticRecoveryInput",
+            non_retryable=True,
+        )
+    if shot_index < 0:
+        raise ApplicationError(
+            "shot index must be non-negative",
+            type="SyntheticRecoveryInput",
+            non_retryable=True,
+        )
+    attempt = activity.info().attempt
+    if fail_first and attempt == 1:
+        raise ApplicationError(
+            f"synthetic recovery retry for shot {shot_index}",
+            type="SyntheticRecoveryTransient",
+        )
+    await asyncio.sleep(0.01)
+    return {
+        "shot_index": shot_index,
+        "terminal_key": f"{project_key}:shot:{shot_index:03d}:terminal",
+        "activity_attempt": attempt,
+    }
+
+
+@workflow.defn
+class SyntheticRecoveryWorkflow:
+    """Synthetic M02 exit workflow proving fan-out, pause, retry, restart and replay durability."""
+
+    def __init__(self) -> None:
+        self._project_key = ""
+        self._shot_count = 0
+        self._approval_after = 0
+        self._expected_approval_revision = 1
+        self._approval_received = False
+        self._waiting_for_approval = False
+        self._seen_signal_keys: set[str] = set()
+        self._completed: dict[int, dict[str, Any]] = {}
+
+    @workflow.signal
+    def approve(self, payload: dict[str, Any]) -> None:
+        signal_key = str(payload.get("signal_key", "")).strip()
+        if not signal_key or signal_key in self._seen_signal_keys:
+            return
+        self._seen_signal_keys.add(signal_key)
+        revision = int(payload.get("request_revision", 0))
+        decision = str(payload.get("decision", "")).strip()
+        if revision != self._expected_approval_revision or decision != "approved":
+            return
+        self._approval_received = True
+
+    @workflow.query
+    def progress(self) -> dict[str, Any]:
+        return {
+            "project_key": self._project_key,
+            "shot_count": self._shot_count,
+            "completed_count": len(self._completed),
+            "waiting_for_approval": self._waiting_for_approval,
+            "approval_received": self._approval_received,
+        }
+
+    def _restore(self, input: dict[str, Any]) -> tuple[list[int], int]:
+        unknown = set(input) - RECOVERY_INPUT_KEYS
+        if unknown:
+            raise ApplicationError(
+                f"unknown recovery input keys: {', '.join(sorted(unknown))}",
+                type="SyntheticRecoveryInput",
+                non_retryable=True,
+            )
+        self._project_key = str(input.get("project_key", "")).strip()
+        self._shot_count = int(input.get("shot_count", 0))
+        self._approval_after = int(input.get("approval_after", self._shot_count // 2))
+        self._expected_approval_revision = int(input.get("expected_approval_revision", 1))
+        if not self._project_key:
+            raise ApplicationError(
+                "project_key is required",
+                type="SyntheticRecoveryInput",
+                non_retryable=True,
+            )
+        if not 1 <= self._shot_count <= RECOVERY_MAX_SHOTS:
+            raise ApplicationError(
+                f"shot_count must be between 1 and {RECOVERY_MAX_SHOTS}",
+                type="SyntheticRecoveryInput",
+                non_retryable=True,
+            )
+        if not 0 <= self._approval_after <= self._shot_count:
+            raise ApplicationError(
+                "approval_after must be within shot_count",
+                type="SyntheticRecoveryInput",
+                non_retryable=True,
+            )
+        fail_first_indexes = sorted({int(value) for value in input.get("fail_first_indexes", [])})
+        if any(value < 0 or value >= self._shot_count for value in fail_first_indexes):
+            raise ApplicationError(
+                "fail_first_indexes contains an out-of-range shot",
+                type="SyntheticRecoveryInput",
+                non_retryable=True,
+            )
+        completed_results = input.get("completed_results", [])
+        if not isinstance(completed_results, list):
+            raise ApplicationError(
+                "completed_results must be a list",
+                type="SyntheticRecoveryInput",
+                non_retryable=True,
+            )
+        for item in completed_results:
+            if not isinstance(item, dict):
+                raise ApplicationError(
+                    "completed_results contains a non-object",
+                    type="SyntheticRecoveryInput",
+                    non_retryable=True,
+                )
+            shot_index = int(item["shot_index"])
+            if shot_index in self._completed:
+                raise ApplicationError(
+                    f"duplicate completed shot {shot_index}",
+                    type="SyntheticRecoveryDuplicate",
+                    non_retryable=True,
+                )
+            self._completed[shot_index] = dict(item)
+        self._approval_received = bool(input.get("approval_received", False))
+        self._seen_signal_keys = {str(value) for value in input.get("seen_signal_keys", [])}
+        return fail_first_indexes, self._approval_after
+
+    async def _fan_out(self, indexes: list[int], fail_first: set[int]) -> None:
+        pending = [index for index in indexes if index not in self._completed]
+        if not pending:
+            return
+        tasks = [
+            workflow.execute_activity(
+                synthetic_recovery_shot,
+                {
+                    "project_key": self._project_key,
+                    "shot_index": index,
+                    "fail_first": index in fail_first,
+                },
+                schedule_to_close_timeout=RECOVERY_ACTIVITY_SCHEDULE_TO_CLOSE,
+                start_to_close_timeout=RECOVERY_ACTIVITY_START_TO_CLOSE,
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(milliseconds=50),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(milliseconds=200),
+                    maximum_attempts=3,
+                    non_retryable_error_types=["SyntheticRecoveryInput"],
+                ),
+            )
+            for index in pending
+        ]
+        results = await asyncio.gather(*tasks)
+        for result in results:
+            shot_index = int(result["shot_index"])
+            if shot_index in self._completed:
+                raise ApplicationError(
+                    f"duplicate terminal result for shot {shot_index}",
+                    type="SyntheticRecoveryDuplicate",
+                    non_retryable=True,
+                )
+            self._completed[shot_index] = dict(result)
+
+    def _continue_as_new_if_suggested(
+        self,
+        fail_first_indexes: list[int],
+    ) -> None:
+        if not workflow.info().is_continue_as_new_suggested():
+            return
+        workflow.continue_as_new(
+            {
+                "project_key": self._project_key,
+                "shot_count": self._shot_count,
+                "fail_first_indexes": fail_first_indexes,
+                "approval_after": self._approval_after,
+                "expected_approval_revision": self._expected_approval_revision,
+                "completed_results": [self._completed[index] for index in sorted(self._completed)],
+                "approval_received": self._approval_received,
+                "seen_signal_keys": sorted(self._seen_signal_keys),
+            }
+        )
+
+    @workflow.run
+    async def run(self, input: dict[str, Any]) -> dict[str, Any]:
+        fail_first_indexes, approval_after = self._restore(input)
+        fail_first = set(fail_first_indexes)
+        first_batch = list(range(0, approval_after))
+        second_batch = list(range(approval_after, self._shot_count))
+
+        await self._fan_out(first_batch, fail_first)
+        self._continue_as_new_if_suggested(fail_first_indexes)
+
+        if approval_after < self._shot_count and not self._approval_received:
+            self._waiting_for_approval = True
+            await workflow.wait_condition(lambda: self._approval_received)
+            self._waiting_for_approval = False
+
+        self._continue_as_new_if_suggested(fail_first_indexes)
+        await self._fan_out(second_batch, fail_first)
+        self._continue_as_new_if_suggested(fail_first_indexes)
+
+        completed = [self._completed[index] for index in sorted(self._completed)]
+        if len(completed) != self._shot_count:
+            raise ApplicationError(
+                f"completed {len(completed)} of {self._shot_count} shots",
+                type="SyntheticRecoveryIncomplete",
+                non_retryable=True,
+            )
+        terminal_keys = [str(item["terminal_key"]) for item in completed]
+        if len(set(terminal_keys)) != self._shot_count:
+            raise ApplicationError(
+                "duplicate terminal side-effect identity detected",
+                type="SyntheticRecoveryDuplicate",
+                non_retryable=True,
+            )
+        return {
+            "project_key": self._project_key,
+            "shot_count": self._shot_count,
+            "completed_count": len(completed),
+            "terminal_keys": terminal_keys,
+            "retried_shots": [
+                int(item["shot_index"])
+                for item in completed
+                if int(item["activity_attempt"]) > 1
+            ],
+            "history_length": workflow.info().get_current_history_length(),
+            "continue_as_new_suggested": workflow.info().is_continue_as_new_suggested(),
+        }

--- a/apps/worker/src/ai_automation_force_worker/worker.py
+++ b/apps/worker/src/ai_automation_force_worker/worker.py
@@ -4,6 +4,7 @@ from temporalio.client import Client
 from temporalio.worker import Worker
 from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 
+from .recovery import SyntheticRecoveryWorkflow, synthetic_recovery_shot
 from .settings import WorkerSettings
 from .workflows import (
     SyntheticApprovalWorkflow,
@@ -29,6 +30,7 @@ def build_worker(client: Client, settings: WorkerSettings) -> Worker:
             SyntheticCancellationWorkflow,
             SyntheticApprovalWorkflow,
             SyntheticProviderAsyncWorkflow,
+            SyntheticRecoveryWorkflow,
         ],
         activities=[
             synthetic_echo,
@@ -36,6 +38,7 @@ def build_worker(client: Client, settings: WorkerSettings) -> Worker:
             synthetic_cancellable,
             synthetic_provider_submit,
             synthetic_provider_poll,
+            synthetic_recovery_shot,
         ],
         workflow_runner=SandboxedWorkflowRunner(),
     )

--- a/apps/worker/tests/test_recovery_acceptance.py
+++ b/apps/worker/tests/test_recovery_acceptance.py
@@ -98,7 +98,8 @@ def test_100_shot_workflow_survives_worker_restart_retries_approval_and_replays(
     assert len(set(result["terminal_keys"])) == 100
     assert result["retried_shots"] == expected_retries
     assert result["continue_as_new_suggested"] is False
-    assert result["history_length"] == retained_event_count
+    assert result["history_length"] <= retained_event_count
+    assert retained_event_count - result["history_length"] <= 5
     assert retained_event_count < 4096
 
     asyncio.run(Replayer(workflows=[SyntheticRecoveryWorkflow]).replay_workflow(history))

--- a/apps/worker/tests/test_recovery_acceptance.py
+++ b/apps/worker/tests/test_recovery_acceptance.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import pytest
+from temporalio.worker import Replayer
+
+from ai_automation_force_worker import (
+    SyntheticRecoveryWorkflow,
+    WorkerSettings,
+    build_worker,
+    connect_temporal,
+)
+
+TEMPORAL_INTEGRATION = os.environ.get("AAF_TEMPORAL_INTEGRATION") == "1"
+
+
+async def wait_for_approval_barrier(handle: Any) -> dict[str, Any]:
+    for _ in range(200):
+        progress = await handle.query(SyntheticRecoveryWorkflow.progress)
+        if progress["waiting_for_approval"] and progress["completed_count"] == 50:
+            return dict(progress)
+        await asyncio.sleep(0.05)
+    raise AssertionError("recovery workflow did not reach the 50-shot approval barrier")
+
+
+@pytest.mark.temporal
+@pytest.mark.skipif(not TEMPORAL_INTEGRATION, reason="AAF_TEMPORAL_INTEGRATION=1 is required")
+def test_100_shot_workflow_survives_worker_restart_retries_approval_and_replays() -> None:
+    settings = WorkerSettings()
+    expected_retries = list(range(0, 100, 10))
+
+    async def scenario() -> tuple[dict[str, Any], object, int]:
+        client = await connect_temporal(settings)
+        worker_one = build_worker(client, settings)
+        async with worker_one:
+            handle = await client.start_workflow(
+                SyntheticRecoveryWorkflow.run,
+                {
+                    "project_key": "wp8-100-shot",
+                    "shot_count": 100,
+                    "fail_first_indexes": expected_retries,
+                    "approval_after": 50,
+                    "expected_approval_revision": 7,
+                },
+                id="WFX-009800-recovery",
+                task_queue=settings.task_queue,
+            )
+            barrier = await wait_for_approval_barrier(handle)
+            assert barrier == {
+                "project_key": "wp8-100-shot",
+                "shot_count": 100,
+                "completed_count": 50,
+                "waiting_for_approval": True,
+                "approval_received": False,
+            }
+
+        # No worker is polling here. Signals are accepted by Temporal and delivered after restart.
+        await handle.signal(
+            SyntheticRecoveryWorkflow.approve,
+            {
+                "request_revision": 6,
+                "decision": "approved",
+                "signal_key": "wp8-stale",
+            },
+        )
+        await handle.signal(
+            SyntheticRecoveryWorkflow.approve,
+            {
+                "request_revision": 7,
+                "decision": "approved",
+                "signal_key": "wp8-valid",
+            },
+        )
+        await handle.signal(
+            SyntheticRecoveryWorkflow.approve,
+            {
+                "request_revision": 7,
+                "decision": "rejected",
+                "signal_key": "wp8-valid",
+            },
+        )
+
+        worker_two = build_worker(client, settings)
+        async with worker_two:
+            result = await asyncio.wait_for(handle.result(), timeout=30.0)
+            history = await handle.fetch_history()
+        return dict(result), history, len(history.events)
+
+    result, history, retained_event_count = asyncio.run(scenario())
+
+    assert result["project_key"] == "wp8-100-shot"
+    assert result["shot_count"] == 100
+    assert result["completed_count"] == 100
+    assert len(result["terminal_keys"]) == 100
+    assert len(set(result["terminal_keys"])) == 100
+    assert result["retried_shots"] == expected_retries
+    assert result["continue_as_new_suggested"] is False
+    assert result["history_length"] == retained_event_count
+    assert retained_event_count < 4096
+
+    asyncio.run(Replayer(workflows=[SyntheticRecoveryWorkflow]).replay_workflow(history))

--- a/packages/python-core/tests/test_m02_recovery_scale.py
+++ b/packages/python-core/tests/test_m02_recovery_scale.py
@@ -1,6 +1,28 @@
 from __future__ import annotations
 
-from ai_automation_force_core import operation_fingerprint
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from ai_automation_force_core import (
+    AuditFields,
+    Job,
+    JobStatus,
+    PostgresJobControlRepository,
+    operation_fingerprint,
+)
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+ALEMBIC_INI = Path(__file__).parents[1] / "alembic.ini"
+
+
+def alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
 
 
 def test_100_shot_operations_have_unique_order_independent_fingerprints() -> None:
@@ -26,3 +48,127 @@ def test_100_shot_operations_have_unique_order_independent_fingerprints() -> Non
             "project_id": operation["project_id"],
         }
         assert operation_fingerprint(reordered) == fingerprint
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_100_jobs_enqueue_reuse_and_complete_without_duplicate_terminal_events() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    repository = PostgresJobControlRepository(engine)
+    started_at = datetime.now(UTC)
+
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO core.projects (
+                        id, external_id, title, status, audience, "cast", content_format,
+                        language, target_duration_seconds, output, creative, provider_policy,
+                        created_at, updated_at
+                    ) VALUES (
+                        gen_random_uuid(), 'PRJ-009801', 'WP8 100-shot persistence', 'draft',
+                        '{}'::jsonb, '{}'::jsonb, 'short-film', 'en', 120,
+                        '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, now(), now()
+                    )
+                    """
+                )
+            )
+
+        for index in range(100):
+            now = started_at + timedelta(milliseconds=index)
+            job_id = f"JOB-{980100 + index:06d}"
+            idempotency_key = f"wp8-shot-{index:03d}-create"
+            job = Job(
+                job_id=job_id,
+                project_id="PRJ-009801",
+                job_type="synthetic-recovery-shot",
+                idempotency_key=idempotency_key,
+                retry_budget_remaining=3,
+                audit=AuditFields(created_at=now, updated_at=now, revision=1),
+            )
+            operation = {
+                "project_id": "PRJ-009801",
+                "shot_index": index,
+                "operation": "synthetic-recovery-shot",
+            }
+            created = repository.submit(job, operation)
+            assert created.action == "created"
+            reused = repository.submit(
+                job,
+                {
+                    "operation": "synthetic-recovery-shot",
+                    "shot_index": index,
+                    "project_id": "PRJ-009801",
+                },
+            )
+            assert reused.action == "reused"
+            assert reused.operation_fingerprint == created.operation_fingerprint
+
+            eligible_at = now + timedelta(seconds=1)
+            repository.transition(
+                job_id,
+                JobStatus.ELIGIBLE,
+                now=eligible_at,
+                expected_revision=1,
+            )
+            repository.claim(
+                job_id,
+                owner=f"wp8-worker-{index % 4}",
+                now=eligible_at + timedelta(seconds=1),
+                lease_for=timedelta(seconds=30),
+                expected_revision=2,
+            )
+            repository.transition(
+                job_id,
+                JobStatus.RUNNING,
+                now=eligible_at + timedelta(seconds=2),
+                expected_revision=3,
+            )
+            completed = repository.transition(
+                job_id,
+                JobStatus.COMPLETED,
+                now=eligible_at + timedelta(seconds=3),
+                expected_revision=4,
+            )
+            assert completed.revision == 5
+
+        with engine.connect() as connection:
+            job_count = connection.execute(
+                text("SELECT count(*) FROM core.jobs WHERE project_id = (SELECT id FROM core.projects WHERE external_id = 'PRJ-009801')")
+            ).scalar_one()
+            completed_count = connection.execute(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM core.jobs
+                    WHERE project_id = (
+                        SELECT id FROM core.projects WHERE external_id = 'PRJ-009801'
+                    ) AND status = 'completed'
+                    """
+                )
+            ).scalar_one()
+            terminal_event_count = connection.execute(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM core.outbox_messages AS event
+                    JOIN core.jobs AS job ON job.id = event.job_id
+                    JOIN core.projects AS project ON project.id = job.project_id
+                    WHERE project.external_id = 'PRJ-009801'
+                      AND event.event_type = 'job.status.changed'
+                      AND event.payload ->> 'status' = 'completed'
+                    """
+                )
+            ).scalar_one()
+
+        assert job_count == 100
+        assert completed_count == 100
+        assert terminal_event_count == 100
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")

--- a/packages/python-core/tests/test_m02_recovery_scale.py
+++ b/packages/python-core/tests/test_m02_recovery_scale.py
@@ -139,7 +139,15 @@ def test_100_jobs_enqueue_reuse_and_complete_without_duplicate_terminal_events()
 
         with engine.connect() as connection:
             job_count = connection.execute(
-                text("SELECT count(*) FROM core.jobs WHERE project_id = (SELECT id FROM core.projects WHERE external_id = 'PRJ-009801')")
+                text(
+                    """
+                    SELECT count(*)
+                    FROM core.jobs
+                    WHERE project_id = (
+                        SELECT id FROM core.projects WHERE external_id = 'PRJ-009801'
+                    )
+                    """
+                )
             ).scalar_one()
             completed_count = connection.execute(
                 text(

--- a/packages/python-core/tests/test_m02_recovery_scale.py
+++ b/packages/python-core/tests/test_m02_recovery_scale.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from ai_automation_force_core import operation_fingerprint
+
+
+def test_100_shot_operations_have_unique_order_independent_fingerprints() -> None:
+    operations = [
+        {
+            "project_id": "PRJ-009800",
+            "shot_id": f"SHT-{index + 1:06d}",
+            "operation": "synthetic-recovery-shot",
+            "shot_index": index,
+        }
+        for index in range(100)
+    ]
+    fingerprints = [operation_fingerprint(operation) for operation in operations]
+
+    assert len(fingerprints) == 100
+    assert len(set(fingerprints)) == 100
+
+    for operation, fingerprint in zip(operations, fingerprints, strict=True):
+        reordered = {
+            "shot_index": operation["shot_index"],
+            "operation": operation["operation"],
+            "shot_id": operation["shot_id"],
+            "project_id": operation["project_id"],
+        }
+        assert operation_fingerprint(reordered) == fingerprint


### PR DESCRIPTION
## Scope
Implements the final M02-WP8 recovery/load acceptance package using synthetic, spend-free workflows only.

## Delivered
- dedicated `SyntheticRecoveryWorkflow`
- 100-shot fan-out/join with deterministic fail-first retry injection
- 50-shot manual approval barrier with stale/duplicate signal suppression
- worker-offline signal delivery and second-worker resume acceptance
- stable terminal shot identities with duplicate-terminal detection
- retained Temporal history replay
- native Temporal Continue-As-New suggestion policy at safe batch boundaries
- API lifespan restart independence from persisted job/workflow references
- 100 canonical PostgreSQL jobs with duplicate submit reuse and exactly 100 terminal completion events
- existing WP4/WP5/WP6 acceptance remains covered for cancellation, approval and duplicate callback behavior

## Exact accepted candidate
Head: `ba2d5ff6cb2833c0dd854992fa1d65a8eb119c3e`

- Core Domain Contracts #118: run `33258739071` / job `99116892924` — GREEN
- Durable Control Plane #56: run `33258739029` / job `99116892818` — GREEN

Both jobs passed Ruff, mypy, PostgreSQL integration, schema/OpenAPI verification, compile checks; Durable also passed the full PostgreSQL + Temporal integration suite including worker restart, approval resume, 100-shot recovery and replay.

## Safety boundary
No real provider credentials/calls/spend, no media/object storage, no M03+ implementation.

## Superseded without code change
This draft PR is closed only because the connected GitHub ready-for-review mutation fails at the connector GraphQL schema layer (`Repository.fullDatabaseId`). The exact same branch/head is being opened as a non-draft replacement PR. No executable code or candidate SHA changed.