### PR TITLE
M03 governance: record approval and storage-stack revalidation

### DIFF
--- a/checkpoints/2026-08-29-m03-development-approved.md
+++ b/checkpoints/2026-08-29-m03-development-approved.md
@@ -1,0 +1,73 @@
+# M03 Development Approved
+
+Date: 2026-08-29
+
+Status: **M03_DEVELOPMENT_APPROVED_WP1_ACTIVE**
+
+## Fresh operator authorization
+
+The operator explicitly authorized M03 executable development with:
+
+`Milestone 3 development approve — start.`
+
+The authorization is fresh, milestone-specific, and applies to the planned M03 scope only.
+
+## Entry criteria
+
+M03 entry criteria are satisfied:
+
+- P0 complete;
+- M01 accepted;
+- M02 accepted and closed at `acf8d30f04124290cab97eab702c2cca6b9e3dcb`;
+- explicit M03 consent received;
+- object-storage SDK/local integration stack revalidated in `docs/architecture/M03-CURRENT-STACK-REVALIDATION-2026-08-29.md`.
+
+## Revalidated implementation direction
+
+- canonical SDK boundary: synchronous `boto3 1.43.80` / `botocore 1.43.80`;
+- provider-neutral core contracts; boto3 shapes must not leak into canonical models;
+- deterministic filesystem adapter for local/unit development;
+- preferred future network-level S3 compatibility target: Adobe S3Mock 5.1.0;
+- Moto 5.2.3 permitted for focused test fixtures;
+- MinIO Community Server is not a mandatory new CI dependency because its upstream community repository is archived/source-only;
+- aiobotocore is not introduced in WP1 because current `3.9.0` does not support the current botocore line.
+
+## Current executable target
+
+**M03-WP1 — Storage adapter and object metadata**
+
+WP1 acceptance requires:
+
+- stable storage/object IDs and canonical key rules;
+- provider-neutral storage adapter contract;
+- safe filesystem implementation;
+- S3-compatible boto3 implementation;
+- SHA-256/size/MIME/region/version/ETag metadata semantics;
+- path traversal/root escape protection;
+- no credentials in domain state/logs;
+- tests for deterministic keying, hashing and adapter behavior;
+- existing M01/M02 regression gates remain green.
+
+## M03 work-package sequence
+
+1. WP1 — storage adapter and object metadata;
+2. WP2 — upload sessions;
+3. WP3 — quarantine/probe/security;
+4. WP4 — asset lineage/provenance/rights;
+5. WP5 — derivatives/proxies;
+6. WP6 — signed delivery;
+7. WP7 — retention/archive/delete/export primitives;
+8. WP8 — milestone acceptance;
+9. M03 closure and fresh M04 consent gate.
+
+## Scope boundary
+
+M03 does not authorize:
+
+- M04 character/entity library implementation;
+- AI generation provider execution or provider spend;
+- public publishing/social execution;
+- full web/mobile/auth/billing features;
+- autonomous destructive lifecycle actions outside the M03 plan.
+
+GitHub remains canonical. Linear mirrors verified execution state.

--- a/checkpoints/LATEST.md
+++ b/checkpoints/LATEST.md
@@ -1,68 +1,69 @@
 # Latest Checkpoint
 
 Current checkpoint:
-`checkpoints/2026-08-29-m02-complete.md`
+`checkpoints/2026-08-29-m03-development-approved.md`
 
-Current phase: **M03 — Asset Storage and Provenance (consent gate)**
+Current phase: **M03 — Asset Storage and Provenance**
 
-Status: **M02_COMPLETE_M03_READY_FOR_CONSENT**
+Status: **M03_DEVELOPMENT_APPROVED_WP1_ACTIVE**
 
 ## Completed baseline
 
 - M01 complete: `424b76214ab8eb94d3205a2eba2d75cf4ffa0cc7`
