### PR TITLE
M03-WP6: signed delivery authorization foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,22 +152,24 @@ The table below tracks the currently active implementation milestone. Completed 
 
 | Phase / Module | Scope | Start date | End date | Status | Progress |
 | --- | --- | --- | --- | --- | --- |
-| **M03 Overall** | Asset Storage and Provenance — 8 work packages | 2026-08-29 | TBD | 🟡 In progress | `█████░░░░░` **50% landed (4/8)** |
+| **M03 Overall** | Asset Storage and Provenance — 8 work packages | 2026-08-29 | TBD | 🟡 In progress | `██████▎░░░` **62.5% landed (5/8)** |
 | **M03-WP1** | Storage adapter and object metadata | 2026-08-29 | 2026-08-29 | ✅ Complete / landed | `██████████` **100%** |
 | **M03-WP2** | Upload sessions | 2026-08-29 | 2026-08-29 | ✅ Complete / landed | `██████████` **100%** |
 | **M03-WP3** | Quarantine/probe/security | 2026-08-29 | 2026-08-30 | ✅ Complete / landed | `██████████` **100%** |
 | **M03-WP4** | Asset lineage/provenance/rights | 2026-08-30 | 2026-08-31 | ✅ Complete / promoted to `main` | `██████████` **100%** |
-| **M03-WP5** | Derivatives/proxies | 2026-08-31 | TBD | 🟡 Active — stacked PR certification | `█████░░░░░` **active; not yet landed** |
-| ↳ **PR #39** | WP5 derivatives foundation | 2026-08-31 | TBD | 🟡 Stacked foundation | `███████░░░` **implementation present; awaiting stack promotion** |
-| ↳ **PR #40** | Executable derivative rendering worker | 2026-08-31 | TBD | 🟠 CI blocked — Core CI/Governance pass; Durable Control Plane failing | `███████░░░` **implementation present; certification pending** |
-| **M03-WP6** | Signed delivery | TBD | TBD | ⚪ Pending | `░░░░░░░░░░` **0%** |
+| **M03-WP5** | Derivatives/proxies | 2026-08-31 | 2026-09-01 | ✅ Complete / promoted to `main` | `██████████` **100%** |
+| ↳ **PR #41** | WP5 deterministic derivative foundation promotion | 2026-09-01 | 2026-09-01 | ✅ Merged | `██████████` **100%** |
+| ↳ **PR #42** | WP5 executable resource-bounded derivative worker promotion | 2026-09-01 | 2026-09-01 | ✅ Merged — fresh Governance/Core/Durable green | `██████████` **100%** |
+| **M03-WP6** | Signed delivery | 2026-09-01 | TBD | 🟡 Active — authorized delivery foundation | `░░░░░░░░░░` **0% landed; implementation active** |
 | **M03-WP7** | Retention/archive/delete/export primitives | TBD | TBD | ⚪ Pending | `░░░░░░░░░░` **0%** |
 | **M03-WP8** | Acceptance | TBD | TBD | ⚪ Pending | `░░░░░░░░░░` **0%** |
 
 ### Current engineering checkpoint
 
-The active development frontier is **M03-WP5**. PR #40 is stacked on the WP5 foundation in PR #39. Promotion remains gated on the repository's required checks; passing tests are not weakened or bypassed to manufacture completion.
+The active development frontier is **M03-WP6 — Signed delivery**. WP5 is fully promoted to `main`: PR #41 landed the deterministic derivative contract foundation and PR #42 landed the executable resource-bounded worker after fresh Repository Governance, Core Domain Contracts and Durable Control Plane verification.
+
+WP6 remains fail-closed around tenant boundaries: private media must use authorized short-lived access, public exposure must be explicit, and share-link behavior must stay constrained rather than becoming an alternate authorization bypass.
 
 Current continuation order:
 
-`WP5 failing test root cause -> minimal code fix -> Durable Control Plane green -> PR #40 certification -> stacked promotion -> WP5 completion -> WP6`
+`WP6 delivery/access contract -> S3 signed GET adapter -> tenant/share-link authorization -> Range strategy acceptance -> exact-head CI -> WP6 promotion -> WP7`

--- a/packages/python-core/src/ai_automation_force_core/__init__.py
+++ b/packages/python-core/src/ai_automation_force_core/__init__.py
@@ -6,6 +6,20 @@ namespace for pre-M01 repository code. New consumers should import this package.
 
 from lullabies_core import *  # noqa: F403
 from lullabies_core import __all__ as _legacy_all
