### PR TITLE
ABD-265: make main protection enforceable and verifiable

### DIFF
--- a/.github/workflows/control-plane.yml
+++ b/.github/workflows/control-plane.yml
@@ -10,12 +10,6 @@ on:
       - "packages/contracts/**"
       - ".github/workflows/control-plane.yml"
   pull_request:
-    paths:
-      - "apps/api/**"
-      - "apps/worker/**"
-      - "packages/python-core/**"
-      - "packages/contracts/**"
-      - ".github/workflows/control-plane.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/control-plane.yml
+++ b/.github/workflows/control-plane.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   validate:
+    name: durable-control-plane
     runs-on: ubuntu-latest
     timeout-minutes: 25
     services:

--- a/.github/workflows/core-contracts.yml
+++ b/.github/workflows/core-contracts.yml
@@ -8,10 +8,6 @@ on:
       - "schemas/**"
       - ".github/workflows/core-contracts.yml"
   pull_request:
-    paths:
-      - "packages/python-core/**"
-      - "schemas/**"
-      - ".github/workflows/core-contracts.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/core-contracts.yml
+++ b/.github/workflows/core-contracts.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   validate:
+    name: core-domain-contracts
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:

--- a/.github/workflows/repository-governance.yml
+++ b/.github/workflows/repository-governance.yml
@@ -1,0 +1,66 @@
+name: Repository Governance
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "scripts/apply_main_protection.ps1"
+      - "scripts/verify_main_protection.ps1"
+      - "docs/governance/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: repository-governance
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Parse protection PowerShell
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          foreach ($path in @('scripts/apply_main_protection.ps1','scripts/verify_main_protection.ps1')) {
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path $path), [ref]$tokens, [ref]$errors) | Out-Null
+            if ($errors.Count -gt 0) {
+              foreach ($parseError in $errors) { Write-Host $parseError.Message }
+              exit 1
+            }
+            Write-Host "PowerShell parse PASS: $path"
+          }
+
+      - name: Verify stable required-check identities and PR coverage
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $core = Get-Content '.github/workflows/core-contracts.yml' -Raw
+          $durable = Get-Content '.github/workflows/control-plane.yml' -Raw
+          $apply = Get-Content 'scripts/apply_main_protection.ps1' -Raw
+          $verify = Get-Content 'scripts/verify_main_protection.ps1' -Raw
+
+          foreach ($pair in @(
+            @{ Text = $core; Marker = 'name: core-domain-contracts'; Label = 'core workflow' },
+            @{ Text = $durable; Marker = 'name: durable-control-plane'; Label = 'durable workflow' },
+            @{ Text = $apply; Marker = 'core-domain-contracts'; Label = 'apply script core context' },
+            @{ Text = $apply; Marker = 'durable-control-plane'; Label = 'apply script durable context' },
+            @{ Text = $verify; Marker = 'core-domain-contracts'; Label = 'verify script core context' },
+            @{ Text = $verify; Marker = 'durable-control-plane'; Label = 'verify script durable context' }
+          )) {
+            if (-not $pair.Text.Contains($pair.Marker)) {
+              throw "$($pair.Label) missing marker: $($pair.Marker)"
+            }
+          }
+
+          if ($core -notmatch '(?m)^  pull_request:\s*$') { throw 'Core Domain Contracts must run on every pull request.' }
+          if ($durable -notmatch '(?m)^  pull_request:\s*$') { throw 'Durable Control Plane must run on every pull request.' }
+          if ($apply.Contains('"validate"')) { throw 'Protection applicator must not require ambiguous legacy validate context.' }
+
+          Write-Host 'Repository governance static contract PASS.'