-- M02 WP1 — FastAPI scaffold: `c8591278ed0fc5624e1bff6169d7684ad36e01dd`
-- M02 WP2 — Temporal foundation: `29a3432480027f63f9c572782297e8707c501730`
-- M02 WP3 — job/idempotency/outbox: `0de15a90cff5f44eeccdaf1d667aba69b890bbcc`
-- M02 WP4 — retry/circuit/cancel: `54c613a5adfa95c6ebc5d6699cf7dbafa140d68e`
-- M02 WP5 — durable approval waits: `f1169d6a68b1a45248d343df58b882d8d15db7b6`
-- M02 governance reconciliation: `12a4e33678beb6e6c5fce41f9c8b5c312083aa3a`
-- M02 WP6 — fake async provider callback/reconciliation: `2b93c023249852d29862abbe36f6b2f46f9f02d4`
-- M02 WP7 — job control API + durable SSE progress: `b1e99d0da6b38ae3c826c15bb594c40b8c34d607`
-- M02 WP7 completion checkpoint: `80e75b55e9d77803f55b47d80485d45317b55c58`
-- M02 WP8 — replay/restart/100-shot recovery acceptance: `bb82c3bd115723504cf233e0cab93ca9513d10a8`
+- M02 complete/closure checkpoint merge: `acf8d30f04124290cab97eab702c2cca6b9e3dcb`
+- M02 final executable WP8 merge: `bb82c3bd115723504cf233e0cab93ca9513d10a8`
 
-## M02 final verified acceptance
+## M03 development consent
 
-WP8 accepted executable head:
-`ba2d5ff6cb2833c0dd854992fa1d65a8eb119c3e`
-
-Fresh required CI on replacement PR #22:
-- Core Domain Contracts #119: run `33258831160` / job `99117141725` — GREEN
-- Durable Control Plane #57: run `33258831136` / job `99117141664` — GREEN
-
-M02 closure evidence:
-`checkpoints/2026-08-29-m02-complete.md`
-
-The final M02 acceptance proves synthetic 100-shot fan-out/join, deterministic retries, worker restart/resume, API restart independence, approval wait/resume, retained Temporal history replay, canonical idempotency and exactly one terminal completion event per accepted 100-job persistence fixture. Continue-As-New is governed by Temporal's native suggestion at safe batch boundaries; the 100-shot acceptance did not falsely claim a rollover when the server did not suggest one.
-
-## Linear mirror
-
-M2 WP1-WP8 and governance reconciliation are all Done after canonical evidence reconciliation.
-
-## Next planned milestone
-
-**M03 — Asset Storage and Provenance**
-
-Plan:
-`docs/milestones/M03/PLAN.md`
-
-Consent brief:
-`docs/architecture/M03-DEVELOPMENT-CONSENT-BRIEF.md`
-
-Planned scope includes S3-compatible storage abstraction, upload sessions, quarantine/media probing, asset lineage/provenance/rights, derivatives/proxies, signed delivery, retention/archive/delete/export primitives and milestone acceptance.
-
-## M03 consent gate
-
-M03 executable development is **not authorized** yet. M02 authorization is consumed and is not reusable.
-
-Generic `continue`, `next`, `resume`, `audit`, planning or research instructions are non-authorizing for M03 executable work.
-
-A valid explicit authorization phrase is:
+Fresh explicit operator authorization received on 2026-08-29:
 
 `Milestone 3 development approve — start.`
 
-Before the first executable M03 work package, current object-storage/provider SDK versions and the local test-storage stack must be revalidated and recorded canonically.
+M03 consent checkpoint:
+`checkpoints/2026-08-29-m03-development-approved.md`
 