+from lullabies_core.delivery import (
+    AssetAccessClass,
+    DeliveryAuthorization,
+    DeliveryAuthorizationError,
+    DeliveryAuthorizationKind,
+    DeliveryBindingError,
+    DeliveryMode,
+    DeliverySubject,
+    ShareLinkConstraint,
+    SignedDeliveryGrant,
+    authorize_delivery,
+    bind_delivery_subject,
+)
+from lullabies_core.delivery_s3 import DeliverySigningError, S3DeliveryAdapter
 from lullabies_core.derivatives import (
     DERIVATIVE_STATUS_TRANSITIONS,
     TERMINAL_DERIVATIVE_STATUSES,
@@ -88,6 +102,7 @@ from lullabies_core.upload_session import (
 
 __all__ = [
     *_legacy_all,
+    "AssetAccessClass",
     "AssetProvenancePersistResult",
     "AssetProvenanceRecord",
     "AssetProvenanceRecordId",
@@ -96,6 +111,13 @@ __all__ = [
     "AssetUsabilityPolicy",
     "AssetUsabilityRejection",
     "DERIVATIVE_STATUS_TRANSITIONS",
+    "DeliveryAuthorization",
+    "DeliveryAuthorizationError",
+    "DeliveryAuthorizationKind",
+    "DeliveryBindingError",
+    "DeliveryMode",
+    "DeliverySigningError",
+    "DeliverySubject",
     "DerivativeKind",
     "DerivativePersistenceConflictError",
     "DerivativePersistResult",
@@ -121,8 +143,11 @@ __all__ = [
     "QuarantinePersistenceConflictError",
     "QuarantineRejectionCode",
     "QuarantineStatus",
+    "S3DeliveryAdapter",
     "S3UploadCompletionEvidence",
     "S3UploadSessionAdapter",
+    "ShareLinkConstraint",
+    "SignedDeliveryGrant",
     "StorageAdapter",
     "StorageBackend",
     "StorageBlobStat",
@@ -147,6 +172,8 @@ __all__ = [
     "UploadSessionExpiredError",
     "UploadSessionStatus",
     "assert_derivative_transition",
+    "authorize_delivery",
+    "bind_delivery_subject",
     "build_object_key",
     "build_upload_object_key",
     "derivative_operation_fingerprint",

--- a/packages/python-core/src/ai_automation_force_core/delivery.py
+++ b/packages/python-core/src/ai_automation_force_core/delivery.py
@@ -1,0 +1,27 @@
+from lullabies_core.delivery import (
+    AssetAccessClass,
+    DeliveryAuthorization,
+    DeliveryAuthorizationError,
+    DeliveryAuthorizationKind,
+    DeliveryBindingError,
+    DeliveryMode,
+    DeliverySubject,
+    ShareLinkConstraint,
+    SignedDeliveryGrant,
+    authorize_delivery,
+    bind_delivery_subject,
+)
+
+__all__ = [
+    "AssetAccessClass",
+    "DeliveryAuthorization",
+    "DeliveryAuthorizationError",
+    "DeliveryAuthorizationKind",
+    "DeliveryBindingError",
+    "DeliveryMode",
+    "DeliverySubject",
+    "ShareLinkConstraint",
+    "SignedDeliveryGrant",
+    "authorize_delivery",
+    "bind_delivery_subject",
+]

--- a/packages/python-core/src/ai_automation_force_core/delivery_s3.py
+++ b/packages/python-core/src/ai_automation_force_core/delivery_s3.py
@@ -1,0 +1,3 @@
+from lullabies_core.delivery_s3 import DeliverySigningError, S3DeliveryAdapter
+
+__all__ = ["DeliverySigningError", "S3DeliveryAdapter"]

--- a/packages/python-core/src/lullabies_core/delivery.py
+++ b/packages/python-core/src/lullabies_core/delivery.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from .common import AssetId, ProjectId, StorageObjectId, StrictModel
+from .production import Asset
+from .provenance import AssetProvenanceRecord
+from .storage import StorageObject, validate_object_key
+
+
+class AssetAccessClass(StrEnum):
+    PRIVATE = "private"
+    PUBLIC = "public"
+
+
+class DeliveryMode(StrEnum):
+    DOWNLOAD = "download"
+    STREAM = "stream"
+
+
+class DeliveryAuthorizationKind(StrEnum):
+    PROJECT = "project"
+    SHARE_LINK = "share-link"
+    PUBLIC = "public"
+
+
+class DeliveryAuthorizationError(RuntimeError):
+    """A delivery request is not authorized by the canonical access boundary."""
+
+
+class DeliveryBindingError(RuntimeError):
+    """Canonical asset/provenance/storage records do not describe one object."""
+
+
+class DeliverySubject(StrictModel):
+    project_id: ProjectId
+    asset_id: AssetId
+    storage_object_id: StorageObjectId
+    object_key: str = Field(min_length=1, max_length=1024)
+    mime_type: str = Field(min_length=3, max_length=255)
+    access_class: AssetAccessClass = AssetAccessClass.PRIVATE
+
+    @model_validator(mode="after")
+    def validate_key(self) -> DeliverySubject:
+        validate_object_key(self.object_key)
+        return self
+
+
+class ShareLinkConstraint(StrictModel):
+    """Resolved share-link authority; raw bearer tokens are intentionally excluded."""
+
+    share_link_id: str = Field(min_length=8, max_length=160)
+    project_id: ProjectId
+    asset_id: AssetId
+    token_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    allowed_modes: list[DeliveryMode] = Field(min_length=1, max_length=2)
+    expires_at: AwareDatetime
+    revoked_at: AwareDatetime | None = None
+    max_uses: int | None = Field(default=None, ge=1, le=1_000_000)
+    use_count: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def validate_constraint(self) -> ShareLinkConstraint:
+        if len(set(self.allowed_modes)) != len(self.allowed_modes):
+            raise ValueError("allowed_modes must not contain duplicates")
+        if self.revoked_at is not None and self.revoked_at > self.expires_at:
+            raise ValueError("revoked_at must not follow expires_at")
+        if self.max_uses is not None and self.use_count > self.max_uses:
+            raise ValueError("use_count must not exceed max_uses")
+        return self
+
+
+class DeliveryAuthorization(StrictModel):
+    kind: DeliveryAuthorizationKind
+    project_id: ProjectId
+    asset_id: AssetId
+    share_link_id: str | None = Field(default=None, min_length=8, max_length=160)
+
+    @model_validator(mode="after")
+    def validate_share_link_reference(self) -> DeliveryAuthorization:
+        if self.kind is DeliveryAuthorizationKind.SHARE_LINK and self.share_link_id is None:
+            raise ValueError("share-link authorization requires share_link_id")
+        if self.kind is not DeliveryAuthorizationKind.SHARE_LINK and self.share_link_id is not None:
+            raise ValueError("only share-link authorization may carry share_link_id")
+        return self
+
+
+class SignedDeliveryGrant(StrictModel):
+    """Ephemeral delivery capability; never canonical persistence or authorization."""
+
+    method: Literal["GET"] = "GET"
+    url: str = Field(min_length=1)
+    object_key: str = Field(min_length=1, max_length=1024)
+    mode: DeliveryMode
+    authorization: DeliveryAuthorizationKind
+    expires_at: AwareDatetime
+    supports_range: bool = True
+
+    @model_validator(mode="after")
+    def validate_key(self) -> SignedDeliveryGrant:
+        validate_object_key(self.object_key)
+        return self
+
+
+def bind_delivery_subject(
+    asset: Asset,
+    provenance: AssetProvenanceRecord,
+    storage_object: StorageObject,
+    *,
+    access_class: AssetAccessClass = AssetAccessClass.PRIVATE,
+) -> DeliverySubject:
+    """Bind delivery only when canonical identity, project and bytes agree exactly."""
+
+    if asset.project_id is None:
+        raise DeliveryBindingError("delivery requires a project-scoped asset")
+    if provenance.asset_id != asset.asset_id:
+        raise DeliveryBindingError("provenance asset does not match delivery asset")
+    if provenance.project_id != asset.project_id:
+        raise DeliveryBindingError("provenance project does not match delivery asset")
+    if provenance.storage_object_id != storage_object.storage_object_id:
+        raise DeliveryBindingError("provenance storage object does not match delivery object")
+    if storage_object.project_id != asset.project_id:
+        raise DeliveryBindingError("storage object project does not match delivery asset")
+    if provenance.content_sha256 != asset.sha256 or storage_object.sha256 != asset.sha256:
+        raise DeliveryBindingError("delivery authority hashes do not agree")
+    if storage_object.mime_type != asset.mime_type:
+        raise DeliveryBindingError("storage object MIME type does not match delivery asset")
+
+    return DeliverySubject(
+        project_id=asset.project_id,
+        asset_id=asset.asset_id,
+        storage_object_id=storage_object.storage_object_id,
+        object_key=storage_object.object_key,
+        mime_type=storage_object.mime_type,
+        access_class=access_class,
+    )
+
+
+def authorize_delivery(
+    subject: DeliverySubject,
+    mode: DeliveryMode,
+    *,
+    now: datetime,
+    requester_project_id: str | None = None,
+    share_link: ShareLinkConstraint | None = None,
+) -> DeliveryAuthorization:
+    """Resolve one fail-closed access path without treating a signed URL as authorization."""
+
+    if requester_project_id is not None and requester_project_id == subject.project_id:
+        return DeliveryAuthorization(
+            kind=DeliveryAuthorizationKind.PROJECT,
+            project_id=subject.project_id,
+            asset_id=subject.asset_id,
+        )
+
+    if share_link is not None:
+        if share_link.project_id != subject.project_id or share_link.asset_id != subject.asset_id:
+            raise DeliveryAuthorizationError("share link is not bound to the requested asset")
+        if share_link.revoked_at is not None:
+            raise DeliveryAuthorizationError("share link is revoked")
+        if now >= share_link.expires_at:
+            raise DeliveryAuthorizationError("share link is expired")
+        if mode not in share_link.allowed_modes:
+            raise DeliveryAuthorizationError("share link does not authorize the requested mode")
+        if share_link.max_uses is not None and share_link.use_count >= share_link.max_uses:
+            raise DeliveryAuthorizationError("share link use limit is exhausted")
+        return DeliveryAuthorization(
+            kind=DeliveryAuthorizationKind.SHARE_LINK,
+            project_id=subject.project_id,
+            asset_id=subject.asset_id,
+            share_link_id=share_link.share_link_id,
+        )
+
+    if subject.access_class is AssetAccessClass.PUBLIC:
+        return DeliveryAuthorization(
+            kind=DeliveryAuthorizationKind.PUBLIC,
+            project_id=subject.project_id,
+            asset_id=subject.asset_id,
+        )
+
+    raise DeliveryAuthorizationError("private asset delivery requires project or share-link authority")

--- a/packages/python-core/src/lullabies_core/delivery.py
+++ b/packages/python-core/src/lullabies_core/delivery.py
@@ -182,4 +182,6 @@ def authorize_delivery(
             asset_id=subject.asset_id,
         )
 
-    raise DeliveryAuthorizationError("private asset delivery requires project or share-link authority")
+    raise DeliveryAuthorizationError(
+        "private asset delivery requires project or share-link authority"
+    )

--- a/packages/python-core/src/lullabies_core/delivery_s3.py
+++ b/packages/python-core/src/lullabies_core/delivery_s3.py
@@ -40,7 +40,9 @@ class S3DeliveryAdapter:
         expires_in_seconds: int = 900,
     ) -> SignedDeliveryGrant:
         if authorization.project_id != subject.project_id:
-            raise DeliveryAuthorizationError("authorization project does not match delivery subject")
+            raise DeliveryAuthorizationError(
+                "authorization project does not match delivery subject"
+            )
         if authorization.asset_id != subject.asset_id:
             raise DeliveryAuthorizationError("authorization asset does not match delivery subject")
         if expires_in_seconds < 1 or expires_in_seconds > self.max_expiry_seconds:

--- a/packages/python-core/src/lullabies_core/delivery_s3.py
+++ b/packages/python-core/src/lullabies_core/delivery_s3.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+from .delivery import (
+    DeliveryAuthorization,
+    DeliveryAuthorizationError,
+    DeliveryMode,
+    DeliverySubject,
+    SignedDeliveryGrant,
+)
+from .storage import StorageBackend
+from .storage_s3 import S3StorageAdapter
+
+
+class DeliverySigningError(RuntimeError):
+    """The storage backend could not issue a valid ephemeral delivery capability."""
+
+
+@dataclass(frozen=True)
+class S3DeliveryAdapter:
+    """Issue exact-object, short-lived S3 GET capabilities after authorization."""
+
+    storage: S3StorageAdapter
+    max_expiry_seconds: int = 3600
+
+    def __post_init__(self) -> None:
+        if self.max_expiry_seconds < 1 or self.max_expiry_seconds > 3600:
+            raise ValueError("max_expiry_seconds must be between 1 and 3600 seconds")
+
+    def create_grant(
+        self,
+        subject: DeliverySubject,
+        authorization: DeliveryAuthorization,
+        *,
+        mode: DeliveryMode,
+        now: datetime,
+        expires_in_seconds: int = 900,
+    ) -> SignedDeliveryGrant:
+        if authorization.project_id != subject.project_id:
+            raise DeliveryAuthorizationError("authorization project does not match delivery subject")
+        if authorization.asset_id != subject.asset_id:
+            raise DeliveryAuthorizationError("authorization asset does not match delivery subject")
+        if expires_in_seconds < 1 or expires_in_seconds > self.max_expiry_seconds:
+            raise ValueError(
+                f"signed delivery expiry must be between 1 and {self.max_expiry_seconds} seconds"
+            )
+
+        params: dict[str, Any] = {
+            "Bucket": self.storage.settings.bucket,
+            "Key": subject.object_key,
+            "ResponseContentType": subject.mime_type,
+            "ResponseContentDisposition": (
+                "attachment" if mode is DeliveryMode.DOWNLOAD else "inline"
+            ),
+        }
+        url = self.storage.client.generate_presigned_url(
+            ClientMethod="get_object",
+            Params=params,
+            ExpiresIn=expires_in_seconds,
+            HttpMethod="GET",
+        )
+        if not isinstance(url, str) or not url:
+            raise DeliverySigningError("S3 did not return a signed delivery URL")
+
+        return SignedDeliveryGrant(
+            url=url,
+            object_key=subject.object_key,
+            mode=mode,
+            authorization=authorization.kind,
+            expires_at=now + timedelta(seconds=expires_in_seconds),
+            # S3 GET accepts ordinary HTTP Range requests against the same signed
+            # capability. Range is deliberately not embedded in the signature so one
+            # short-lived stream grant can support seeking without widening object scope.
+            supports_range=True,
+        )
+
+    @property
+    def backend(self) -> StorageBackend:
+        return self.storage.backend

--- a/packages/python-core/tests/test_delivery.py
+++ b/packages/python-core/tests/test_delivery.py
@@ -7,7 +7,6 @@ import pytest
 import ai_automation_force_core as core
 from ai_automation_force_core import delivery
 
-
 NOW = datetime(2026, 9, 1, 19, 0, tzinfo=UTC)
 DIGEST = "a" * 64
 

--- a/packages/python-core/tests/test_delivery.py
+++ b/packages/python-core/tests/test_delivery.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 import ai_automation_force_core as core
-import ai_automation_force_core.delivery as delivery
+from ai_automation_force_core import delivery
 
 
 NOW = datetime(2026, 9, 1, 19, 0, tzinfo=UTC)

--- a/packages/python-core/tests/test_delivery.py
+++ b/packages/python-core/tests/test_delivery.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ai_automation_force_core import (
+    Asset,
+    AssetAccessClass,
+    AssetKind,
+    AssetProvenanceRecord,
+    AssetProvenanceSource,
+    AuditFields,
+    DeliveryAuthorizationError,
+    DeliveryAuthorizationKind,
+    DeliveryBindingError,
+    DeliveryMode,
+    ShareLinkConstraint,
+    StorageBackend,
+    StorageObject,
+    authorize_delivery,
+    bind_delivery_subject,
+    build_object_key,
+)
+
+
+NOW = datetime(2026, 9, 1, 19, 0, tzinfo=UTC)
+DIGEST = "a" * 64
+
+
+def canonical_records() -> tuple[Asset, AssetProvenanceRecord, StorageObject]:
+    asset = Asset(
+        asset_id="AST-006001",
+        project_id="PRJ-006001",
+        kind=AssetKind.IMAGE,
+        uri="s3://aaf-private/source/PRJ-006001/STO-006001",
+        sha256=DIGEST,
+        mime_type="image/png",
+        size_bytes=12,
+        audit=AuditFields(created_at=NOW, updated_at=NOW, created_by="wp6-test"),
+    )
+    provenance = AssetProvenanceRecord(
+        provenance_record_id="PRV-006001",
+        asset_id=asset.asset_id,
+        project_id=asset.project_id,
+        storage_object_id="STO-006001",
+        source_kind=AssetProvenanceSource.UPLOAD,
+        content_sha256=DIGEST,
+        created_at=NOW,
+    )
+    storage = StorageObject(
+        storage_object_id="STO-006001",
+        project_id=asset.project_id,
+        backend=StorageBackend.S3,
+        bucket="aaf-private",
+        object_key=build_object_key(
+            "source",
+            "STO-006001",
+            project_id="PRJ-006001",
+        ),
+        sha256=DIGEST,
+        mime_type="image/png",
+        size_bytes=12,
+        region="us-east-1",
+        audit=AuditFields(created_at=NOW, updated_at=NOW, created_by="wp6-test"),
+    )
+    return asset, provenance, storage
+
+
+def test_delivery_binding_requires_exact_project_storage_hash_and_mime_authority() -> None:
+    asset, provenance, storage = canonical_records()
+
+    subject = bind_delivery_subject(asset, provenance, storage)
+
+    assert subject.project_id == "PRJ-006001"
+    assert subject.asset_id == "AST-006001"
+    assert subject.storage_object_id == "STO-006001"
+    assert subject.access_class is AssetAccessClass.PRIVATE
+
+    with pytest.raises(DeliveryBindingError, match="storage object project"):
+        bind_delivery_subject(
+            asset,
+            provenance,
+            storage.model_copy(update={"project_id": "PRJ-006002"}),
+        )
+
+    with pytest.raises(DeliveryBindingError, match="hashes do not agree"):
+        bind_delivery_subject(
+            asset,
+            provenance,
+            storage.model_copy(update={"sha256": "b" * 64}),
+        )
+
+    with pytest.raises(DeliveryBindingError, match="MIME type"):
+        bind_delivery_subject(
+            asset,
+            provenance,
+            storage.model_copy(update={"mime_type": "image/jpeg"}),
+        )
+
+
+def test_private_delivery_fails_closed_across_projects() -> None:
+    asset, provenance, storage = canonical_records()
+    subject = bind_delivery_subject(asset, provenance, storage)
+
+    authorized = authorize_delivery(
+        subject,
+        DeliveryMode.DOWNLOAD,
+        now=NOW,
+        requester_project_id="PRJ-006001",
+    )
+    assert authorized.kind is DeliveryAuthorizationKind.PROJECT
+
+    with pytest.raises(DeliveryAuthorizationError, match="private asset"):
+        authorize_delivery(
+            subject,
+            DeliveryMode.DOWNLOAD,
+            now=NOW,
+            requester_project_id="PRJ-006999",
+        )
+
+
+def test_public_access_is_explicit_and_does_not_change_object_scope() -> None:
+    asset, provenance, storage = canonical_records()
+    subject = bind_delivery_subject(
+        asset,
+        provenance,
+        storage,
+        access_class=AssetAccessClass.PUBLIC,
+    )
+
+    authorized = authorize_delivery(subject, DeliveryMode.STREAM, now=NOW)
+
+    assert authorized.kind is DeliveryAuthorizationKind.PUBLIC
+    assert authorized.asset_id == asset.asset_id
+    assert authorized.project_id == asset.project_id
+
+
+def test_share_link_is_exact_asset_mode_expiry_revocation_and_use_bound() -> None:
+    asset, provenance, storage = canonical_records()
+    subject = bind_delivery_subject(asset, provenance, storage)
+    link = ShareLinkConstraint(
+        share_link_id="SHARE-006001",
+        project_id="PRJ-006001",
+        asset_id="AST-006001",
+        token_sha256="c" * 64,
+        allowed_modes=[DeliveryMode.STREAM],
+        expires_at=NOW + timedelta(minutes=10),
+        max_uses=2,
+        use_count=1,
+    )
+
+    authorized = authorize_delivery(
+        subject,
+        DeliveryMode.STREAM,
+        now=NOW,
+        requester_project_id="PRJ-006999",
+        share_link=link,
+    )
+    assert authorized.kind is DeliveryAuthorizationKind.SHARE_LINK
+    assert authorized.share_link_id == "SHARE-006001"
+
+    with pytest.raises(DeliveryAuthorizationError, match="requested mode"):
+        authorize_delivery(subject, DeliveryMode.DOWNLOAD, now=NOW, share_link=link)
+
+    with pytest.raises(DeliveryAuthorizationError, match="expired"):
+        authorize_delivery(
+            subject,
+            DeliveryMode.STREAM,
+            now=link.expires_at,
+            share_link=link,
+        )
+
+    with pytest.raises(DeliveryAuthorizationError, match="revoked"):
+        authorize_delivery(
+            subject,
+            DeliveryMode.STREAM,
+            now=NOW,
+            share_link=link.model_copy(update={"revoked_at": NOW}),
+        )
+
+    with pytest.raises(DeliveryAuthorizationError, match="use limit"):
+        authorize_delivery(
+            subject,
+            DeliveryMode.STREAM,
+            now=NOW,
+            share_link=link.model_copy(update={"use_count": 2}),
+        )
+
+    with pytest.raises(DeliveryAuthorizationError, match="not bound"):
+        authorize_delivery(
+            subject,
+            DeliveryMode.STREAM,
+            now=NOW,
+            share_link=link.model_copy(update={"asset_id": "AST-006002"}),
+        )

--- a/packages/python-core/tests/test_delivery.py
+++ b/packages/python-core/tests/test_delivery.py
@@ -4,58 +4,40 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from ai_automation_force_core import (
-    Asset,
-    AssetKind,
-    AssetProvenanceRecord,
-    AssetProvenanceSource,
-    AuditFields,
-    StorageBackend,
-    StorageObject,
-    build_object_key,
-)
-from ai_automation_force_core.delivery import (
-    AssetAccessClass,
-    DeliveryAuthorizationError,
-    DeliveryAuthorizationKind,
-    DeliveryBindingError,
-    DeliveryMode,
-    ShareLinkConstraint,
-    authorize_delivery,
-    bind_delivery_subject,
-)
+import ai_automation_force_core as core
+import ai_automation_force_core.delivery as delivery
 
 
 NOW = datetime(2026, 9, 1, 19, 0, tzinfo=UTC)
 DIGEST = "a" * 64
 
 
-def canonical_records() -> tuple[Asset, AssetProvenanceRecord, StorageObject]:
-    asset = Asset(
+def canonical_records() -> tuple[core.Asset, core.AssetProvenanceRecord, core.StorageObject]:
+    asset = core.Asset(
         asset_id="AST-006001",
         project_id="PRJ-006001",
-        kind=AssetKind.IMAGE,
+        kind=core.AssetKind.IMAGE,
         uri="s3://aaf-private/source/PRJ-006001/STO-006001",
         sha256=DIGEST,
         mime_type="image/png",
         size_bytes=12,
-        audit=AuditFields(created_at=NOW, updated_at=NOW, created_by="wp6-test"),
+        audit=core.AuditFields(created_at=NOW, updated_at=NOW, created_by="wp6-test"),
     )
-    provenance = AssetProvenanceRecord(
+    provenance = core.AssetProvenanceRecord(
         provenance_record_id="PRV-006001",
         asset_id=asset.asset_id,
         project_id=asset.project_id,
         storage_object_id="STO-006001",
-        source_kind=AssetProvenanceSource.UPLOAD,
+        source_kind=core.AssetProvenanceSource.UPLOAD,
         content_sha256=DIGEST,
         created_at=NOW,
     )
-    storage = StorageObject(
+    storage = core.StorageObject(
         storage_object_id="STO-006001",
         project_id=asset.project_id,
-        backend=StorageBackend.S3,
+        backend=core.StorageBackend.S3,
         bucket="aaf-private",
-        object_key=build_object_key(
+        object_key=core.build_object_key(
             "source",
             "STO-006001",
             project_id="PRJ-006001",
@@ -64,7 +46,7 @@ def canonical_records() -> tuple[Asset, AssetProvenanceRecord, StorageObject]:
         mime_type="image/png",
         size_bytes=12,
         region="us-east-1",
-        audit=AuditFields(created_at=NOW, updated_at=NOW, created_by="wp6-test"),
+        audit=core.AuditFields(created_at=NOW, updated_at=NOW, created_by="wp6-test"),
     )
     return asset, provenance, storage
 
@@ -72,29 +54,29 @@ def canonical_records() -> tuple[Asset, AssetProvenanceRecord, StorageObject]:
 def test_delivery_binding_requires_exact_project_storage_hash_and_mime_authority() -> None:
     asset, provenance, storage = canonical_records()
 
-    subject = bind_delivery_subject(asset, provenance, storage)
+    subject = delivery.bind_delivery_subject(asset, provenance, storage)
 
     assert subject.project_id == "PRJ-006001"
     assert subject.asset_id == "AST-006001"
     assert subject.storage_object_id == "STO-006001"
-    assert subject.access_class is AssetAccessClass.PRIVATE
+    assert subject.access_class is delivery.AssetAccessClass.PRIVATE
 
-    with pytest.raises(DeliveryBindingError, match="storage object project"):
-        bind_delivery_subject(
+    with pytest.raises(delivery.DeliveryBindingError, match="storage object project"):
+        delivery.bind_delivery_subject(
             asset,
             provenance,
             storage.model_copy(update={"project_id": "PRJ-006002"}),
         )
 
-    with pytest.raises(DeliveryBindingError, match="hashes do not agree"):
-        bind_delivery_subject(
+    with pytest.raises(delivery.DeliveryBindingError, match="hashes do not agree"):
+        delivery.bind_delivery_subject(
             asset,
             provenance,
             storage.model_copy(update={"sha256": "b" * 64}),
         )
 
-    with pytest.raises(DeliveryBindingError, match="MIME type"):
-        bind_delivery_subject(
+    with pytest.raises(delivery.DeliveryBindingError, match="MIME type"):
+        delivery.bind_delivery_subject(
             asset,
             provenance,
             storage.model_copy(update={"mime_type": "image/jpeg"}),
@@ -103,20 +85,20 @@ def test_delivery_binding_requires_exact_project_storage_hash_and_mime_authority
 
 def test_private_delivery_fails_closed_across_projects() -> None:
     asset, provenance, storage = canonical_records()
-    subject = bind_delivery_subject(asset, provenance, storage)
+    subject = delivery.bind_delivery_subject(asset, provenance, storage)
 
-    authorized = authorize_delivery(
+    authorized = delivery.authorize_delivery(
         subject,
-        DeliveryMode.DOWNLOAD,
+        delivery.DeliveryMode.DOWNLOAD,
         now=NOW,
         requester_project_id="PRJ-006001",
     )
-    assert authorized.kind is DeliveryAuthorizationKind.PROJECT
+    assert authorized.kind is delivery.DeliveryAuthorizationKind.PROJECT
 
-    with pytest.raises(DeliveryAuthorizationError, match="private asset"):
-        authorize_delivery(
+    with pytest.raises(delivery.DeliveryAuthorizationError, match="private asset"):
+        delivery.authorize_delivery(
             subject,
-            DeliveryMode.DOWNLOAD,
+            delivery.DeliveryMode.DOWNLOAD,
             now=NOW,
             requester_project_id="PRJ-006999",
         )
@@ -124,75 +106,80 @@ def test_private_delivery_fails_closed_across_projects() -> None:
 
 def test_public_access_is_explicit_and_does_not_change_object_scope() -> None:
     asset, provenance, storage = canonical_records()
-    subject = bind_delivery_subject(
+    subject = delivery.bind_delivery_subject(
         asset,
         provenance,
         storage,
-        access_class=AssetAccessClass.PUBLIC,
+        access_class=delivery.AssetAccessClass.PUBLIC,
     )
 
-    authorized = authorize_delivery(subject, DeliveryMode.STREAM, now=NOW)
+    authorized = delivery.authorize_delivery(subject, delivery.DeliveryMode.STREAM, now=NOW)
 
-    assert authorized.kind is DeliveryAuthorizationKind.PUBLIC
+    assert authorized.kind is delivery.DeliveryAuthorizationKind.PUBLIC
     assert authorized.asset_id == asset.asset_id
     assert authorized.project_id == asset.project_id
 
 
 def test_share_link_is_exact_asset_mode_expiry_revocation_and_use_bound() -> None:
     asset, provenance, storage = canonical_records()
-    subject = bind_delivery_subject(asset, provenance, storage)
-    link = ShareLinkConstraint(
+    subject = delivery.bind_delivery_subject(asset, provenance, storage)
+    link = delivery.ShareLinkConstraint(
         share_link_id="SHARE-006001",
         project_id="PRJ-006001",
         asset_id="AST-006001",
         token_sha256="c" * 64,
-        allowed_modes=[DeliveryMode.STREAM],
+        allowed_modes=[delivery.DeliveryMode.STREAM],
         expires_at=NOW + timedelta(minutes=10),
         max_uses=2,
         use_count=1,
     )
 
-    authorized = authorize_delivery(
+    authorized = delivery.authorize_delivery(
         subject,
-        DeliveryMode.STREAM,
+        delivery.DeliveryMode.STREAM,
         now=NOW,
         requester_project_id="PRJ-006999",
         share_link=link,
     )
-    assert authorized.kind is DeliveryAuthorizationKind.SHARE_LINK
+    assert authorized.kind is delivery.DeliveryAuthorizationKind.SHARE_LINK
     assert authorized.share_link_id == "SHARE-006001"
 
-    with pytest.raises(DeliveryAuthorizationError, match="requested mode"):
-        authorize_delivery(subject, DeliveryMode.DOWNLOAD, now=NOW, share_link=link)
-
-    with pytest.raises(DeliveryAuthorizationError, match="expired"):
-        authorize_delivery(
+    with pytest.raises(delivery.DeliveryAuthorizationError, match="requested mode"):
+        delivery.authorize_delivery(
             subject,
-            DeliveryMode.STREAM,
+            delivery.DeliveryMode.DOWNLOAD,
+            now=NOW,
+            share_link=link,
+        )
+
+    with pytest.raises(delivery.DeliveryAuthorizationError, match="expired"):
+        delivery.authorize_delivery(
+            subject,
+            delivery.DeliveryMode.STREAM,
             now=link.expires_at,
             share_link=link,
         )
 
-    with pytest.raises(DeliveryAuthorizationError, match="revoked"):
-        authorize_delivery(
+    with pytest.raises(delivery.DeliveryAuthorizationError, match="revoked"):
+        delivery.authorize_delivery(
             subject,
-            DeliveryMode.STREAM,
+            delivery.DeliveryMode.STREAM,
             now=NOW,
             share_link=link.model_copy(update={"revoked_at": NOW}),
         )
 
-    with pytest.raises(DeliveryAuthorizationError, match="use limit"):
-        authorize_delivery(
+    with pytest.raises(delivery.DeliveryAuthorizationError, match="use limit"):
+        delivery.authorize_delivery(
             subject,
-            DeliveryMode.STREAM,
+            delivery.DeliveryMode.STREAM,
             now=NOW,
             share_link=link.model_copy(update={"use_count": 2}),
         )
 
-    with pytest.raises(DeliveryAuthorizationError, match="not bound"):
-        authorize_delivery(
+    with pytest.raises(delivery.DeliveryAuthorizationError, match="not bound"):
+        delivery.authorize_delivery(
             subject,
-            DeliveryMode.STREAM,
+            delivery.DeliveryMode.STREAM,
             now=NOW,
             share_link=link.model_copy(update={"asset_id": "AST-006002"}),
         )

--- a/packages/python-core/tests/test_delivery.py
+++ b/packages/python-core/tests/test_delivery.py
@@ -6,21 +6,23 @@ import pytest
 
 from ai_automation_force_core import (
     Asset,
-    AssetAccessClass,
     AssetKind,
     AssetProvenanceRecord,
     AssetProvenanceSource,
     AuditFields,
+    StorageBackend,
+    StorageObject,
+    build_object_key,
+)
+from ai_automation_force_core.delivery import (
+    AssetAccessClass,
     DeliveryAuthorizationError,
     DeliveryAuthorizationKind,
     DeliveryBindingError,
     DeliveryMode,
     ShareLinkConstraint,
-    StorageBackend,
-    StorageObject,
     authorize_delivery,
     bind_delivery_subject,
-    build_object_key,
 )
 
 

--- a/packages/python-core/tests/test_delivery_s3.py
+++ b/packages/python-core/tests/test_delivery_s3.py
@@ -7,7 +7,6 @@ import pytest
 
 from ai_automation_force_core import delivery, delivery_s3, storage_s3
 
-
 NOW = datetime(2026, 9, 1, 19, 30, tzinfo=UTC)
 
 

--- a/packages/python-core/tests/test_delivery_s3.py
+++ b/packages/python-core/tests/test_delivery_s3.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from ai_automation_force_core import (
+    AssetAccessClass,
+    DeliveryAuthorization,
+    DeliveryAuthorizationError,
+    DeliveryAuthorizationKind,
+    DeliveryMode,
+    DeliverySubject,
+    S3DeliveryAdapter,
+)
+from ai_automation_force_core.storage_s3 import S3StorageAdapter, S3StorageSettings
+
+
+NOW = datetime(2026, 9, 1, 19, 30, tzinfo=UTC)
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.signed_url: object = "https://storage.example/private-object?signature=opaque"
+
+    def generate_presigned_url(self, **kwargs: Any) -> object:
+        self.calls.append(("generate_presigned_url", kwargs))
+        return self.signed_url
+
+
+def subject() -> DeliverySubject:
+    return DeliverySubject(
+        project_id="PRJ-006101",
+        asset_id="AST-006101",
+        storage_object_id="STO-006101",
+        object_key="source/PRJ-006101/STO-006101",
+        mime_type="video/mp4",
+        access_class=AssetAccessClass.PRIVATE,
+    )
+
+
+def authorization() -> DeliveryAuthorization:
+    return DeliveryAuthorization(
+        kind=DeliveryAuthorizationKind.PROJECT,
+        project_id="PRJ-006101",
+        asset_id="AST-006101",
+    )
+
+
+def adapter(client: FakeS3Client) -> S3DeliveryAdapter:
+    storage = S3StorageAdapter(
+        S3StorageSettings(bucket="aaf-private", region_name="us-east-1"),
+        client=client,
+    )
+    return S3DeliveryAdapter(storage)
+
+
+def test_stream_grant_signs_exact_get_object_and_leaves_range_requestable() -> None:
+    client = FakeS3Client()
+    delivery = adapter(client)
+
+    grant = delivery.create_grant(
+        subject(),
+        authorization(),
+        mode=DeliveryMode.STREAM,
+        now=NOW,
+        expires_in_seconds=300,
+    )
+
+    assert grant.method == "GET"
+    assert grant.mode is DeliveryMode.STREAM
+    assert grant.supports_range is True
+    assert grant.expires_at == NOW + timedelta(seconds=300)
+    assert grant.authorization is DeliveryAuthorizationKind.PROJECT
+
+    name, kwargs = client.calls[-1]
+    assert name == "generate_presigned_url"
+    assert kwargs["ClientMethod"] == "get_object"
+    assert kwargs["HttpMethod"] == "GET"
+    assert kwargs["ExpiresIn"] == 300
+    assert kwargs["Params"] == {
+        "Bucket": "aaf-private",
+        "Key": "source/PRJ-006101/STO-006101",
+        "ResponseContentType": "video/mp4",
+        "ResponseContentDisposition": "inline",
+    }
+    assert "Range" not in kwargs["Params"]
+
+
+def test_download_grant_uses_attachment_and_is_short_lived() -> None:
+    client = FakeS3Client()
+    delivery = adapter(client)
+
+    grant = delivery.create_grant(
+        subject(),
+        authorization(),
+        mode=DeliveryMode.DOWNLOAD,
+        now=NOW,
+        expires_in_seconds=60,
+    )
+
+    assert grant.expires_at == NOW + timedelta(seconds=60)
+    assert client.calls[-1][1]["Params"]["ResponseContentDisposition"] == "attachment"
+
+    with pytest.raises(ValueError, match="between 1 and 3600"):
+        delivery.create_grant(
+            subject(),
+            authorization(),
+            mode=DeliveryMode.DOWNLOAD,
+            now=NOW,
+            expires_in_seconds=3601,
+        )
+
+
+def test_signing_refuses_authority_for_another_asset_or_project() -> None:
+    client = FakeS3Client()
+    delivery = adapter(client)
+
+    with pytest.raises(DeliveryAuthorizationError, match="project"):
+        delivery.create_grant(
+            subject(),
+            authorization().model_copy(update={"project_id": "PRJ-006999"}),
+            mode=DeliveryMode.STREAM,
+            now=NOW,
+        )
+
+    with pytest.raises(DeliveryAuthorizationError, match="asset"):
+        delivery.create_grant(
+            subject(),
+            authorization().model_copy(update={"asset_id": "AST-006999"}),
+            mode=DeliveryMode.STREAM,
+            now=NOW,
+        )
+
+    assert client.calls == []
+
+
+def test_invalid_signed_url_fails_closed() -> None:
+    client = FakeS3Client()
+    client.signed_url = ""
+    delivery = adapter(client)
+
+    with pytest.raises(RuntimeError, match="did not return"):
+        delivery.create_grant(
+            subject(),
+            authorization(),
+            mode=DeliveryMode.STREAM,
+            now=NOW,
+        )

--- a/packages/python-core/tests/test_delivery_s3.py
+++ b/packages/python-core/tests/test_delivery_s3.py
@@ -5,9 +5,7 @@ from typing import Any
 
 import pytest
 
-import ai_automation_force_core.delivery as delivery
-import ai_automation_force_core.delivery_s3 as delivery_s3
-import ai_automation_force_core.storage_s3 as storage_s3
+from ai_automation_force_core import delivery, delivery_s3, storage_s3
 
 
 NOW = datetime(2026, 9, 1, 19, 30, tzinfo=UTC)

--- a/packages/python-core/tests/test_delivery_s3.py
+++ b/packages/python-core/tests/test_delivery_s3.py
@@ -5,16 +5,9 @@ from typing import Any
 
 import pytest
 
-from ai_automation_force_core.delivery import (
-    AssetAccessClass,
-    DeliveryAuthorization,
-    DeliveryAuthorizationError,
-    DeliveryAuthorizationKind,
-    DeliveryMode,
-    DeliverySubject,
-)
-from ai_automation_force_core.delivery_s3 import S3DeliveryAdapter
-from ai_automation_force_core.storage_s3 import S3StorageAdapter, S3StorageSettings
+import ai_automation_force_core.delivery as delivery
+import ai_automation_force_core.delivery_s3 as delivery_s3
+import ai_automation_force_core.storage_s3 as storage_s3
 
 
 NOW = datetime(2026, 9, 1, 19, 30, tzinfo=UTC)
@@ -30,50 +23,50 @@ class FakeS3Client:
         return self.signed_url
 
 
-def subject() -> DeliverySubject:
-    return DeliverySubject(
+def subject() -> delivery.DeliverySubject:
+    return delivery.DeliverySubject(
         project_id="PRJ-006101",
         asset_id="AST-006101",
         storage_object_id="STO-006101",
         object_key="source/PRJ-006101/STO-006101",
         mime_type="video/mp4",
-        access_class=AssetAccessClass.PRIVATE,
+        access_class=delivery.AssetAccessClass.PRIVATE,
     )
 
 
-def authorization() -> DeliveryAuthorization:
-    return DeliveryAuthorization(
-        kind=DeliveryAuthorizationKind.PROJECT,
+def authorization() -> delivery.DeliveryAuthorization:
+    return delivery.DeliveryAuthorization(
+        kind=delivery.DeliveryAuthorizationKind.PROJECT,
         project_id="PRJ-006101",
         asset_id="AST-006101",
     )
 
 
-def adapter(client: FakeS3Client) -> S3DeliveryAdapter:
-    storage = S3StorageAdapter(
-        S3StorageSettings(bucket="aaf-private", region_name="us-east-1"),
+def adapter(client: FakeS3Client) -> delivery_s3.S3DeliveryAdapter:
+    storage = storage_s3.S3StorageAdapter(
+        storage_s3.S3StorageSettings(bucket="aaf-private", region_name="us-east-1"),
         client=client,
     )
-    return S3DeliveryAdapter(storage)
+    return delivery_s3.S3DeliveryAdapter(storage)
 
 
 def test_stream_grant_signs_exact_get_object_and_leaves_range_requestable() -> None:
     client = FakeS3Client()
-    delivery = adapter(client)
+    adapter_under_test = adapter(client)
 
-    grant = delivery.create_grant(
+    grant = adapter_under_test.create_grant(
         subject(),
         authorization(),
-        mode=DeliveryMode.STREAM,
+        mode=delivery.DeliveryMode.STREAM,
         now=NOW,
         expires_in_seconds=300,
     )
 
     assert grant.method == "GET"
-    assert grant.mode is DeliveryMode.STREAM
+    assert grant.mode is delivery.DeliveryMode.STREAM
     assert grant.supports_range is True
     assert grant.expires_at == NOW + timedelta(seconds=300)
-    assert grant.authorization is DeliveryAuthorizationKind.PROJECT
+    assert grant.authorization is delivery.DeliveryAuthorizationKind.PROJECT
 
     name, kwargs = client.calls[-1]
     assert name == "generate_presigned_url"
@@ -91,12 +84,12 @@ def test_stream_grant_signs_exact_get_object_and_leaves_range_requestable() -> N
 
 def test_download_grant_uses_attachment_and_is_short_lived() -> None:
     client = FakeS3Client()
-    delivery = adapter(client)
+    adapter_under_test = adapter(client)
 
-    grant = delivery.create_grant(
+    grant = adapter_under_test.create_grant(
         subject(),
         authorization(),
-        mode=DeliveryMode.DOWNLOAD,
+        mode=delivery.DeliveryMode.DOWNLOAD,
         now=NOW,
         expires_in_seconds=60,
     )
@@ -105,10 +98,10 @@ def test_download_grant_uses_attachment_and_is_short_lived() -> None:
     assert client.calls[-1][1]["Params"]["ResponseContentDisposition"] == "attachment"
 
     with pytest.raises(ValueError, match="between 1 and 3600"):
-        delivery.create_grant(
+        adapter_under_test.create_grant(
             subject(),
             authorization(),
-            mode=DeliveryMode.DOWNLOAD,
+            mode=delivery.DeliveryMode.DOWNLOAD,
             now=NOW,
             expires_in_seconds=3601,
         )
@@ -116,21 +109,21 @@ def test_download_grant_uses_attachment_and_is_short_lived() -> None:
 
 def test_signing_refuses_authority_for_another_asset_or_project() -> None:
     client = FakeS3Client()
-    delivery = adapter(client)
+    adapter_under_test = adapter(client)
 
-    with pytest.raises(DeliveryAuthorizationError, match="project"):
-        delivery.create_grant(
+    with pytest.raises(delivery.DeliveryAuthorizationError, match="project"):
+        adapter_under_test.create_grant(
             subject(),
             authorization().model_copy(update={"project_id": "PRJ-006999"}),
-            mode=DeliveryMode.STREAM,
+            mode=delivery.DeliveryMode.STREAM,
             now=NOW,
         )
 
-    with pytest.raises(DeliveryAuthorizationError, match="asset"):
-        delivery.create_grant(
+    with pytest.raises(delivery.DeliveryAuthorizationError, match="asset"):
+        adapter_under_test.create_grant(
             subject(),
             authorization().model_copy(update={"asset_id": "AST-006999"}),
-            mode=DeliveryMode.STREAM,
+            mode=delivery.DeliveryMode.STREAM,
             now=NOW,
         )
 
@@ -140,12 +133,12 @@ def test_signing_refuses_authority_for_another_asset_or_project() -> None:
 def test_invalid_signed_url_fails_closed() -> None:
     client = FakeS3Client()
     client.signed_url = ""
-    delivery = adapter(client)
+    adapter_under_test = adapter(client)
 
     with pytest.raises(RuntimeError, match="did not return"):
-        delivery.create_grant(
+        adapter_under_test.create_grant(
             subject(),
             authorization(),
-            mode=DeliveryMode.STREAM,
+            mode=delivery.DeliveryMode.STREAM,
             now=NOW,
         )

--- a/packages/python-core/tests/test_delivery_s3.py
+++ b/packages/python-core/tests/test_delivery_s3.py
@@ -5,15 +5,15 @@ from typing import Any
 
 import pytest
 
-from ai_automation_force_core import (
+from ai_automation_force_core.delivery import (
     AssetAccessClass,
     DeliveryAuthorization,
     DeliveryAuthorizationError,
     DeliveryAuthorizationKind,
     DeliveryMode,
     DeliverySubject,
-    S3DeliveryAdapter,
 )
+from ai_automation_force_core.delivery_s3 import S3DeliveryAdapter
 from ai_automation_force_core.storage_s3 import S3StorageAdapter, S3StorageSettings
 
 


### PR DESCRIPTION
First reviewable M03-WP6 slice from the exact WP5-promoted `main` head.

Implements:
- canonical delivery binding across Asset, provenance and StorageObject identity/project/hash/MIME;
- explicit private/public asset access classes;
- fail-closed project-scoped delivery authorization;
- constrained share-link authority model with exact asset/project binding, mode allowlist, expiry, revocation and use limits;
- ephemeral signed-delivery grants that are capabilities, not canonical authorization;
- S3 short-lived presigned GET delivery with exact object key, response content type and inline/attachment disposition;
- Range strategy: one short-lived GET capability remains seekable via ordinary HTTP Range requests; Range is intentionally not broadened into a separate object grant;
- unit coverage for cross-project denial, binding integrity, public opt-in, share-link constraints, expiry bounds and S3 signing parameters;
- README milestone dashboard advanced to 5/8 landed and WP6 active.

Security boundary:
- no arbitrary filesystem path input;
- no raw bearer share token persisted in the delivery contract (digest only);
- no signed URL treated as authorization;
- no cross-project fallback for private assets;
- no production CDN or paid infrastructure commitment.

Follow-up within WP6 after this slice certifies: durable share-link persistence/atomic use accounting and application/API authorization integration. WP7 remains out of scope.