--- a/docs/governance/MAIN_PROTECTION.md
+++ b/docs/governance/MAIN_PROTECTION.md
@@ -1,0 +1,96 @@
+# Main Protection Governance
+
+Status: **IMPLEMENTATION READY — LIVE READ-BACK REQUIRED**
+
+Linear: `ABD-265`
+Repository: `Vertex-Systems-Network/ai-automation-force`
+Protected branch target: `main`
+
+## Why this gate exists
+
+`main` was verified unprotected during the Universal Master Prompt adoption audit. Process-only discipline is not sufficient for production-grade promotion: the repository must enforce the integration boundary itself.
+
+A second defect was found during implementation: both canonical workflows previously published the same GitHub check-run context, `validate`. Requiring that ambiguous context cannot prove that both Core Domain Contracts and Durable Control Plane passed.
+
+The governance hardening therefore establishes stable distinct job contexts:
+
+- `core-domain-contracts`
+- `durable-control-plane`
+
+Both workflows are configured to run on **every pull request**, so required checks cannot remain permanently `Expected` on documentation/governance-only PRs.
+
+## Target live policy
+
+The idempotent applicator `scripts/apply_main_protection.ps1` configures:
+
+- pull-request-only integration;
+- strict/up-to-date required checks;
+- required contexts `core-domain-contracts` and `durable-control-plane`;
+- administrator enforcement;
+- stale-review dismissal;
+- required conversation resolution;
+- force-push denial;
+- branch-deletion denial;
+- no repository/user/team push restrictions beyond the PR boundary;
+- no undocumented bypass actors.
+
+## Review modes
+
+The applicator requires an explicit review mode; there is no silent default.
+
+### `independent`
+
+Use where another qualified reviewer is available.
+
+- at least one approving review is required;
+- stale approvals are dismissed;
+- approval after the latest push is required;
+- SELF REVIEW cannot be represented as independent approval.
+
+### `solo-self-review`
+
+Use only as an explicit solo-operator exception where an independent reviewer is genuinely unavailable.
+
+- repository-required approving-review count is zero;
+- stale-review protection remains configured;
+- every implementation/security/data/migration promotion must record `SELF REVIEW` honestly in PR/checkpoint evidence;
+- green CI plus SELF REVIEW is not described as independent review;
+- this mode does not weaken the required exact-head checks, conversation resolution, PR-only integration, admin enforcement, force-push or deletion controls.
+
+Changing review mode is a governance change and must be deliberate.
+
+## Application
+
+From an authenticated admin workstation with GitHub CLI:
+
+```powershell
+pwsh scripts/apply_main_protection.ps1 -ReviewMode independent
+```
+
+or, only for the explicit solo exception:
+
+```powershell
+pwsh scripts/apply_main_protection.ps1 -ReviewMode solo-self-review
+```
+
+The script is intentionally an admin action. It never stores tokens or credentials in the repository.
+
+## Certification / read-back
+
+Documentation intent and a successful API write are not acceptance evidence by themselves. Run:
+
+```powershell
+pwsh scripts/verify_main_protection.ps1 -ReviewMode independent
+```
+
+or the matching solo mode.
+
+The verifier reads live GitHub protection and fails unless it observes the expected policy, including both distinct required contexts. It also rejects the legacy ambiguous required context `validate`.
+
+`ABD-265` must remain open until live read-back passes and the effective protection is independently re-read through GitHub evidence.
+
+## WP4 interaction
+
+This hardening lane is repository governance only and must remain separate from M03/WP4 implementation PR #33.
+
+WP4 may remain code-complete and CI-green while this gate is unresolved, but it must not be promoted as production-grade governance until live protection is certified or a separately approved governance exception explicitly accepts the residual risk.