-Until explicit M03 consent is received, only planning, research/revalidation, documentation and issue/milestone reconciliation may continue.
+Current stack revalidation:
+`docs/architecture/M03-CURRENT-STACK-REVALIDATION-2026-08-29.md`
+
+## Revalidated storage baseline
+
+- Python runtime remains 3.12+.
+- Initial canonical S3 SDK: boto3/botocore `1.43.80`.
+- `aiobotocore 3.9.0` is not introduced because its current botocore compatibility range does not include `1.43.80`.
+- Filesystem adapter is the deterministic local/unit implementation.
+- Preferred future network-level S3 CI target: Adobe S3Mock `5.1.0`.
+- Moto `5.2.3` may be used for focused fixtures.
+- MinIO Community Server is not a mandatory new CI dependency because the upstream community repository is archived/source-only; S3/MinIO protocol compatibility remains a target.
+
+## Current executable target
+
+**M03-WP1 — Storage adapter and object metadata**
+
+Required WP1 scope:
+
+- provider-neutral storage adapter interface;
+- stable storage object IDs/object keys;
+- deterministic filesystem adapter with path containment and atomic writes;
+- S3-compatible boto3 adapter with configurable endpoint/region/addressing;
+- SHA-256, MIME, byte size, region, version ID and ETag metadata semantics;
+- credentials/configuration never become canonical domain state;
+- no upload-session API (WP2), quarantine/probe pipeline (WP3), derivatives (WP5), signed delivery (WP6), or retention implementation (WP7) yet;
+- exact-head required CI and existing M01/M02 regressions must be green before merge.
+
+## Remaining M03 sequence
+
+1. WP1 — storage adapter and object metadata;
+2. WP2 — upload sessions;
+3. WP3 — quarantine/probe/security;
+4. WP4 — asset lineage/provenance/rights;
+5. WP5 — derivatives/proxies;
+6. WP6 — signed delivery;
+7. WP7 — retention/archive/delete/export primitives;
+8. WP8 — acceptance;
+9. M03 closure and fresh M04 consent gate.
+
+## Consent boundary
+
+M03 authorization does not authorize M04+ executable work. Generic continuation commands may continue already-authorized M03 work but cannot expand beyond M03 or authorize M04.
 
 GitHub remains canonical for engineering contracts, implementation evidence and checkpoints. Linear mirrors verified execution state.

