### PR TITLE
M03-WP4: establish append-only asset provenance persistence

### DIFF
--- a/checkpoints/2026-08-30-m03-wp4-review-checkpoint.md
+++ b/checkpoints/2026-08-30-m03-wp4-review-checkpoint.md
@@ -1,0 +1,73 @@
+# M03-WP4 — Review Checkpoint
+
+Status: `VERIFYING / IN REVIEW`
+
+Repository: `Vertex-Systems-Network/ai-automation-force`
+Linear: `ABD-203`
+Pull request: `#33`
+Branch: `agent/20260830-ai-automation-force-abd-203`
+Accepted base: `a92388a287051ddffe123b5cf90d74fa17553b41`
+Implementation head before this checkpoint: `1790674bcf692d31fd0d816d01736499de504583`
+
+## Scope completed in the implementation candidate
+
+- append-only `AssetProvenanceRecord` contracts for upload/import/provider/derived origins;
+- additive/reversible migration `0011_asset_provenance`;
+- restrictive foreign-key linkage to canonical assets, projects, storage objects and rights records;
+- immutable create/noop/conflict persistence;
+- fail-closed project-boundary, canonical/storage hash, rights and parent-derived provenance checks;
+- asset usability evaluation without duplicating `Asset.canonical_status` or `RightsRecord` authority;
+- canonical package exports and PostgreSQL acceptance coverage.
+
+## Data / migration impact
+
+- adds `core.asset_provenance_records` only;
+- source assets remain immutable and are not overwritten by derivatives;
+- downgrade removes only the WP4 provenance table/indexes;
+- no destructive backfill is performed;
+- no external provider credentials, spend or production media routing is introduced.
+
+Recovery class: `ROLLBACK WITH COMPATIBILITY` while no later schema depends on migration 0011. After downstream migrations depend on it, prefer forward fix unless the dependency chain is explicitly rolled back in reverse order.
+
+## Security / rights review
+
+The candidate is fail-closed for cross-project references, mismatched storage/canonical hashes, mismatched rights links and derived records without a valid parent path. Rights/publication authority remains with the existing rights model; provenance evidence does not self-authorize publication.
+
+No secrets, provider credentials or unrestricted AI authority are added.
+
+## Verification evidence
+
+Exact implementation head `1790674bcf692d31fd0d816d01736499de504583`:
+
+- `Core Domain Contracts` — PASS;
+- `Durable Control Plane` — PASS.
+
+These checks are necessary but not sufficient for promotion.
+
+## Review state
+
+- PR remains draft;
+- submitted independent reviews: `0` at this checkpoint;
+- unresolved review threads: `0` at the latest read;
+- current review classification: `SELF REVIEW / automated exact-head verification only` until a genuine independent review is submitted.
+
+## Repository-governance gap
+
+Live `main` protection/ruleset enforcement is currently absent and is tracked separately in Linear `ABD-265`. That governance hardening must not be mixed into the WP4 implementation diff or used to weaken existing tests/checks.
+
+## Known limitations / locked scope
+
+- no WP5 derivative generation;
+- no WP6 signed delivery;
+- no WP7 retention/archive/delete orchestration;
+- no M04+ work;
+- no claim that green CI alone makes WP4 production-released;
+- no promotion claim while the implementation review remains unresolved.
+
+## Next safe action
+
+1. re-run the canonical workflows on the checkpoint descendant head;
+2. perform final WP4 diff/security/data review against the accepted base;
+3. obtain independent review when available, otherwise preserve explicit `SELF REVIEW` status;
+4. promote only through the repository's normal reviewed integration path;
+5. after accepted merge, update the milestone/checkpoint with the exact merge SHA and accepted CI evidence before starting WP5.

--- a/checkpoints/2026-08-30-m03-wp4-review-checkpoint.md
+++ b/checkpoints/2026-08-30-m03-wp4-review-checkpoint.md
@@ -1,13 +1,13 @@
 # M03-WP4 — Review Checkpoint
 
-Status: `VERIFYING / IN REVIEW`
+Status: `REVIEWED / GOVERNANCE BLOCKED`
 
 Repository: `Vertex-Systems-Network/ai-automation-force`
 Linear: `ABD-203`
 Pull request: `#33`
 Branch: `agent/20260830-ai-automation-force-abd-203`
 Accepted base: `a92388a287051ddffe123b5cf90d74fa17553b41`
-Implementation head before this checkpoint: `1790674bcf692d31fd0d816d01736499de504583`
+Final reviewed implementation code head: `df214410f040033097b3d2e018e3a8db3d3deb22`
 
 ## Scope completed in the implementation candidate
 
@@ -16,6 +16,7 @@ Implementation head before this checkpoint: `1790674bcf692d31fd0d816d01736499de5
 - restrictive foreign-key linkage to canonical assets, projects, storage objects and rights records;
 - immutable create/noop/conflict persistence;
 - fail-closed project-boundary, canonical/storage hash, rights and parent-derived provenance checks;
+- fail-closed chronology: provenance evidence cannot predate the canonical asset it describes;
 - asset usability evaluation without duplicating `Asset.canonical_status` or `RightsRecord` authority;
 - canonical package exports and PostgreSQL acceptance coverage.
 
@@ -29,31 +30,45 @@ Implementation head before this checkpoint: `1790674bcf692d31fd0d816d01736499de5
 
 Recovery class: `ROLLBACK WITH COMPATIBILITY` while no later schema depends on migration 0011. After downstream migrations depend on it, prefer forward fix unless the dependency chain is explicitly rolled back in reverse order.
 
-## Security / rights review
+## Security / rights / integrity review
 
-The candidate is fail-closed for cross-project references, mismatched storage/canonical hashes, mismatched rights links and derived records without a valid parent path. Rights/publication authority remains with the existing rights model; provenance evidence does not self-authorize publication.
+The candidate is fail-closed for:
 
-No secrets, provider credentials or unrestricted AI authority are added.
+- cross-project references;
+- mismatched storage/canonical hashes;
+- mismatched rights links;
+- derived records without a valid parent path;
+- provenance timestamps earlier than canonical asset creation.
+
+Rights/publication authority remains with the existing rights model; provenance evidence does not self-authorize publication. No secrets, provider credentials or unrestricted AI authority are added.
+
+The chronology defect was found during SELF REVIEW and corrected in-scope with a focused PostgreSQL regression rather than broad refactoring.
 
 ## Verification evidence
 
-Exact implementation head `1790674bcf692d31fd0d816d01736499de504583`:
+Exact reviewed implementation code head `df214410f040033097b3d2e018e3a8db3d3deb22`:
 
-- `Core Domain Contracts` — PASS;
-- `Durable Control Plane` — PASS.
+- `Core Domain Contracts` run `33304722513` — PASS;
+- `Durable Control Plane` run `33304722516` — PASS.
 
-These checks are necessary but not sufficient for promotion.
+The SELF REVIEW is recorded on PR #33 against this exact code head. These checks establish implementation validity but do not override repository-governance requirements.
 
 ## Review state
 
 - PR remains draft;
-- submitted independent reviews: `0` at this checkpoint;
-- unresolved review threads: `0` at the latest read;
-- current review classification: `SELF REVIEW / automated exact-head verification only` until a genuine independent review is submitted.
+- submitted independent approving reviews: `0`;
+- current review classification: `SELF REVIEW`;
+- no independent-review claim is made.
 