--- a/scripts/apply_main_protection.ps1
+++ b/scripts/apply_main_protection.ps1
@@ -8,6 +8,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$GitHubActionsAppId = 15368
+$ApiVersion = "2026-03-10"
 
 function Require-Command([string]$Name) {
     if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
@@ -28,9 +30,10 @@ $requireLastPushApproval = $ReviewMode -eq "independent"
 $payload = [ordered]@{
     required_status_checks = [ordered]@{
         strict = $true
-        contexts = @(
-            "core-domain-contracts",
-            "durable-control-plane"
+        contexts = @()
+        checks = @(
+            [ordered]@{ context = "core-domain-contracts"; app_id = $GitHubActionsAppId },
+            [ordered]@{ context = "durable-control-plane"; app_id = $GitHubActionsAppId }
         )
     }
     enforce_admins = $true
@@ -58,7 +61,7 @@ try {
     gh api `
         --method PUT `
         -H "Accept: application/vnd.github+json" `
-        -H "X-GitHub-Api-Version: 2022-11-28" `
+        -H "X-GitHub-Api-Version: $ApiVersion" `
         "repos/$Repository/branches/$Branch/protection" `
         --input $temp
     if ($LASTEXITCODE -ne 0) {
@@ -70,11 +73,11 @@ finally {
 }
 
 Write-Host "Applied protected-$Branch policy to $Repository."
-Write-Host "Required checks: core-domain-contracts, durable-control-plane"
+Write-Host "Required GitHub Actions checks: core-domain-contracts, durable-control-plane (app_id=$GitHubActionsAppId)"
 if ($ReviewMode -eq "independent") {
     Write-Host "Review mode: at least one independent approving review; stale approvals dismissed; last-push approval enforced."
 }
 else {
     Write-Warning "Review mode: explicit solo SELF REVIEW exception. Independent approval is not claimed; review provenance must remain explicit in PR/checkpoint evidence."
 }
-Write-Host "Run scripts/verify_main_protection.ps1 to certify live read-back before closing the governance gate."
+Write-Host "Run scripts/verify_main_protection.ps1 with the same ReviewMode to certify live read-back before closing the governance gate."

--- a/scripts/apply_main_protection.ps1
+++ b/scripts/apply_main_protection.ps1
@@ -1,0 +1,80 @@
+[CmdletBinding()]
+param(
+    [string]$Repository = "Vertex-Systems-Network/ai-automation-force",
+    [string]$Branch = "main",
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("independent", "solo-self-review")]
+    [string]$ReviewMode
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Command([string]$Name) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found. Install/authenticate GitHub CLI before applying repository protection."
+    }
+}
+
+Require-Command "gh"
+
+gh auth status | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "GitHub CLI is not authenticated."
+}
+
+$requiredApprovals = if ($ReviewMode -eq "independent") { 1 } else { 0 }
+$requireLastPushApproval = $ReviewMode -eq "independent"
+
+$payload = [ordered]@{
+    required_status_checks = [ordered]@{
+        strict = $true
+        contexts = @(
+            "core-domain-contracts",
+            "durable-control-plane"
+        )
+    }
+    enforce_admins = $true
+    required_pull_request_reviews = [ordered]@{
+        dismiss_stale_reviews = $true
+        require_code_owner_reviews = $false
+        required_approving_review_count = $requiredApprovals
+        require_last_push_approval = $requireLastPushApproval
+        dismissal_restrictions = @{}
+        bypass_pull_request_allowances = @{}
+    }
+    restrictions = $null
+    required_conversation_resolution = $true
+    required_linear_history = $false
+    allow_force_pushes = $false
+    allow_deletions = $false
+    block_creations = $false
+    lock_branch = $false
+    allow_fork_syncing = $false
+}
+
+$temp = New-TemporaryFile
+try {
+    $payload | ConvertTo-Json -Depth 10 | Set-Content -Path $temp -Encoding utf8
+    gh api `
+        --method PUT `
+        -H "Accept: application/vnd.github+json" `
+        -H "X-GitHub-Api-Version: 2022-11-28" `
+        "repos/$Repository/branches/$Branch/protection" `
+        --input $temp
+    if ($LASTEXITCODE -ne 0) {
+        throw "GitHub rejected the branch-protection update."
+    }
+}
+finally {
+    Remove-Item $temp -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Applied protected-$Branch policy to $Repository."
+Write-Host "Required checks: core-domain-contracts, durable-control-plane"
+if ($ReviewMode -eq "independent") {
+    Write-Host "Review mode: at least one independent approving review; stale approvals dismissed; last-push approval enforced."
+}
+else {
+    Write-Warning "Review mode: explicit solo SELF REVIEW exception. Independent approval is not claimed; review provenance must remain explicit in PR/checkpoint evidence."
+}
+Write-Host "Run scripts/verify_main_protection.ps1 to certify live read-back before closing the governance gate."

--- a/scripts/verify_main_protection.ps1
+++ b/scripts/verify_main_protection.ps1
@@ -1,0 +1,93 @@
+[CmdletBinding()]
+param(
+    [string]$Repository = "Vertex-Systems-Network/ai-automation-force",
+    [string]$Branch = "main",
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("independent", "solo-self-review")]
+    [string]$ReviewMode
+)
+
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+    throw "Main protection verification failed: $Message"
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Fail "GitHub CLI is not installed."
+}
+
+gh auth status | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Fail "GitHub CLI is not authenticated."
+}
+
+$json = gh api `
+    -H "Accept: application/vnd.github+json" `
+    -H "X-GitHub-Api-Version: 2022-11-28" `
+    "repos/$Repository/branches/$Branch/protection"
+if ($LASTEXITCODE -ne 0 -or -not $json) {
+    Fail "live branch protection could not be read."
+}
+
+$protection = $json | ConvertFrom-Json -Depth 20
+
+if ($protection.required_status_checks.strict -ne $true) {
+    Fail "required status checks are not strict/up-to-date."
+}
+
+$contexts = @($protection.required_status_checks.contexts)
+foreach ($required in @("core-domain-contracts", "durable-control-plane")) {
+    if ($contexts -notcontains $required) {
+        Fail "required check '$required' is not enforced."
+    }
+}
+
+if ($contexts -contains "validate") {
+    Fail "ambiguous legacy check context 'validate' is still configured as a required context."
+}
+
+if ($protection.enforce_admins.enabled -ne $true) {
+    Fail "administrator enforcement is disabled."
+}
+if ($protection.required_conversation_resolution.enabled -ne $true) {
+    Fail "conversation resolution is not required."
+}
+if ($protection.allow_force_pushes.enabled -eq $true) {
+    Fail "force pushes are allowed."
+}
+if ($protection.allow_deletions.enabled -eq $true) {
+    Fail "branch deletion is allowed."
+}
+
+$reviews = $protection.required_pull_request_reviews
+if ($null -eq $reviews) {
+    Fail "pull-request review protection is absent."
+}
+if ($reviews.dismiss_stale_reviews -ne $true) {
+    Fail "stale review dismissal is disabled."
+}
+
+if ($ReviewMode -eq "independent") {
+    if ([int]$reviews.required_approving_review_count -lt 1) {
+        Fail "independent review mode requires at least one approving review."
+    }
+    if ($reviews.require_last_push_approval -ne $true) {
+        Fail "independent review mode requires last-push approval protection."
+    }
+}
+else {
+    if ([int]$reviews.required_approving_review_count -ne 0) {
+        Fail "solo SELF REVIEW exception expected zero required approving reviews."
+    }
+    Write-Warning "Live protection uses the explicit solo SELF REVIEW exception; this is not independent review authority."
+}
+
+Write-Host "PASS: live main protection is effective for $Repository/$Branch."
+Write-Host "Strict required checks: core-domain-contracts, durable-control-plane"
+Write-Host "PR-only integration: enforced"
+Write-Host "Admin enforcement: enabled"
+Write-Host "Conversation resolution: required"
+Write-Host "Force pushes: blocked"
+Write-Host "Branch deletion: blocked"
+Write-Host "Review mode: $ReviewMode"

--- a/scripts/verify_main_protection.ps1
+++ b/scripts/verify_main_protection.ps1
@@ -8,6 +8,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$GitHubActionsAppId = 15368
+$ApiVersion = "2026-03-10"
 
 function Fail([string]$Message) {
     throw "Main protection verification failed: $Message"
@@ -24,7 +26,7 @@ if ($LASTEXITCODE -ne 0) {
 
 $json = gh api `
     -H "Accept: application/vnd.github+json" `
-    -H "X-GitHub-Api-Version: 2022-11-28" `
+    -H "X-GitHub-Api-Version: $ApiVersion" `
     "repos/$Repository/branches/$Branch/protection"
 if ($LASTEXITCODE -ne 0 -or -not $json) {
     Fail "live branch protection could not be read."
@@ -37,13 +39,17 @@ if ($protection.required_status_checks.strict -ne $true) {
 }
 
 $contexts = @($protection.required_status_checks.contexts)
+$checks = @($protection.required_status_checks.checks)
 foreach ($required in @("core-domain-contracts", "durable-control-plane")) {
-    if ($contexts -notcontains $required) {
-        Fail "required check '$required' is not enforced."
+    $bound = @($checks | Where-Object {
+        $_.context -eq $required -and [int]$_.app_id -eq $GitHubActionsAppId
+    })
+    if ($bound.Count -ne 1) {
+        Fail "required check '$required' is not uniquely bound to GitHub Actions app_id=$GitHubActionsAppId."
     }
 }
 
-if ($contexts -contains "validate") {
+if ($contexts -contains "validate" -or @($checks | Where-Object { $_.context -eq "validate" }).Count -gt 0) {
     Fail "ambiguous legacy check context 'validate' is still configured as a required context."
 }
 
@@ -84,7 +90,7 @@ else {
 }
 
 Write-Host "PASS: live main protection is effective for $Repository/$Branch."
-Write-Host "Strict required checks: core-domain-contracts, durable-control-plane"
+Write-Host "Strict required GitHub Actions checks: core-domain-contracts, durable-control-plane (app_id=$GitHubActionsAppId)"
 Write-Host "PR-only integration: enforced"
 Write-Host "Admin enforcement: enabled"
 Write-Host "Conversation resolution: required"


### PR DESCRIPTION
## Superseded by promotion carrier

This draft governance carrier completed implementation + SELF REVIEW on exact head `65a1e8a66eaee99d92c5d84e7f049b9320a79701`.

Exact-head CI PASS:
- Repository Governance #3
- Core Domain Contracts #202
- Durable Control Plane #140

The connector's draft→ready GraphQL mutation is broken upstream (`Repository.fullDatabaseId` schema error), so this draft is intentionally closed unmerged and the same branch/head is reopened as a non-draft promotion PR. No bytes are changed for promotion.

This carrier never included M03/WP4 product/runtime/schema/migration code. Live main-protection read-back remains required after governance tooling lands; ABD-265 must remain open until that separate live acceptance passes.