--- a/docs/architecture/M03-CURRENT-STACK-REVALIDATION-2026-08-29.md
+++ b/docs/architecture/M03-CURRENT-STACK-REVALIDATION-2026-08-29.md
@@ -1,0 +1,131 @@
+# M03 Current Stack Revalidation — 2026-08-29
+
+Status: **REVALIDATED_FOR_M03_ENTRY**
+
+## Operator authorization
+
+Fresh explicit operator authorization received on 2026-08-29:
+
+`Milestone 3 development approve — start.`
+
+This authorizes executable M03 work within `docs/milestones/M03/PLAN.md`. It does not authorize M04+ or expand the M03 scope.
+
+## Revalidation requirement
+
+`checkpoints/LATEST.md` required current object-storage/provider SDK versions and the local test-storage stack to be revalidated before the first executable M03 work package.
+
+Revalidation was performed against current upstream/PyPI information on 2026-08-29.
+
+## Python S3 SDK decision
+
+### boto3 / botocore
+
+Observed current stable line:
+
+- `boto3 1.43.80`
+- `botocore 1.43.80`
+- release date: 2026-08-25
+- Python support includes Python 3.12 used by this repository
+- Apache-2.0
+
+Decision: **use synchronous boto3 as the initial S3-compatible adapter SDK**.
+
+Reasons:
+
+- AWS-maintained reference S3 client;
+- works with custom S3-compatible endpoints;
+- stable production status;
+- avoids introducing an async compatibility matrix into the canonical storage boundary;
+- blocking SDK calls belong in worker Activities or bounded thread/off-event-loop execution, not inside deterministic Temporal workflow code.
+
+The canonical domain API remains provider-neutral and must not expose boto3 request/response shapes.
+
+### aiobotocore
+
+Observed current release:
+
+- `aiobotocore 3.9.0`
+- release date: 2026-08-01
+- supports Python 3.12
+- its declared botocore range is `>=1.43.3,<1.43.57`
+
+This does not cover current botocore `1.43.80`.
+
+Decision: **do not add aiobotocore in M03-WP1**. Revisit only if an async transport is materially required and its botocore compatibility is revalidated at that time.
+
+## Local S3-compatible integration target
+
+### MinIO status change
+
+The historical M03 plan mentioned a local MinIO/filesystem test adapter. Current upstream state changed materially:
+
+- the `minio/minio` community repository was archived on 2026-04-25;
+- the community edition is described as source-only distribution;
+- historical precompiled releases are no longer maintained.
+
+Decision: **do not make MinIO Community Server a new mandatory CI dependency**. Preserve MinIO/S3 compatibility as a protocol target, but do not anchor M03 acceptance to an archived server distribution.
+
+The MinIO Python client remains available, but M03-WP1 does not use it as the canonical SDK because boto3 provides the reference S3-compatible boundary required by the plan.
+
+## Test stack decision
+
+Two active test options were revalidated:
+
+### Adobe S3Mock
+
+- current 5.x line is actively developed;
+- current immutable Docker release observed: `5.1.0`;
+- supports Docker integration and S3 multipart/checksum behavior;
+- suitable for network-level S3-compatible integration tests.
+
+### Moto
+
+- current release observed: `5.2.3` (2026-08-22);
+- Python 3.12 supported;
+- Apache-2.0;
+- suitable for fast Python-level S3 behavior tests/mocks.
+
+Decision for M03:
+
+1. **filesystem adapter** for deterministic local/unit tests and development without network/object-store dependency;
+2. **boto3 S3 adapter** as the production-facing S3-compatible implementation boundary;
+3. **Adobe S3Mock 5.1.0** as the preferred network-level CI compatibility target when container integration is introduced;
+4. **Moto 5.2.3** may be used for focused unit/integration fixtures where a full network store is unnecessary;
+5. MinIO remains an optional compatibility target and is not required for merge acceptance.
+
+## M03-WP1 implementation boundary
+
+WP1 may now implement:
+
+- provider-neutral object metadata/value contracts;
+- storage adapter protocol/interface;
+- filesystem adapter with root containment and atomic writes;
+- S3-compatible boto3 adapter with custom endpoint/region/path-style configuration;
+- stable storage-object identity and object-key rules;
+- SHA-256, MIME, byte-size, ETag/version/checksum metadata where trustworthy;
+- no upload-session API yet (WP2);
+- no quarantine/probe pipeline yet (WP3);
+- no derivatives/signed delivery/retention implementation yet (WP5-WP7).
+
+## Security constraints
+
+- no arbitrary filesystem paths from callers;
+- object keys are normalized canonical identities, never trusted host paths;
+- credentials remain configuration/secrets, never canonical domain state or logs;
+- endpoint URLs must not embed credentials;
+- TLS verification defaults on; insecure local test mode must be explicit;
+- do not treat ETag as a universal content hash;
+- SHA-256 content digest is canonical when content bytes are available;
+- no large binary fixture is committed to Git.
+
+## Source evidence
+
+Revalidation sources:
+
+- PyPI `boto3` / `botocore` current release metadata;
+- PyPI `aiobotocore 3.9.0` dependency metadata;
+- `minio/minio` GitHub repository status/distribution notice;
+- `adobe/S3Mock` GitHub releases/current 5.x changelog;
+- PyPI `moto 5.2.3` metadata.
+
+Mutable versions must be revalidated again if M03 execution crosses a meaningful dependency-update boundary.


### PR DESCRIPTION
## Scope
Documentation/governance only before first executable M03 work package.

Records fresh explicit operator authorization:
`Milestone 3 development approve — start.`

## Revalidation
- boto3/botocore 1.43.80 selected as initial S3-compatible SDK boundary
- aiobotocore 3.9.0 excluded from WP1 because its current botocore range does not cover 1.43.80
- filesystem adapter retained for deterministic local/unit use
- Adobe S3Mock 5.1.0 preferred for future network-level S3 CI
- Moto 5.2.3 permitted for focused fixtures
- MinIO Community Server no longer mandatory because current upstream community distribution is archived/source-only

## Governance
Advances `LATEST.md` to `M03_DEVELOPMENT_APPROVED_WP1_ACTIVE` and keeps M04+ blocked behind fresh consent.

## Executable impact
None. No runtime, migration, API or storage adapter code in this PR.