-## Repository-governance gap
+## Repository-governance blocker
 
-Live `main` protection/ruleset enforcement is currently absent and is tracked separately in Linear `ABD-265`. That governance hardening must not be mixed into the WP4 implementation diff or used to weaken existing tests/checks.
+Live `main` protection/ruleset enforcement is absent and is tracked as Linear `ABD-265`.
+
+The available connected GitHub capability can read branch protection/rulesets but cannot mutate hosted protection settings. Therefore this checkpoint does not fake or document an unenforced protection as complete.
+
+Before WP4 promotion under the adopted Universal Master Prompt governance baseline, require live repository read-back showing the intended protected-main controls are actually effective, or an explicit approved repository exception that records the residual risk and review model.
+
+Do not mix this hosted-admin remediation into the WP4 implementation diff and do not weaken tests/checks to bypass it.
 
 ## Known limitations / locked scope
 
@@ -61,13 +76,13 @@ Live `main` protection/ruleset enforcement is currently absent and is tracked se
 - no WP6 signed delivery;
 - no WP7 retention/archive/delete orchestration;
 - no M04+ work;
-- no claim that green CI alone makes WP4 production-released;
-- no promotion claim while the implementation review remains unresolved.
+- no claim that green CI alone makes WP4 released or production-verified;
+- no WP5 implementation while WP4 promotion remains blocked.
 
-## Next safe action
+## Exact next safe action
 
-1. re-run the canonical workflows on the checkpoint descendant head;
-2. perform final WP4 diff/security/data review against the accepted base;
-3. obtain independent review when available, otherwise preserve explicit `SELF REVIEW` status;
-4. promote only through the repository's normal reviewed integration path;
-5. after accepted merge, update the milestone/checkpoint with the exact merge SHA and accepted CI evidence before starting WP5.
+1. resolve `ABD-265` with live GitHub protection/ruleset read-back evidence (or an explicit approved exception if protection genuinely cannot be enabled);
+2. re-read `main`, PR base/head, review state and exact current checks after that hosted-admin change;
+3. if branch freshness or check identity changed, reconcile and run fresh exact-head Core + Durable gates;
+4. promote WP4 only through the accepted repository integration path;
+5. after accepted merge, record exact merge/evidence and activate only the next documented WP5 boundary.

--- a/packages/python-core/migrations/sql/0011_asset_provenance_down.sql
+++ b/packages/python-core/migrations/sql/0011_asset_provenance_down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS core.idx_asset_provenance_storage;
+
+DROP INDEX IF EXISTS core.idx_asset_provenance_asset_created;
+
+DROP TABLE IF EXISTS core.asset_provenance_records;

--- a/packages/python-core/migrations/sql/0011_asset_provenance_up.sql
+++ b/packages/python-core/migrations/sql/0011_asset_provenance_up.sql
@@ -1,0 +1,44 @@
+CREATE TABLE core.asset_provenance_records (
+    id uuid PRIMARY KEY,
+    external_id text NOT NULL UNIQUE,
+    schema_version smallint NOT NULL DEFAULT 1,
+    asset_id uuid NOT NULL,
+    project_id uuid,
+    storage_object_id uuid,
+    source_kind text NOT NULL,
+    source_reference text,
+    import_reference text,
+    provider_reference text,
+    content_sha256 text NOT NULL,
+    rights_record_id uuid,
+    created_at timestamptz NOT NULL,
+    CONSTRAINT fk_asset_provenance_asset FOREIGN KEY (asset_id)
+        REFERENCES core.assets(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_asset_provenance_project FOREIGN KEY (project_id)
+        REFERENCES core.projects(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_asset_provenance_storage FOREIGN KEY (storage_object_id)
+        REFERENCES core.storage_objects(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_asset_provenance_rights FOREIGN KEY (rights_record_id)
+        REFERENCES core.rights_records(id) ON DELETE RESTRICT,
+    CONSTRAINT ck_asset_provenance_external CHECK (external_id ~ '^PRV-[0-9]{6,20}$'),
+    CONSTRAINT ck_asset_provenance_source_kind CHECK (
+        source_kind IN ('upload', 'import', 'provider', 'derived')
+    ),
+    CONSTRAINT ck_asset_provenance_sha256 CHECK (content_sha256 ~ '^[a-f0-9]{64}$'),
+    CONSTRAINT ck_asset_provenance_upload_evidence CHECK (
+        source_kind <> 'upload' OR storage_object_id IS NOT NULL
+    ),
+    CONSTRAINT ck_asset_provenance_import_evidence CHECK (
+        source_kind <> 'import' OR import_reference IS NOT NULL
+    ),
+    CONSTRAINT ck_asset_provenance_provider_evidence CHECK (
+        source_kind <> 'provider' OR provider_reference IS NOT NULL
+    )
+);
+
+CREATE INDEX idx_asset_provenance_asset_created
+    ON core.asset_provenance_records (asset_id, created_at, id);
+
+CREATE INDEX idx_asset_provenance_storage
+    ON core.asset_provenance_records (storage_object_id)
+    WHERE storage_object_id IS NOT NULL;

--- a/packages/python-core/migrations/versions/20260830_0011_asset_provenance.py
+++ b/packages/python-core/migrations/versions/20260830_0011_asset_provenance.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "20260830_0011"
+down_revision = "20260829_0010"
+branch_labels = None
+depends_on = None
+
+_SQL_DIR = Path(__file__).resolve().parents[1] / "sql"
+
+
+def _statements(filename: str) -> list[str]:
+    text = (_SQL_DIR / filename).read_text(encoding="utf-8")
+    return [statement.strip() for statement in text.split(";\n") if statement.strip()]
+
+
+def _execute(filename: str) -> None:
+    for statement in _statements(filename):
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute("0011_asset_provenance_up.sql")
+
+
+def downgrade() -> None:
+    _execute("0011_asset_provenance_down.sql")

--- a/packages/python-core/src/ai_automation_force_core/__init__.py
+++ b/packages/python-core/src/ai_automation_force_core/__init__.py
@@ -34,6 +34,10 @@ from lullabies_core.provenance import (
     AssetProvenanceRecord,
     AssetProvenanceRecordId,
     AssetProvenanceSource,
+    AssetUsabilityDecision,
+    AssetUsabilityPolicy,
+    AssetUsabilityRejection,
+    evaluate_asset_usability,
 )
 from lullabies_core.storage import (
     FilesystemStorageAdapter,
@@ -73,6 +77,9 @@ __all__ = [
     "AssetProvenanceRecord",
     "AssetProvenanceRecordId",
     "AssetProvenanceSource",
+    "AssetUsabilityDecision",
+    "AssetUsabilityPolicy",
+    "AssetUsabilityRejection",
     "DirectUploadGrant",
     "FilesystemStorageAdapter",
     "MediaProbeResult",
@@ -116,6 +123,7 @@ __all__ = [
     "build_object_key",
     "build_upload_object_key",
     "detect_magic_mime",
+    "evaluate_asset_usability",
     "evaluate_quarantine",
     "sha256_bytes",
     "storage_object_from_write",

--- a/packages/python-core/src/ai_automation_force_core/__init__.py
+++ b/packages/python-core/src/ai_automation_force_core/__init__.py
@@ -20,6 +20,8 @@ from lullabies_core.media_security import (
     evaluate_quarantine,
 )
 from lullabies_core.persistence import (
+    AssetProvenancePersistResult,
+    PostgresAssetProvenanceRepository,
     PostgresQuarantineInspectionRepository,
     PostgresStorageObjectRepository,
     PostgresUploadSessionRepository,
@@ -27,6 +29,11 @@ from lullabies_core.persistence import (
     QuarantinePersistResult,
     StorageObjectPersistResult,
     UploadPersistenceConflictError,
+)
+from lullabies_core.provenance import (
+    AssetProvenanceRecord,
+    AssetProvenanceRecordId,
+    AssetProvenanceSource,
 )
 from lullabies_core.storage import (
     FilesystemStorageAdapter,
@@ -62,12 +69,17 @@ from lullabies_core.upload_session import (
 
 __all__ = [
     *_legacy_all,
+    "AssetProvenancePersistResult",
+    "AssetProvenanceRecord",
+    "AssetProvenanceRecordId",
+    "AssetProvenanceSource",
     "DirectUploadGrant",
     "FilesystemStorageAdapter",
     "MediaProbeResult",
     "MediaProbeStatus",
     "MediaSecurityPolicy",
     "MultipartPartGrant",
+    "PostgresAssetProvenanceRepository",
     "PostgresQuarantineInspectionRepository",
     "PostgresStorageObjectRepository",
     "PostgresUploadSessionRepository",

--- a/packages/python-core/src/lullabies_core/persistence/__init__.py
+++ b/packages/python-core/src/lullabies_core/persistence/__init__.py
@@ -12,6 +12,7 @@ from .approval_wait import (
     ApprovalWaitVersionConflictError,
     PostgresApprovalWaitRepository,
 )
+from .asset_provenance import AssetProvenancePersistResult, PostgresAssetProvenanceRepository
 from .circuit_breaker import CircuitBreakerConflictError, PostgresCircuitBreakerRepository
 from .control_surface import PostgresControlSurfaceRepository
 from .job_control import (
@@ -41,6 +42,7 @@ __all__ = [
     "ApprovalWaitConflictError",
     "ApprovalWaitExpiredError",
     "ApprovalWaitVersionConflictError",
+    "AssetProvenancePersistResult",
     "CircuitBreakerConflictError",
     "JobIdempotencyConflictError",
     "JobLeaseConflictError",
@@ -53,6 +55,7 @@ __all__ = [
     "PersistenceReferenceError",
     "PersistenceShapeError",
     "PostgresApprovalWaitRepository",
+    "PostgresAssetProvenanceRepository",
     "PostgresCircuitBreakerRepository",
     "PostgresControlSurfaceRepository",
     "PostgresJobControlRepository",

--- a/packages/python-core/src/lullabies_core/persistence/asset_provenance.py
+++ b/packages/python-core/src/lullabies_core/persistence/asset_provenance.py
@@ -42,8 +42,9 @@ class PostgresAssetProvenanceRepository:
         }
         missing = [name for name in required if f"core.{name}" not in metadata.tables]
         if missing:
+            missing_tables = ", ".join(sorted(missing))
             raise PersistenceReferenceError(
-                f"asset provenance persistence tables are not migrated: {', '.join(sorted(missing))}"
+                f"asset provenance persistence tables are not migrated: {missing_tables}"
             )
         self.provenance_table = metadata.tables["core.asset_provenance_records"]
         self.asset_parents_table = metadata.tables["core.asset_parents"]
@@ -64,7 +65,8 @@ class PostgresAssetProvenanceRepository:
                             canonical.provenance_record_id,
                         )
                     raise PersistenceConflictError(
-                        f"asset provenance {canonical.provenance_record_id} already has different data"
+                        "asset provenance "
+                        f"{canonical.provenance_record_id} already has different data"
                     )
 
                 asset = self._require_external(
@@ -158,7 +160,8 @@ class PostgresAssetProvenanceRepository:
             )
         if str(storage["sha256"]) != str(asset["sha256"]):
             raise PersistenceConflictError(
-                f"storage object {record.storage_object_id} hash does not match asset {record.asset_id}"
+                f"storage object {record.storage_object_id} hash does not match "
+                f"asset {record.asset_id}"
             )
         return cast(UUID, storage["id"])
 

--- a/packages/python-core/src/lullabies_core/persistence/asset_provenance.py
+++ b/packages/python-core/src/lullabies_core/persistence/asset_provenance.py
@@ -79,6 +79,7 @@ class PostgresAssetProvenanceRepository:
                 storage_id = self._validate_storage(connection, canonical, asset)
                 rights_id = self._validate_rights(connection, canonical, asset)
                 self._validate_content_hash(canonical, asset)
+                self._validate_chronology(canonical, asset)
                 self._validate_derived_parent(connection, canonical, asset)
 
                 connection.execute(
@@ -199,6 +200,14 @@ class PostgresAssetProvenanceRepository:
         if record.content_sha256 != str(asset["sha256"]):
             raise PersistenceConflictError(
                 f"provenance hash does not match canonical asset {record.asset_id}"
+            )
+
+    @staticmethod
+    def _validate_chronology(record: AssetProvenanceRecord, asset: RowMapping) -> None:
+        if record.created_at < asset["created_at"]:
+            raise PersistenceConflictError(
+                f"asset provenance {record.provenance_record_id} cannot predate "
+                f"canonical asset {record.asset_id}"
             )
 
     def _validate_derived_parent(

--- a/packages/python-core/src/lullabies_core/persistence/asset_provenance.py
+++ b/packages/python-core/src/lullabies_core/persistence/asset_provenance.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, cast
+from uuid import UUID, uuid4
+
+from sqlalchemy import MetaData, insert, select
+from sqlalchemy.engine import Connection, Engine, RowMapping
+from sqlalchemy.exc import IntegrityError
+
+from ..common import SCHEMA_VERSION, SchemaVersion
+from ..provenance import AssetProvenanceRecord, AssetProvenanceSource
+from ._db import (
+    PersistenceConflictError,
+    PersistenceNotFoundError,
+    PersistenceReferenceError,
+)
+
+AssetProvenancePersistAction = Literal["created", "noop"]
+
+
+@dataclass(frozen=True)
+class AssetProvenancePersistResult:
+    action: AssetProvenancePersistAction
+    provenance_record_id: str
+
+
+class PostgresAssetProvenanceRepository:
+    """Append-only persistence boundary for M03/WP4 asset provenance evidence."""
+
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+        metadata = MetaData()
+        metadata.reflect(bind=engine, schema="core")
+        required = {
+            "asset_provenance_records",
+            "asset_parents",
+            "assets",
+            "projects",
+            "rights_records",
+            "storage_objects",
+        }
+        missing = [name for name in required if f"core.{name}" not in metadata.tables]
+        if missing:
+            raise PersistenceReferenceError(
+                f"asset provenance persistence tables are not migrated: {', '.join(sorted(missing))}"
+            )
+        self.provenance_table = metadata.tables["core.asset_provenance_records"]
+        self.asset_parents_table = metadata.tables["core.asset_parents"]
+        self.assets_table = metadata.tables["core.assets"]
+        self.projects_table = metadata.tables["core.projects"]
+        self.rights_table = metadata.tables["core.rights_records"]
+        self.storage_table = metadata.tables["core.storage_objects"]
+
+    def save(self, record: AssetProvenanceRecord) -> AssetProvenancePersistResult:
+        canonical = AssetProvenanceRecord.model_validate(record.model_dump())
+        try:
+            with self.engine.begin() as connection:
+                existing = self._row_by_external(connection, canonical.provenance_record_id)
+                if existing is not None:
+                    if self._from_row(connection, existing) == canonical:
+                        return AssetProvenancePersistResult(
+                            "noop",
+                            canonical.provenance_record_id,
+                        )
+                    raise PersistenceConflictError(
+                        f"asset provenance {canonical.provenance_record_id} already has different data"
+                    )
+
+                asset = self._require_external(
+                    connection,
+                    self.assets_table,
+                    canonical.asset_id,
+                    "asset",
+                )
+                project_id = self._validate_project(connection, canonical, asset)
+                storage_id = self._validate_storage(connection, canonical, asset)
+                rights_id = self._validate_rights(connection, canonical, asset)
+                self._validate_content_hash(canonical, asset)
+                self._validate_derived_parent(connection, canonical, asset)
+
+                connection.execute(
+                    insert(self.provenance_table).values(
+                        id=uuid4(),
+                        external_id=canonical.provenance_record_id,
+                        schema_version=canonical.schema_version,
+                        asset_id=asset["id"],
+                        project_id=project_id,
+                        storage_object_id=storage_id,
+                        source_kind=canonical.source_kind.value,
+                        source_reference=canonical.source_reference,
+                        import_reference=canonical.import_reference,
+                        provider_reference=canonical.provider_reference,
+                        content_sha256=canonical.content_sha256,
+                        rights_record_id=rights_id,
+                        created_at=canonical.created_at,
+                    )
+                )
+        except (PersistenceConflictError, PersistenceReferenceError):
+            raise
+        except IntegrityError as exc:
+            raise PersistenceConflictError(
+                f"database rejected asset provenance {canonical.provenance_record_id}"
+            ) from exc
+        return AssetProvenancePersistResult("created", canonical.provenance_record_id)
+
+    def load(self, provenance_record_id: str) -> AssetProvenanceRecord:
+        with self.engine.connect() as connection:
+            row = self._row_by_external(connection, provenance_record_id)
+            if row is None:
+                raise PersistenceNotFoundError(
+                    f"asset provenance {provenance_record_id} was not found"
+                )
+            return self._from_row(connection, row)
+
+    def _validate_project(
+        self,
+        connection: Connection,
+        record: AssetProvenanceRecord,
+        asset: RowMapping,
+    ) -> UUID | None:
+        asset_project_id = cast(UUID | None, asset["project_id"])
+        if record.project_id is None:
+            if asset_project_id is not None:
+                raise PersistenceReferenceError(
+                    f"project-scoped asset {record.asset_id} requires provenance project_id"
+                )
+            return None
+        project = self._require_external(
+            connection,
+            self.projects_table,
+            record.project_id,
+            "project",
+        )
+        if project["id"] != asset_project_id:
+            raise PersistenceReferenceError(
+                f"asset provenance project {record.project_id} does not own {record.asset_id}"
+            )
+        return cast(UUID, project["id"])
+
+    def _validate_storage(
+        self,
+        connection: Connection,
+        record: AssetProvenanceRecord,
+        asset: RowMapping,
+    ) -> UUID | None:
+        if record.storage_object_id is None:
+            return None
+        storage = self._require_external(
+            connection,
+            self.storage_table,
+            record.storage_object_id,
+            "storage object",
+        )
+        if storage["project_id"] != asset["project_id"]:
+            raise PersistenceReferenceError(
+                f"storage object {record.storage_object_id} is outside the asset project boundary"
+            )
+        if str(storage["sha256"]) != str(asset["sha256"]):
+            raise PersistenceConflictError(
+                f"storage object {record.storage_object_id} hash does not match asset {record.asset_id}"
+            )
+        return cast(UUID, storage["id"])
+
+    def _validate_rights(
+        self,
+        connection: Connection,
+        record: AssetProvenanceRecord,
+        asset: RowMapping,
+    ) -> UUID | None:
+        asset_rights_id = cast(UUID | None, asset["rights_record_id"])
+        if record.rights_record_id is None:
+            if asset_rights_id is not None:
+                raise PersistenceReferenceError(
+                    f"rights-aware asset {record.asset_id} requires provenance rights_record_id"
+                )
+            return None
+        rights = self._require_external(
+            connection,
+            self.rights_table,
+            record.rights_record_id,
+            "rights record",
+        )
+        if rights["id"] != asset_rights_id:
+            raise PersistenceReferenceError(
+                f"provenance rights {record.rights_record_id} do not match asset {record.asset_id}"
+            )
+        if str(rights["subject_type"]) != "asset" or str(rights["subject_id"]) != record.asset_id:
+            raise PersistenceReferenceError(
+                f"rights record {record.rights_record_id} is not bound to asset {record.asset_id}"
+            )
+        return cast(UUID, rights["id"])
+
+    @staticmethod
+    def _validate_content_hash(record: AssetProvenanceRecord, asset: RowMapping) -> None:
+        if record.content_sha256 != str(asset["sha256"]):
+            raise PersistenceConflictError(
+                f"provenance hash does not match canonical asset {record.asset_id}"
+            )
+
+    def _validate_derived_parent(
+        self,
+        connection: Connection,
+        record: AssetProvenanceRecord,
+        asset: RowMapping,
+    ) -> None:
+        if record.source_kind is not AssetProvenanceSource.DERIVED:
+            return
+        parent_id = connection.execute(
+            select(self.asset_parents_table.c.parent_asset_id)
+            .where(self.asset_parents_table.c.child_asset_id == asset["id"])
+            .limit(1)
+        ).scalar_one_or_none()
+        if parent_id is None:
+            raise PersistenceReferenceError(
+                f"derived provenance requires an existing parent for asset {record.asset_id}"
+            )
+
+    def _from_row(self, connection: Connection, row: RowMapping) -> AssetProvenanceRecord:
+        persisted_schema_version = int(row["schema_version"])
+        if persisted_schema_version != SCHEMA_VERSION:
+            raise PersistenceReferenceError(
+                "unsupported asset provenance schema version "
+                f"{persisted_schema_version}; expected {SCHEMA_VERSION}"
+            )
+        schema_version = cast(SchemaVersion, persisted_schema_version)
+        return AssetProvenanceRecord(
+            schema_version=schema_version,
+            provenance_record_id=str(row["external_id"]),
+            asset_id=self._external_for_internal(
+                connection,
+                self.assets_table,
+                cast(UUID, row["asset_id"]),
+                "asset",
+            ),
+            project_id=self._optional_external_for_internal(
+                connection,
+                self.projects_table,
+                cast(UUID | None, row["project_id"]),
+                "project",
+            ),
+            storage_object_id=self._optional_external_for_internal(
+                connection,
+                self.storage_table,
+                cast(UUID | None, row["storage_object_id"]),
+                "storage object",
+            ),
+            source_kind=AssetProvenanceSource(str(row["source_kind"])),
+            source_reference=(
+                str(row["source_reference"]) if row["source_reference"] is not None else None
+            ),
+            import_reference=(
+                str(row["import_reference"]) if row["import_reference"] is not None else None
+            ),
+            provider_reference=(
+                str(row["provider_reference"]) if row["provider_reference"] is not None else None
+            ),
+            content_sha256=str(row["content_sha256"]),
+            rights_record_id=self._optional_external_for_internal(
+                connection,
+                self.rights_table,
+                cast(UUID | None, row["rights_record_id"]),
+                "rights record",
+            ),
+            created_at=row["created_at"],
+        )
+
+    def _row_by_external(self, connection: Connection, external_id: str) -> RowMapping | None:
+        return connection.execute(
+            select(self.provenance_table).where(self.provenance_table.c.external_id == external_id)
+        ).mappings().one_or_none()
+
+    @staticmethod
+    def _require_external(
+        connection: Connection,
+        table: object,
+        external_id: str,
+        label: str,
+    ) -> RowMapping:
+        typed_table = cast(object, table)
+        row = connection.execute(
+            select(typed_table).where(typed_table.c.external_id == external_id)  # type: ignore[attr-defined]
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceReferenceError(f"missing {label}:{external_id}")
+        return row
+
+    @staticmethod
+    def _external_for_internal(
+        connection: Connection,
+        table: object,
+        internal_id: UUID,
+        label: str,
+    ) -> str:
+        typed_table = cast(object, table)
+        value = connection.execute(
+            select(typed_table.c.external_id).where(typed_table.c.id == internal_id)  # type: ignore[attr-defined]
+        ).scalar_one_or_none()
+        if value is None:
+            raise PersistenceReferenceError(f"missing {label} external identity for {internal_id}")
+        return str(value)
+
+    @classmethod
+    def _optional_external_for_internal(
+        cls,
+        connection: Connection,
+        table: object,
+        internal_id: UUID | None,
+        label: str,
+    ) -> str | None:
+        if internal_id is None:
+            return None
+        return cls._external_for_internal(connection, table, internal_id, label)

--- a/packages/python-core/src/lullabies_core/persistence/asset_provenance.py
+++ b/packages/python-core/src/lullabies_core/persistence/asset_provenance.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal, cast
 from uuid import UUID, uuid4
 
-from sqlalchemy import MetaData, insert, select
+from sqlalchemy import MetaData, Table, insert, select
 from sqlalchemy.engine import Connection, Engine, RowMapping
 from sqlalchemy.exc import IntegrityError
 
@@ -273,13 +273,12 @@ class PostgresAssetProvenanceRepository:
     @staticmethod
     def _require_external(
         connection: Connection,
-        table: object,
+        table: Table,
         external_id: str,
         label: str,
     ) -> RowMapping:
-        typed_table = cast(object, table)
         row = connection.execute(
-            select(typed_table).where(typed_table.c.external_id == external_id)  # type: ignore[attr-defined]
+            select(table).where(table.c.external_id == external_id)
         ).mappings().one_or_none()
         if row is None:
             raise PersistenceReferenceError(f"missing {label}:{external_id}")
@@ -288,13 +287,12 @@ class PostgresAssetProvenanceRepository:
     @staticmethod
     def _external_for_internal(
         connection: Connection,
-        table: object,
+        table: Table,
         internal_id: UUID,
         label: str,
     ) -> str:
-        typed_table = cast(object, table)
         value = connection.execute(
-            select(typed_table.c.external_id).where(typed_table.c.id == internal_id)  # type: ignore[attr-defined]
+            select(table.c.external_id).where(table.c.id == internal_id)
         ).scalar_one_or_none()
         if value is None:
             raise PersistenceReferenceError(f"missing {label} external identity for {internal_id}")
@@ -304,7 +302,7 @@ class PostgresAssetProvenanceRepository:
     def _optional_external_for_internal(
         cls,
         connection: Connection,
-        table: object,
+        table: Table,
         internal_id: UUID | None,
         label: str,
     ) -> str | None:

--- a/packages/python-core/src/lullabies_core/provenance.py
+++ b/packages/python-core/src/lullabies_core/provenance.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from .common import (
+    SCHEMA_VERSION,
+    AssetId,
+    ProjectId,
+    RightsRecordId,
+    SchemaVersion,
+    StorageObjectId,
+    StrictModel,
+    external_id_pattern,
+)
+
+AssetProvenanceRecordId = Annotated[
+    str,
+    Field(pattern=external_id_pattern("PRV")),
+]
+
+
+class AssetProvenanceSource(StrEnum):
+    """Normalized origin class for one append-only asset provenance assertion."""
+
+    UPLOAD = "upload"
+    IMPORT = "import"
+    PROVIDER = "provider"
+    DERIVED = "derived"
+
+
+class AssetProvenanceRecord(StrictModel):
+    """Immutable origin/evidence linkage for one canonical Asset.
+
+    Canonical approval/rejection remains owned by ``Asset.canonical_status`` and legal
+    publication state remains owned by ``RightsRecord``. This record only binds the
+    canonical asset to physical/source evidence and a witnessed content hash.
+    """
+
+    schema_version: SchemaVersion = SCHEMA_VERSION
+    provenance_record_id: AssetProvenanceRecordId
+    asset_id: AssetId
+    project_id: ProjectId | None = None
+    storage_object_id: StorageObjectId | None = None
+    source_kind: AssetProvenanceSource
+    source_reference: str | None = Field(default=None, min_length=1, max_length=2048)
+    import_reference: str | None = Field(default=None, min_length=1, max_length=2048)
+    provider_reference: str | None = Field(default=None, min_length=1, max_length=2048)
+    content_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    rights_record_id: RightsRecordId | None = None
+    created_at: AwareDatetime
+
+    @model_validator(mode="after")
+    def validate_source_evidence(self) -> AssetProvenanceRecord:
+        if self.source_kind is AssetProvenanceSource.UPLOAD and self.storage_object_id is None:
+            raise ValueError("upload provenance requires storage_object_id")
+        if self.source_kind is AssetProvenanceSource.IMPORT and self.import_reference is None:
+            raise ValueError("import provenance requires import_reference")
+        if self.source_kind is AssetProvenanceSource.PROVIDER and self.provider_reference is None:
+            raise ValueError("provider provenance requires provider_reference")
+        return self

--- a/packages/python-core/src/lullabies_core/provenance.py
+++ b/packages/python-core/src/lullabies_core/provenance.py
@@ -8,6 +8,8 @@ from pydantic import AwareDatetime, Field, model_validator
 from .common import (
     SCHEMA_VERSION,
     AssetId,
+    CanonicalStatus,
+    CommercialUseStatus,
     ProjectId,
     RightsRecordId,
     SchemaVersion,
@@ -15,6 +17,7 @@ from .common import (
     StrictModel,
     external_id_pattern,
 )
+from .production import Asset, RightsRecord
 
 AssetProvenanceRecordId = Annotated[
     str,
@@ -70,3 +73,100 @@ class AssetProvenanceRecord(StrictModel):
         ):
             raise ValueError("provider provenance requires provider_reference")
         return self
+
+
+class AssetUsabilityPolicy(StrictModel):
+    """Explicit evidence requirements for treating an approved Asset as usable.
+
+    The policy composes existing authorities instead of creating a second approval or
+    rights state machine. ``Asset.canonical_status`` remains approval authority and
+    ``RightsRecord`` remains publication/legal-rights authority.
+    """
+
+    require_storage_binding: bool = True
+    require_rights_record: bool = True
+    require_commercial_use: bool = True
+    require_verified_rights: bool = True
+    require_publication_unblocked: bool = True
+
+
+class AssetUsabilityRejection(StrEnum):
+    NOT_CANONICALLY_APPROVED = "not-canonically-approved"
+    PROVENANCE_ASSET_MISMATCH = "provenance-asset-mismatch"
+    PROVENANCE_PROJECT_MISMATCH = "provenance-project-mismatch"
+    PROVENANCE_HASH_MISMATCH = "provenance-hash-mismatch"
+    STORAGE_EVIDENCE_REQUIRED = "storage-evidence-required"
+    RIGHTS_RECORD_REQUIRED = "rights-record-required"
+    RIGHTS_REFERENCE_MISMATCH = "rights-reference-mismatch"
+    RIGHTS_SUBJECT_MISMATCH = "rights-subject-mismatch"
+    COMMERCIAL_USE_NOT_ALLOWED = "commercial-use-not-allowed"
+    RIGHTS_NOT_VERIFIED = "rights-not-verified"
+    PUBLICATION_BLOCKED = "publication-blocked"
+
+
+class AssetUsabilityDecision(StrictModel):
+    usable: bool
+    rejections: list[AssetUsabilityRejection] = Field(default_factory=list)
+
+
+def evaluate_asset_usability(
+    asset: Asset,
+    provenance: AssetProvenanceRecord,
+    rights_record: RightsRecord | None,
+    policy: AssetUsabilityPolicy | None = None,
+) -> AssetUsabilityDecision:
+    """Fail closed unless the selected evidence satisfies the explicit usage policy.
+
+    Persistence is responsible for proving referenced database rows and storage hashes
+    at write time. This pure decision contract composes the canonical asset state,
+    selected provenance assertion and legal-rights state for downstream use gates.
+    """
+
+    active_policy = policy or AssetUsabilityPolicy()
+    rejections: list[AssetUsabilityRejection] = []
+
+    if asset.canonical_status is not CanonicalStatus.APPROVED:
+        rejections.append(AssetUsabilityRejection.NOT_CANONICALLY_APPROVED)
+    if provenance.asset_id != asset.asset_id:
+        rejections.append(AssetUsabilityRejection.PROVENANCE_ASSET_MISMATCH)
+    if provenance.project_id != asset.project_id:
+        rejections.append(AssetUsabilityRejection.PROVENANCE_PROJECT_MISMATCH)
+    if provenance.content_sha256 != asset.sha256:
+        rejections.append(AssetUsabilityRejection.PROVENANCE_HASH_MISMATCH)
+    if active_policy.require_storage_binding and provenance.storage_object_id is None:
+        rejections.append(AssetUsabilityRejection.STORAGE_EVIDENCE_REQUIRED)
+
+    expected_rights_id = asset.rights_record_id
+    if active_policy.require_rights_record and expected_rights_id is None:
+        rejections.append(AssetUsabilityRejection.RIGHTS_RECORD_REQUIRED)
+
+    if provenance.rights_record_id != expected_rights_id:
+        rejections.append(AssetUsabilityRejection.RIGHTS_REFERENCE_MISMATCH)
+
+    if expected_rights_id is not None:
+        if rights_record is None:
+            rejections.append(AssetUsabilityRejection.RIGHTS_RECORD_REQUIRED)
+        else:
+            if rights_record.rights_record_id != expected_rights_id:
+                rejections.append(AssetUsabilityRejection.RIGHTS_REFERENCE_MISMATCH)
+            if (
+                rights_record.subject_type != "asset"
+                or rights_record.subject_id != asset.asset_id
+            ):
+                rejections.append(AssetUsabilityRejection.RIGHTS_SUBJECT_MISMATCH)
+            if (
+                active_policy.require_commercial_use
+                and rights_record.commercial_use is not CommercialUseStatus.ALLOWED
+            ):
+                rejections.append(AssetUsabilityRejection.COMMERCIAL_USE_NOT_ALLOWED)
+            if active_policy.require_verified_rights and rights_record.verified_at is None:
+                rejections.append(AssetUsabilityRejection.RIGHTS_NOT_VERIFIED)
+            if active_policy.require_publication_unblocked and rights_record.publication_blocked:
+                rejections.append(AssetUsabilityRejection.PUBLICATION_BLOCKED)
+
+    # Keep reasons deterministic and unique if multiple reference checks converge.
+    unique_rejections = list(dict.fromkeys(rejections))
+    return AssetUsabilityDecision(
+        usable=not unique_rejections,
+        rejections=unique_rejections,
+    )

--- a/packages/python-core/src/lullabies_core/provenance.py
+++ b/packages/python-core/src/lullabies_core/provenance.py
@@ -54,10 +54,19 @@ class AssetProvenanceRecord(StrictModel):
 
     @model_validator(mode="after")
     def validate_source_evidence(self) -> AssetProvenanceRecord:
-        if self.source_kind is AssetProvenanceSource.UPLOAD and self.storage_object_id is None:
+        if (
+            self.source_kind is AssetProvenanceSource.UPLOAD
+            and self.storage_object_id is None
+        ):
             raise ValueError("upload provenance requires storage_object_id")
-        if self.source_kind is AssetProvenanceSource.IMPORT and self.import_reference is None:
+        if (
+            self.source_kind is AssetProvenanceSource.IMPORT
+            and self.import_reference is None
+        ):
             raise ValueError("import provenance requires import_reference")
-        if self.source_kind is AssetProvenanceSource.PROVIDER and self.provider_reference is None:
+        if (
+            self.source_kind is AssetProvenanceSource.PROVIDER
+            and self.provider_reference is None
+        ):
             raise ValueError("provider provenance requires provider_reference")
         return self

--- a/packages/python-core/tests/test_asset_provenance_graph_authority.py
+++ b/packages/python-core/tests/test_asset_provenance_graph_authority.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+from lineage_fixtures import full_lineage_bundle
+
+from ai_automation_force_core import ProductionLineageBundle
+
+
+def _revalidate(bundle: ProductionLineageBundle, assets: list[object]) -> None:
+    candidate = bundle.model_copy(update={"assets": assets})
+    ProductionLineageBundle.model_validate(candidate.model_dump())
+
+
+def test_wp4_retains_canonical_asset_parent_cycle_rejection() -> None:
+    """WP4 provenance persistence must not bypass the canonical lineage graph authority."""
+    bundle = full_lineage_bundle()
+    source = bundle.assets[0]
+    derived = bundle.assets[1]
+
+    cyclic_source = source.model_copy(update={"parent_asset_ids": [derived.asset_id]})
+    cyclic_derived = derived.model_copy(update={"parent_asset_ids": [source.asset_id]})
+
+    with pytest.raises(ValueError, match="parent cycle"):
+        _revalidate(bundle, [cyclic_source, cyclic_derived, *bundle.assets[2:]])
+
+
+def test_wp4_retains_project_boundary_rejection_for_asset_graph() -> None:
+    """A provenance carrier cannot make an asset from another project part of this graph."""
+    bundle = full_lineage_bundle()
+    foreign_asset = bundle.assets[0].model_copy(update={"project_id": "PRJ-999999"})
+
+    with pytest.raises(ValueError, match="belongs to another project"):
+        _revalidate(bundle, [foreign_asset, *bundle.assets[1:]])

--- a/packages/python-core/tests/test_asset_provenance_persistence.py
+++ b/packages/python-core/tests/test_asset_provenance_persistence.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from lineage_fixtures import full_lineage_bundle
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+from ai_automation_force_core import (
+    AssetProvenanceRecord,
+    AssetProvenanceSource,
+    PersistenceConflictError,
+    PersistenceReferenceError,
+    PostgresAssetProvenanceRepository,
+    PostgresProductionRepository,
+    PostgresStorageObjectRepository,
+    StorageBackend,
+    StorageObject,
+)
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+ALEMBIC_INI = Path(__file__).parents[1] / "alembic.ini"
+
+
+def alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
+
+
+@pytest.fixture
+def migrated_engine() -> Iterator[Engine]:
+    if DATABASE_URL is None:
+        pytest.skip("DATABASE_URL is not configured")
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")
+
+
+def generated_storage(bundle: object) -> StorageObject:
+    typed_bundle = full_lineage_bundle() if bundle is None else bundle
+    asset = typed_bundle.assets[1]  # type: ignore[attr-defined]
+    assert asset.project_id is not None
+    return StorageObject(
+        storage_object_id="STO-003001",
+        project_id=asset.project_id,
+        backend=StorageBackend.FILESYSTEM,
+        object_key=f"generated/{asset.project_id}/STO-003001",
+        sha256=asset.sha256,
+        mime_type=asset.mime_type,
+        size_bytes=asset.size_bytes,
+        original_filename="shot-500.mp4",
+        lifecycle_class="canonical",
+        audit=asset.audit.model_copy(deep=True),
+    )
+
+
+@pytest.mark.postgres
+def test_asset_provenance_round_trip_is_append_only_and_integrity_safe(
+    migrated_engine: Engine,
+) -> None:
+    bundle = full_lineage_bundle()
+    production = PostgresProductionRepository(migrated_engine)
+    production.save_bundle(bundle)
+
+    asset = bundle.assets[1]
+    assert asset.asset_id == "AST-000501"
+    assert asset.project_id is not None
+    assert asset.rights_record_id is not None
+
+    storage = generated_storage(bundle)
+    PostgresStorageObjectRepository(migrated_engine).save(storage)
+
+    repository = PostgresAssetProvenanceRepository(migrated_engine)
+    record = AssetProvenanceRecord(
+        provenance_record_id="PRV-003001",
+        asset_id=asset.asset_id,
+        project_id=asset.project_id,
+        storage_object_id=storage.storage_object_id,
+        source_kind=AssetProvenanceSource.PROVIDER,
+        source_reference="generation-attempt:ATT-000500",
+        provider_reference="provider-generation:provider-job-500",
+        content_sha256=asset.sha256,
+        rights_record_id=asset.rights_record_id,
+        created_at=asset.audit.created_at,
+    )
+
+    first = repository.save(record)
+    restored = repository.load(record.provenance_record_id)
+    second = repository.save(record)
+
+    assert first.action == "created"
+    assert second.action == "noop"
+    assert restored == record
+
+    conflicting_identity = record.model_copy(update={"provider_reference": "provider-generation:other"})
+    with pytest.raises(PersistenceConflictError, match="already has different data"):
+        repository.save(conflicting_identity)
+
+    bad_hash = record.model_copy(
+        update={
+            "provenance_record_id": "PRV-003002",
+            "content_sha256": "0" * 64,
+        }
+    )
+    with pytest.raises(PersistenceConflictError, match="provenance hash"):
+        repository.save(bad_hash)
+
+
+@pytest.mark.postgres
+def test_derived_provenance_requires_existing_canonical_parent(
+    migrated_engine: Engine,
+) -> None:
+    bundle = full_lineage_bundle()
+    PostgresProductionRepository(migrated_engine).save_bundle(bundle)
+    repository = PostgresAssetProvenanceRepository(migrated_engine)
+
+    generated = bundle.assets[1]
+    assert generated.project_id is not None
+    assert generated.rights_record_id is not None
+    derived = AssetProvenanceRecord(
+        provenance_record_id="PRV-003010",
+        asset_id=generated.asset_id,
+        project_id=generated.project_id,
+        source_kind=AssetProvenanceSource.DERIVED,
+        source_reference="asset-parent-graph",
+        content_sha256=generated.sha256,
+        rights_record_id=generated.rights_record_id,
+        created_at=generated.audit.created_at,
+    )
+    assert repository.save(derived).action == "created"
+
+    source = bundle.assets[0]
+    assert source.project_id is not None
+    parentless = AssetProvenanceRecord(
+        provenance_record_id="PRV-003011",
+        asset_id=source.asset_id,
+        project_id=source.project_id,
+        source_kind=AssetProvenanceSource.DERIVED,
+        source_reference="invalid-parentless-derived-fixture",
+        content_sha256=source.sha256,
+        created_at=source.audit.created_at,
+    )
+    with pytest.raises(PersistenceReferenceError, match="existing parent"):
+        repository.save(parentless)

--- a/packages/python-core/tests/test_asset_provenance_persistence.py
+++ b/packages/python-core/tests/test_asset_provenance_persistence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterator
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
@@ -116,6 +117,15 @@ def test_asset_provenance_round_trip_is_append_only_and_integrity_safe(
     )
     with pytest.raises(PersistenceConflictError, match="provenance hash"):
         repository.save(bad_hash)
+
+    predating_evidence = record.model_copy(
+        update={
+            "provenance_record_id": "PRV-003003",
+            "created_at": asset.audit.created_at - timedelta(seconds=1),
+        }
+    )
+    with pytest.raises(PersistenceConflictError, match="cannot predate canonical asset"):
+        repository.save(predating_evidence)
 
 
 @pytest.mark.postgres

--- a/packages/python-core/tests/test_asset_provenance_persistence.py
+++ b/packages/python-core/tests/test_asset_provenance_persistence.py
@@ -19,6 +19,7 @@ from ai_automation_force_core import (
     PostgresAssetProvenanceRepository,
     PostgresProductionRepository,
     PostgresStorageObjectRepository,
+    ProductionLineageBundle,
     StorageBackend,
     StorageObject,
 )
@@ -46,9 +47,8 @@ def migrated_engine() -> Iterator[Engine]:
         command.downgrade(config, "base")
 
 
-def generated_storage(bundle: object) -> StorageObject:
-    typed_bundle = full_lineage_bundle() if bundle is None else bundle
-    asset = typed_bundle.assets[1]  # type: ignore[attr-defined]
+def generated_storage(bundle: ProductionLineageBundle) -> StorageObject:
+    asset = bundle.assets[1]
     assert asset.project_id is not None
     return StorageObject(
         storage_object_id="STO-003001",
@@ -102,7 +102,9 @@ def test_asset_provenance_round_trip_is_append_only_and_integrity_safe(
     assert second.action == "noop"
     assert restored == record
 
-    conflicting_identity = record.model_copy(update={"provider_reference": "provider-generation:other"})
+    conflicting_identity = record.model_copy(
+        update={"provider_reference": "provider-generation:other"}
+    )
     with pytest.raises(PersistenceConflictError, match="already has different data"):
         repository.save(conflicting_identity)
 

--- a/packages/python-core/tests/test_asset_usability.py
+++ b/packages/python-core/tests/test_asset_usability.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from lineage_fixtures import NOW, full_lineage_bundle
+
 from ai_automation_force_core import (
     AssetProvenanceRecord,
     AssetProvenanceSource,
@@ -8,7 +10,6 @@ from ai_automation_force_core import (
     CommercialUseStatus,
     evaluate_asset_usability,
 )
-from lineage_fixtures import NOW, full_lineage_bundle
 
 
 def _provider_provenance():

--- a/packages/python-core/tests/test_asset_usability.py
+++ b/packages/python-core/tests/test_asset_usability.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from ai_automation_force_core import (
+    AssetProvenanceRecord,
+    AssetProvenanceSource,
+    AssetUsabilityRejection,
+    CanonicalStatus,
+    CommercialUseStatus,
+    evaluate_asset_usability,
+)
+from lineage_fixtures import NOW, full_lineage_bundle
+
+
+def _provider_provenance():
+    bundle = full_lineage_bundle()
+    asset = bundle.assets[1]
+    return bundle, asset, AssetProvenanceRecord(
+        provenance_record_id="PRV-000500",
+        asset_id=asset.asset_id,
+        project_id=asset.project_id,
+        storage_object_id="STO-000500",
+        source_kind=AssetProvenanceSource.PROVIDER,
+        provider_reference="provider-job-500",
+        content_sha256=asset.sha256,
+        rights_record_id=asset.rights_record_id,
+        created_at=NOW,
+    )
+
+
+def test_approved_asset_is_not_usable_with_unresolved_rights() -> None:
+    bundle, asset, provenance = _provider_provenance()
+    rights = bundle.rights_records[0]
+
+    decision = evaluate_asset_usability(asset, provenance, rights)
+
+    assert decision.usable is False
+    assert decision.rejections == [
+        AssetUsabilityRejection.COMMERCIAL_USE_NOT_ALLOWED,
+        AssetUsabilityRejection.RIGHTS_NOT_VERIFIED,
+        AssetUsabilityRejection.PUBLICATION_BLOCKED,
+    ]
+
+
+def test_asset_becomes_usable_only_when_all_default_policy_evidence_is_satisfied() -> None:
+    bundle, asset, provenance = _provider_provenance()
+    rights = bundle.rights_records[0].model_copy(
+        update={
+            "commercial_use": CommercialUseStatus.ALLOWED,
+            "verified_at": NOW,
+            "publication_blocked": False,
+        }
+    )
+
+    decision = evaluate_asset_usability(asset, provenance, rights)
+
+    assert decision.usable is True
+    assert decision.rejections == []
+
+
+def test_nonapproved_asset_fails_even_with_sufficient_rights() -> None:
+    bundle, asset, provenance = _provider_provenance()
+    candidate = asset.model_copy(update={"canonical_status": CanonicalStatus.CANDIDATE})
+    rights = bundle.rights_records[0].model_copy(
+        update={
+            "commercial_use": CommercialUseStatus.ALLOWED,
+            "verified_at": NOW,
+            "publication_blocked": False,
+        }
+    )
+
+    decision = evaluate_asset_usability(candidate, provenance, rights)
+
+    assert decision.usable is False
+    assert decision.rejections == [AssetUsabilityRejection.NOT_CANONICALLY_APPROVED]
+
+
+def test_selected_provenance_must_match_canonical_asset_identity_and_hash() -> None:
+    bundle, asset, provenance = _provider_provenance()
+    rights = bundle.rights_records[0].model_copy(
+        update={
+            "commercial_use": CommercialUseStatus.ALLOWED,
+            "verified_at": NOW,
+            "publication_blocked": False,
+        }
+    )
+    mismatched = provenance.model_copy(
+        update={
+            "project_id": "PRJ-999999",
+            "content_sha256": "c" * 64,
+        }
+    )
+
+    decision = evaluate_asset_usability(asset, mismatched, rights)
+
+    assert decision.usable is False
+    assert decision.rejections == [
+        AssetUsabilityRejection.PROVENANCE_PROJECT_MISMATCH,
+        AssetUsabilityRejection.PROVENANCE_HASH_MISMATCH,
+    ]

--- a/packages/python-core/tests/test_migrations.py
+++ b/packages/python-core/tests/test_migrations.py
@@ -36,6 +36,7 @@ EXPECTED_CORE_TABLES = {
     "shots",
     "takes",
     "assets",
+    "asset_provenance_records",
     "storage_objects",
     "upload_sessions",
     "upload_parts",
@@ -83,6 +84,7 @@ WP7_TABLES = {"job_commands"}
 M03_WP1_TABLES = {"storage_objects"}
 M03_WP2_TABLES = {"upload_sessions", "upload_parts", "upload_session_commands"}
 M03_WP3_TABLES = {"quarantine_inspections"}
+M03_WP4_TABLES = {"asset_provenance_records"}
 
 
 def alembic_config() -> Config:
@@ -225,7 +227,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         with engine.connect() as connection:
             result = connection.execute(text("SELECT version_num FROM alembic_version"))
             revision = result.scalar_one()
-        assert revision == "20260829_0010"
+        assert revision == "20260830_0011"
 
         project_id = uuid4()
         with engine.begin() as connection:
@@ -346,9 +348,14 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         command.upgrade(config, "head")
         assert set(inspect(engine).get_table_names(schema="core")) == EXPECTED_CORE_TABLES
 
+        command.downgrade(config, "20260829_0010")
+        m10_tables = set(inspect(engine).get_table_names(schema="core"))
+        pre_wp4_tables = EXPECTED_CORE_TABLES - M03_WP4_TABLES
+        assert m10_tables == pre_wp4_tables
+
         command.downgrade(config, "20260829_0009")
         m09_tables = set(inspect(engine).get_table_names(schema="core"))
-        pre_wp3_tables = EXPECTED_CORE_TABLES - M03_WP3_TABLES
+        pre_wp3_tables = pre_wp4_tables - M03_WP3_TABLES
         assert m09_tables == pre_wp3_tables
 
         command.downgrade(config, "20260829_0008")


### PR DESCRIPTION
## Superseded historical carrier

This draft is closed **without merge** because it diverged from `main` after repository-governance tooling landed.

Canonical M03/WP4 implementation carrier is now PR #37, replayed from fresh governance-tooling main with the final reviewed WP4 implementation/test/migration payload. PR #37 exact head `8638a6bc3b17830d3a6fc2780bf82fb3d49bb7cc` passed fresh Repository Governance #6, Core Domain Contracts #205 and Durable Control Plane #143 and received explicit SELF REVIEW.

No implementation was discarded by closing this stale carrier. Historical review/check evidence here remains provenance only and is not current promotion evidence.

Live `main` protection still reads `protected=false`; ABD-265 / GitHub Issue #36 remains the hard hosted-governance blocker. Do not merge WP4 or start WP5 until that acceptance is resolved.