### PR TITLE
M03-WP6: signed delivery API and access policy

### DIFF
--- a/apps/api/src/ai_automation_force_api/app.py
+++ b/apps/api/src/ai_automation_force_api/app.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, FastAPI, Request, status
 from pydantic import BaseModel, ConfigDict
 
 from .control import ControlService, control_router
+from .delivery import DeliveryService, delivery_router
 from .errors import APIError, ErrorEnvelope, install_error_handlers
 from .request_context import RequestContextMiddleware
 from .settings import Settings, load_settings
@@ -23,6 +24,8 @@ class RuntimeState(BaseModel):
     ready: bool = False
     control_ready: bool = False
     control_error: str | None = None
+    delivery_ready: bool = False
+    delivery_error: str | None = None
 
 
 class HealthResponse(BaseModel):
@@ -40,6 +43,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         runtime = RuntimeState(started_at=datetime.now(UTC), ready=True)
         app.state.runtime = runtime
         app.state.control_service = None
+        app.state.delivery_service = None
         if resolved.control_surface_configured:
             try:
                 app.state.control_service = ControlService(resolved)
@@ -47,12 +51,22 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             except Exception:
                 runtime.ready = False
                 runtime.control_error = "durable control dependencies are unavailable"
+            try:
+                app.state.delivery_service = DeliveryService(resolved)
+                runtime.delivery_ready = True
+            except Exception:
+                runtime.ready = False
+                runtime.delivery_error = "signed delivery dependencies are unavailable"
         try:
             yield
         finally:
-            service = getattr(app.state, "control_service", None)
-            if isinstance(service, ControlService):
-                service.close()
+            delivery_service = getattr(app.state, "delivery_service", None)
+            if isinstance(delivery_service, DeliveryService):
+                delivery_service.close()
+            control_service = getattr(app.state, "control_service", None)
+            if isinstance(control_service, ControlService):
+                control_service.close()
+            runtime.delivery_ready = False
             runtime.control_ready = False
             runtime.ready = False
 
@@ -101,4 +115,5 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.include_router(router, prefix=resolved.api_prefix)
     app.include_router(control_router(), prefix=resolved.api_prefix)
+    app.include_router(delivery_router(), prefix=resolved.api_prefix)
     return app

--- a/apps/api/src/ai_automation_force_api/delivery.py
+++ b/apps/api/src/ai_automation_force_api/delivery.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Annotated
+
+from ai_automation_force_core import (
+    DeliveryAuthorizationError,
+    DeliveryMode,
+    DeliveryResolutionError,
+    DeliverySigningError,
+    PersistenceNotFoundError,
+    PostgresDeliveryRepository,
+    PostgresShareLinkRepository,
+    S3DeliveryAdapter,
+    S3StorageAdapter,
+    S3StorageSettings,
+    SignedDeliveryGrant,
+    StorageBackend,
+    StorageObject,
+    authorize_delivery,
+)
+from fastapi import APIRouter, Header, Request
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+from .errors import APIError
+from .settings import Settings
+
+AssetIdValue = Annotated[str, Field(pattern=r"^AST-[0-9]{6,20}$")]
+ProjectIdValue = Annotated[str, Field(pattern=r"^PRJ-[0-9]{6,20}$")]
+
+
+class StrictDeliveryModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class DeliveryGrantRequest(StrictDeliveryModel):
+    mode: DeliveryMode
+    expires_in_seconds: int | None = Field(default=None, ge=1, le=3600)
+
+
+class DeliveryGrantResponse(StrictDeliveryModel):
+    asset_id: str
+    project_id: str
+    mode: DeliveryMode
+    authorization: str
+    url: str
+    expires_at: datetime
+    supports_range: bool
+    accept_ranges: str | None = None
+
+
+class DeliveryDependencyError(RuntimeError):
+    """A delivery dependency is unavailable or incompatible with canonical storage."""
+
+
+DeliverySignerFactory = Callable[[StorageObject, Settings], S3DeliveryAdapter]
+
+
+def _secret(value: object) -> str | None:
+    if value is None:
+        return None
+    getter = getattr(value, "get_secret_value", None)
+    return str(getter()) if callable(getter) else str(value)
+
+
+def _default_signer(storage: StorageObject, settings: Settings) -> S3DeliveryAdapter:
+    if storage.backend is not StorageBackend.S3 or storage.bucket is None:
+        raise DeliveryDependencyError("signed delivery requires canonical S3 storage")
+    adapter = S3StorageAdapter(
+        S3StorageSettings(
+            bucket=storage.bucket,
+            region_name=storage.region or settings.s3_region_name,
+            endpoint_url=settings.s3_endpoint_url,
+            addressing_style=settings.s3_addressing_style,
+            verify_ssl=settings.s3_verify_ssl,
+            access_key_id=_secret(settings.s3_access_key_id),
+            secret_access_key=_secret(settings.s3_secret_access_key),
+            session_token=_secret(settings.s3_session_token),
+        )
+    )
+    if adapter.settings.bucket != storage.bucket:
+        raise DeliveryDependencyError("delivery signer bucket does not match canonical storage")
+    return S3DeliveryAdapter(
+        adapter,
+        max_expiry_seconds=settings.delivery_url_max_ttl_seconds,
+    )
+
+
+class DeliveryService:
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        signer_factory: DeliverySignerFactory | None = None,
+    ) -> None:
+        if settings.database_url is None:
+            raise ValueError("DATABASE_URL is required for signed delivery")
+        self.settings = settings
+        self.engine: Engine = create_engine(
+            settings.database_url.get_secret_value(),
+            pool_pre_ping=True,
+        )
+        self.delivery = PostgresDeliveryRepository(self.engine)
+        self.share_links = PostgresShareLinkRepository(self.engine)
+        self.signer_factory = signer_factory or _default_signer
+
+    def close(self) -> None:
+        self.engine.dispose()
+
+    def create_grant(
+        self,
+        asset_id: str,
+        request: DeliveryGrantRequest,
+        *,
+        requester_project_id: str | None,
+        share_token: str | None,
+        now: datetime | None = None,
+    ) -> DeliveryGrantResponse:
+        at = now or datetime.now(UTC)
+        resolved = self.delivery.resolve(asset_id)
+        subject = resolved.subject
+
+        if share_token is not None:
+            digest = hashlib.sha256(share_token.encode("utf-8")).hexdigest()
+            consumed = self.share_links.authorize_and_consume(
+                subject,
+                request.mode,
+                token_sha256=digest,
+                now=at,
+            )
+            authorization = consumed.authorization
+        else:
+            authorization = authorize_delivery(
+                subject,
+                request.mode,
+                now=at,
+                requester_project_id=requester_project_id,
+            )
+
+        storage = resolved.storage_object
+        if storage.backend is not StorageBackend.S3 or storage.bucket is None:
+            raise DeliveryDependencyError("signed delivery requires canonical S3 storage")
+
+        ttl = request.expires_in_seconds or self.settings.delivery_url_max_ttl_seconds
+        if ttl > self.settings.delivery_url_max_ttl_seconds:
+            raise ValueError(
+                "requested delivery expiry exceeds the configured maximum"
+            )
+        signer = self.signer_factory(storage, self.settings)
+        grant: SignedDeliveryGrant = signer.create_grant(
+            subject,
+            authorization,
+            mode=request.mode,
+            now=at,
+            expires_in_seconds=ttl,
+        )
+        return DeliveryGrantResponse(
+            asset_id=subject.asset_id,
+            project_id=subject.project_id,
+            mode=request.mode,
+            authorization=authorization.kind.value,
+            url=grant.url,
+            expires_at=grant.expires_at,
+            supports_range=grant.supports_range,
+            accept_ranges="bytes" if grant.supports_range else None,
+        )
+
+
+def _service(request: Request) -> DeliveryService:
+    service = getattr(request.app.state, "delivery_service", None)
+    if not isinstance(service, DeliveryService):
+        raise APIError(
+            "DELIVERY_NOT_READY",
+            "signed delivery dependencies are not available",
+            status_code=503,
+        )
+    return service
+
+
+def _share_token(authorization: str | None) -> str | None:
+    if authorization is None:
+        return None
+    scheme, separator, token = authorization.partition(" ")
+    if separator != " " or scheme.lower() != "bearer" or not token:
+        raise APIError(
+            "INVALID_DELIVERY_AUTHORIZATION",
+            "Authorization must use a Bearer token",
+            status_code=401,
+        )
+    if token != token.strip() or len(token) < 16 or len(token) > 4096:
+        raise APIError(
+            "INVALID_DELIVERY_AUTHORIZATION",
+            "share token is malformed",
+            status_code=401,
+        )
+    return token
+
+
+def _project_identity(request: Request, project_header: str | None) -> str | None:
+    trusted = getattr(request.state, "authenticated_project_id", None)
+    if trusted is not None:
+        trusted_id = str(trusted)
+        if project_header is not None and project_header != trusted_id:
+            raise APIError(
+                "PROJECT_IDENTITY_MISMATCH",
+                "project header conflicts with authenticated request context",
+                status_code=403,
+            )
+        return trusted_id
+
+    settings = request.app.state.settings
+    if project_header is None:
+        return None
+    if (
+        settings.environment in {"development", "test"}
+        and settings.internal_dev_identity is not None
+    ):
+        return project_header
+    raise APIError(
+        "UNTRUSTED_PROJECT_IDENTITY",
+        "project identity must be supplied by trusted authentication context",
+        status_code=401,
+    )
+
+
+def _translate_error(exc: Exception) -> APIError:
+    if isinstance(exc, APIError):
+        return exc
+    if isinstance(exc, PersistenceNotFoundError):
+        return APIError("DELIVERY_NOT_FOUND", "asset delivery target was not found", status_code=404)
+    if isinstance(exc, (DeliveryAuthorizationError, DeliveryResolutionError)):
+        return APIError("DELIVERY_FORBIDDEN", str(exc), status_code=403)
+    if isinstance(exc, DeliverySigningError):
+        return APIError("DELIVERY_SIGNING_FAILED", "delivery capability could not be issued", status_code=503)
+    if isinstance(exc, DeliveryDependencyError):
+        return APIError("DELIVERY_DEPENDENCY_UNAVAILABLE", str(exc), status_code=503)
+    if isinstance(exc, ValueError):
+        return APIError("INVALID_DELIVERY_REQUEST", str(exc), status_code=400)
+    return APIError("DELIVERY_FAILURE", "signed delivery operation failed", status_code=500)
+
+
+def delivery_router() -> APIRouter:
+    router = APIRouter(tags=["assets"])
+
+    @router.post("/assets/{asset_id}/delivery", response_model=DeliveryGrantResponse)
+    async def create_delivery_grant(
+        request: Request,
+        asset_id: AssetIdValue,
+        body: DeliveryGrantRequest,
+        authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+        project_id: Annotated[ProjectIdValue | None, Header(alias="X-Project-ID")] = None,
+    ) -> DeliveryGrantResponse:
+        try:
+            return _service(request).create_grant(
+                asset_id,
+                body,
+                requester_project_id=_project_identity(request, project_id),
+                share_token=_share_token(authorization),
+            )
+        except Exception as exc:
+            raise _translate_error(exc) from exc
+
+    return router

--- a/apps/api/src/ai_automation_force_api/delivery.py
+++ b/apps/api/src/ai_automation_force_api/delivery.py
@@ -263,11 +263,13 @@ def delivery_router() -> APIRouter:
         project_id: Annotated[ProjectIdValue | None, Header(alias="X-Project-ID")] = None,
     ) -> DeliveryGrantResponse:
         try:
+            requester_project_id = _project_identity(request, project_id)
+            share_token = _share_token(authorization)
             return _service(request).create_grant(
                 asset_id,
                 body,
-                requester_project_id=_project_identity(request, project_id),
-                share_token=_share_token(authorization),
+                requester_project_id=requester_project_id,
+                share_token=share_token,
             )
         except Exception as exc:
             raise _translate_error(exc) from exc

--- a/apps/api/src/ai_automation_force_api/delivery.py
+++ b/apps/api/src/ai_automation_force_api/delivery.py
@@ -231,11 +231,19 @@ def _translate_error(exc: Exception) -> APIError:
     if isinstance(exc, APIError):
         return exc
     if isinstance(exc, PersistenceNotFoundError):
-        return APIError("DELIVERY_NOT_FOUND", "asset delivery target was not found", status_code=404)
+        return APIError(
+            "DELIVERY_NOT_FOUND",
+            "asset delivery target was not found",
+            status_code=404,
+        )
     if isinstance(exc, (DeliveryAuthorizationError, DeliveryResolutionError)):
         return APIError("DELIVERY_FORBIDDEN", str(exc), status_code=403)
     if isinstance(exc, DeliverySigningError):
-        return APIError("DELIVERY_SIGNING_FAILED", "delivery capability could not be issued", status_code=503)
+        return APIError(
+            "DELIVERY_SIGNING_FAILED",
+            "delivery capability could not be issued",
+            status_code=503,
+        )
     if isinstance(exc, DeliveryDependencyError):
         return APIError("DELIVERY_DEPENDENCY_UNAVAILABLE", str(exc), status_code=503)
     if isinstance(exc, ValueError):

--- a/apps/api/src/ai_automation_force_api/settings.py
+++ b/apps/api/src/ai_automation_force_api/settings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from os import environ
 from typing import Literal
+from urllib.parse import urlsplit
 
 from pydantic import (
     BaseModel,
@@ -15,6 +16,7 @@ from pydantic import (
 )
 
 Environment = Literal["development", "test", "staging", "production"]
+S3AddressingStyle = Literal["auto", "path", "virtual"]
 
 
 class SettingsError(RuntimeError):
@@ -35,6 +37,14 @@ class Settings(BaseModel):
     temporal_task_queue: str = Field(default="aaf-control-v1", min_length=1, max_length=160)
     sse_poll_interval_ms: int = Field(default=250, ge=25, le=5_000)
     sse_heartbeat_seconds: int = Field(default=15, ge=1, le=120)
+    delivery_url_max_ttl_seconds: int = Field(default=900, ge=1, le=3600)
+    s3_region_name: str = Field(default="us-east-1", min_length=1, max_length=160)
+    s3_endpoint_url: str | None = Field(default=None, max_length=2048)
+    s3_addressing_style: S3AddressingStyle = "auto"
+    s3_verify_ssl: bool = True
+    s3_access_key_id: SecretStr | None = None
+    s3_secret_access_key: SecretStr | None = None
+    s3_session_token: SecretStr | None = None
 
     @field_validator(
         "service_name",
@@ -43,6 +53,7 @@ class Settings(BaseModel):
         "temporal_target",
         "temporal_namespace",
         "temporal_task_queue",
+        "s3_region_name",
     )
     @classmethod
     def reject_control_characters(cls, value: str | None) -> str | None:
@@ -52,10 +63,30 @@ class Settings(BaseModel):
             raise ValueError("control characters are not allowed")
         return value
 
+    @field_validator("s3_endpoint_url")
+    @classmethod
+    def validate_s3_endpoint(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        parsed = urlsplit(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("s3_endpoint_url must be an absolute HTTP(S) URL")
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("s3_endpoint_url must not embed credentials")
+        return value
+
     @model_validator(mode="after")
-    def prevent_insecure_identity_outside_dev(self) -> Settings:
+    def prevent_unsafe_configuration(self) -> Settings:
         if self.environment in {"staging", "production"} and self.internal_dev_identity:
             raise ValueError("internal_dev_identity is allowed only in development/test")
+        if (self.s3_access_key_id is None) != (self.s3_secret_access_key is None):
+            raise ValueError("s3_access_key_id and s3_secret_access_key must be supplied together")
+        if (
+            self.s3_endpoint_url is not None
+            and self.s3_endpoint_url.startswith("http://")
+            and self.s3_verify_ssl
+        ):
+            raise ValueError("HTTP s3_endpoint_url requires s3_verify_ssl=false explicitly")
         return self
 
     @property
@@ -82,6 +113,14 @@ def load_settings(source: Mapping[str, str] | None = None) -> Settings:
         "AAF_TEMPORAL_TASK_QUEUE": "temporal_task_queue",
         "AAF_SSE_POLL_INTERVAL_MS": "sse_poll_interval_ms",
         "AAF_SSE_HEARTBEAT_SECONDS": "sse_heartbeat_seconds",
+        "AAF_DELIVERY_URL_MAX_TTL_SECONDS": "delivery_url_max_ttl_seconds",
+        "AAF_S3_REGION_NAME": "s3_region_name",
+        "AAF_S3_ENDPOINT_URL": "s3_endpoint_url",
+        "AAF_S3_ADDRESSING_STYLE": "s3_addressing_style",
+        "AAF_S3_VERIFY_SSL": "s3_verify_ssl",
+        "AAF_S3_ACCESS_KEY_ID": "s3_access_key_id",
+        "AAF_S3_SECRET_ACCESS_KEY": "s3_secret_access_key",
+        "AAF_S3_SESSION_TOKEN": "s3_session_token",
     }
     for environment_key, model_key in env_map.items():
         value = values.get(environment_key)

--- a/apps/api/tests/test_delivery_api.py
+++ b/apps/api/tests/test_delivery_api.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+from ai_automation_force_core import (
+    AssetAccessClass,
+    DeliveryAuthorization,
+    DeliveryMode,
+    PostgresDeliveryRepository,
+    PostgresShareLinkRepository,
+    ShareLinkConstraint,
+    SignedDeliveryGrant,
+    StorageObject,
+)
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from ai_automation_force_api import Settings, create_app
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+ALEMBIC_INI = Path(__file__).parents[3] / "packages/python-core/alembic.ini"
+NOW = datetime(2026, 9, 1, 21, 30, tzinfo=UTC)
+DIGEST = "f" * 64
+RAW_SHARE_TOKEN = "share-token-006501-secure"
+
+
+def alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
+
+
+def seed_deliverable(engine: Any) -> tuple[str, str]:
+    project_id = "PRJ-006501"
+    asset_id = "AST-006501"
+    storage_id = "STO-006501"
+    rights_id = "RGT-006501"
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.projects (
+                    id, external_id, title, status, audience, "cast", content_format,
+                    language, target_duration_seconds, output, creative, provider_policy,
+                    created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :project_id, 'API delivery fixture', 'draft',
+                    '{}'::jsonb, '{}'::jsonb, 'song', 'en', 120,
+                    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, :now, :now
+                )
+                """
+            ),
+            {"project_id": project_id, "now": NOW},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.rights_records (
+                    id, external_id, subject_type, subject_id, commercial_use,
+                    publication_blocked, verified_at
+                ) VALUES (
+                    gen_random_uuid(), :rights_id, 'asset', :asset_id,
+                    'allowed', false, :now
+                )
+                """
+            ),
+            {"rights_id": rights_id, "asset_id": asset_id, "now": NOW},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.assets (
+                    id, external_id, project_id, kind, uri, sha256, mime_type,
+                    size_bytes, rights_record_id, canonical_status,
+                    created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :asset_id,
+                    (SELECT id FROM core.projects WHERE external_id = :project_id),
+                    'video', :uri, :digest, 'video/mp4', 128,
+                    (SELECT id FROM core.rights_records WHERE external_id = :rights_id),
+                    'approved', :now, :now
+                )
+                """
+            ),
+            {
+                "asset_id": asset_id,
+                "project_id": project_id,
+                "uri": f"s3://canonical-media/source/{project_id}/{storage_id}",
+                "digest": DIGEST,
+                "rights_id": rights_id,
+                "now": NOW,
+            },
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.storage_objects (
+                    id, external_id, project_id, backend, bucket, object_key,
+                    sha256, mime_type, size_bytes, region, created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :storage_id,
+                    (SELECT id FROM core.projects WHERE external_id = :project_id),
+                    's3', 'canonical-media', :object_key, :digest,
+                    'video/mp4', 128, 'eu-west-1', :now, :now
+                )
+                """
+            ),
+            {
+                "storage_id": storage_id,
+                "project_id": project_id,
+                "object_key": f"source/{project_id}/{storage_id}",
+                "digest": DIGEST,
+                "now": NOW,
+            },
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.asset_provenance_records (
+                    id, external_id, asset_id, project_id, storage_object_id,
+                    source_kind, content_sha256, rights_record_id, created_at
+                ) VALUES (
+                    gen_random_uuid(), 'PRV-006501',
+                    (SELECT id FROM core.assets WHERE external_id = :asset_id),
+                    (SELECT id FROM core.projects WHERE external_id = :project_id),
+                    (SELECT id FROM core.storage_objects WHERE external_id = :storage_id),
+                    'upload', :digest,
+                    (SELECT id FROM core.rights_records WHERE external_id = :rights_id),
+                    :created_at
+                )
+                """
+            ),
+            {
+                "asset_id": asset_id,
+                "project_id": project_id,
+                "storage_id": storage_id,
+                "digest": DIGEST,
+                "rights_id": rights_id,
+                "created_at": NOW + timedelta(seconds=1),
+            },
+        )
+    return project_id, asset_id
+
+
+class CapturingSigner:
+    def __init__(self, storage: StorageObject, captures: list[StorageObject]) -> None:
+        self.storage = storage
+        self.captures = captures
+
+    def create_grant(
+        self,
+        subject: Any,
+        authorization: DeliveryAuthorization,
+        *,
+        mode: DeliveryMode,
+        now: datetime,
+        expires_in_seconds: int = 900,
+    ) -> SignedDeliveryGrant:
+        self.captures.append(self.storage)
+        return SignedDeliveryGrant(
+            url=(
+                "https://signed.example/"
+                f"{self.storage.bucket}/{subject.object_key}?signature=opaque"
+            ),
+            object_key=subject.object_key,
+            mode=mode,
+            authorization=authorization.kind,
+            expires_at=now + timedelta(seconds=expires_in_seconds),
+            supports_range=True,
+        )
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_signed_delivery_api_enforces_tenant_public_share_and_canonical_bucket_boundaries() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    try:
+        project_id, asset_id = seed_deliverable(engine)
+        share_links = PostgresShareLinkRepository(engine)
+        share_links.create(
+            ShareLinkConstraint(
+                share_link_id="SHARE-006501",
+                project_id=project_id,
+                asset_id=asset_id,
+                token_sha256=hashlib.sha256(RAW_SHARE_TOKEN.encode()).hexdigest(),
+                allowed_modes=[DeliveryMode.STREAM],
+                expires_at=NOW + timedelta(hours=2),
+                max_uses=2,
+            ),
+            created_at=NOW + timedelta(minutes=1),
+        )
+
+        settings = Settings(
+            environment="test",
+            internal_dev_identity="wp6-api-test",
+            database_url=DATABASE_URL,
+            delivery_url_max_ttl_seconds=300,
+            s3_region_name="us-east-1",
+        )
+        app = create_app(settings)
+        captures: list[StorageObject] = []
+
+        with TestClient(app) as client:
+            service = app.state.delivery_service
+            assert service is not None
+            service.signer_factory = lambda storage, _: CapturingSigner(storage, captures)
+
+            denied = client.post(
+                f"/api/v1/assets/{asset_id}/delivery",
+                headers={"X-Project-ID": "PRJ-006599"},
+                json={"mode": "stream", "expires_in_seconds": 120},
+            )
+            assert denied.status_code == 403
+            assert captures == []
+
+            project_grant = client.post(
+                f"/api/v1/assets/{asset_id}/delivery",
+                headers={"X-Project-ID": project_id},
+                json={"mode": "stream", "expires_in_seconds": 120},
+            )
+            assert project_grant.status_code == 200
+            payload = project_grant.json()
+            assert payload["authorization"] == "project"
+            assert payload["supports_range"] is True
+            assert payload["accept_ranges"] == "bytes"
+            assert captures[-1].bucket == "canonical-media"
+            assert captures[-1].region == "eu-west-1"
+            assert "canonical-media" in payload["url"]
+
+            public_repo = PostgresDeliveryRepository(service.engine)
+            public_repo.set_access_class(
+                asset_id,
+                AssetAccessClass.PUBLIC,
+                now=NOW + timedelta(minutes=2),
+            )
+            public_grant = client.post(
+                f"/api/v1/assets/{asset_id}/delivery",
+                json={"mode": "download"},
+            )
+            assert public_grant.status_code == 200
+            assert public_grant.json()["authorization"] == "public"
+
+            public_repo.set_access_class(
+                asset_id,
+                AssetAccessClass.PRIVATE,
+                now=NOW + timedelta(minutes=3),
+            )
+            share_grant = client.post(
+                f"/api/v1/assets/{asset_id}/delivery",
+                headers={"Authorization": f"Bearer {RAW_SHARE_TOKEN}"},
+                json={"mode": "stream", "expires_in_seconds": 60},
+            )
+            assert share_grant.status_code == 200
+            assert share_grant.json()["authorization"] == "share-link"
+            assert share_links.load("SHARE-006501").use_count == 1
+
+            wrong_mode = client.post(
+                f"/api/v1/assets/{asset_id}/delivery",
+                headers={"Authorization": f"Bearer {RAW_SHARE_TOKEN}"},
+                json={"mode": "download"},
+            )
+            assert wrong_mode.status_code == 403
+            assert share_links.load("SHARE-006501").use_count == 1
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")
+
+
+def test_project_header_is_not_trusted_in_production_without_authenticated_context() -> None:
+    settings = Settings(environment="production")
+    app = create_app(settings)
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/assets/AST-006501/delivery",
+            headers={"X-Project-ID": "PRJ-006501"},
+            json={"mode": "stream"},
+        )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "UNTRUSTED_PROJECT_IDENTITY"

--- a/apps/api/tests/test_delivery_api.py
+++ b/apps/api/tests/test_delivery_api.py
@@ -186,6 +186,7 @@ def test_signed_delivery_api_enforces_tenant_public_share_and_canonical_bucket_b
     try:
         project_id, asset_id = seed_deliverable(engine)
         share_links = PostgresShareLinkRepository(engine)
+        share_now = datetime.now(UTC)
         share_links.create(
             ShareLinkConstraint(
                 share_link_id="SHARE-006501",
@@ -193,10 +194,10 @@ def test_signed_delivery_api_enforces_tenant_public_share_and_canonical_bucket_b
                 asset_id=asset_id,
                 token_sha256=hashlib.sha256(RAW_SHARE_TOKEN.encode()).hexdigest(),
                 allowed_modes=[DeliveryMode.STREAM],
-                expires_at=NOW + timedelta(hours=2),
+                expires_at=share_now + timedelta(hours=2),
                 max_uses=2,
             ),
-            created_at=NOW + timedelta(minutes=1),
+            created_at=share_now - timedelta(minutes=1),
         )
 
         settings = Settings(

--- a/packages/python-core/migrations/sql/0014_asset_delivery_policies_down.sql
+++ b/packages/python-core/migrations/sql/0014_asset_delivery_policies_down.sql
@@ -1,0 +1,1 @@
+DROP TABLE core.asset_delivery_policies;

--- a/packages/python-core/migrations/sql/0014_asset_delivery_policies_up.sql
+++ b/packages/python-core/migrations/sql/0014_asset_delivery_policies_up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE core.asset_delivery_policies (
+    id uuid PRIMARY KEY,
+    asset_id uuid NOT NULL UNIQUE,
+    project_id uuid NOT NULL,
+    access_class text NOT NULL DEFAULT 'private',
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    revision integer NOT NULL DEFAULT 1,
+    CONSTRAINT fk_asset_delivery_policy_asset FOREIGN KEY (asset_id)
+        REFERENCES core.assets(id) ON DELETE CASCADE,
+    CONSTRAINT fk_asset_delivery_policy_project FOREIGN KEY (project_id)
+        REFERENCES core.projects(id) ON DELETE RESTRICT,
+    CONSTRAINT ck_asset_delivery_policy_access CHECK (
+        access_class IN ('private', 'public')
+    ),
+    CONSTRAINT ck_asset_delivery_policy_revision CHECK (revision >= 1),
+    CONSTRAINT ck_asset_delivery_policy_audit CHECK (updated_at >= created_at)
+);
+
+CREATE INDEX idx_asset_delivery_policies_project
+    ON core.asset_delivery_policies (project_id, access_class, asset_id);

--- a/packages/python-core/migrations/versions/20260901_0014_asset_delivery_policies.py
+++ b/packages/python-core/migrations/versions/20260901_0014_asset_delivery_policies.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "20260901_0014"
+down_revision = "20260901_0013"
+branch_labels = None
+depends_on = None
+
+_SQL_DIR = Path(__file__).resolve().parents[1] / "sql"
+
+
+def _statements(filename: str) -> list[str]:
+    text = (_SQL_DIR / filename).read_text(encoding="utf-8")
+    return [statement.strip() for statement in text.split(";\n") if statement.strip()]
+
+
+def _execute(filename: str) -> None:
+    for statement in _statements(filename):
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute("0014_asset_delivery_policies_up.sql")
+
+
+def downgrade() -> None:
+    _execute("0014_asset_delivery_policies_down.sql")

--- a/packages/python-core/src/ai_automation_force_core/__init__.py
+++ b/packages/python-core/src/ai_automation_force_core/__init__.py
@@ -47,9 +47,12 @@ from lullabies_core.media_security import (
 )
 from lullabies_core.persistence import (
     AssetProvenancePersistResult,
+    DeliveryPolicyResult,
+    DeliveryResolutionError,
     DerivativePersistenceConflictError,
     DerivativePersistResult,
     PostgresAssetProvenanceRepository,
+    PostgresDeliveryRepository,
     PostgresDerivativeRepository,
     PostgresQuarantineInspectionRepository,
     PostgresShareLinkRepository,
@@ -57,6 +60,7 @@ from lullabies_core.persistence import (
     PostgresUploadSessionRepository,
     QuarantinePersistenceConflictError,
     QuarantinePersistResult,
+    ResolvedDeliveryAsset,
     ShareLinkAuthorizationResult,
     ShareLinkPersistenceConflictError,
     ShareLinkPersistResult,
@@ -89,6 +93,7 @@ from lullabies_core.storage import (
     storage_object_from_write,
     validate_object_key,
 )
+from lullabies_core.storage_s3 import S3StorageAdapter, S3StorageSettings
 from lullabies_core.upload_s3 import S3UploadCompletionEvidence, S3UploadSessionAdapter
 from lullabies_core.upload_session import (
     DirectUploadGrant,
@@ -120,6 +125,8 @@ __all__ = [
     "DeliveryAuthorizationKind",
     "DeliveryBindingError",
     "DeliveryMode",
+    "DeliveryPolicyResult",
+    "DeliveryResolutionError",
     "DeliverySigningError",
     "DeliverySubject",
     "DerivativeKind",
@@ -137,6 +144,7 @@ __all__ = [
     "MediaSecurityPolicy",
     "MultipartPartGrant",
     "PostgresAssetProvenanceRepository",
+    "PostgresDeliveryRepository",
     "PostgresDerivativeRepository",
     "PostgresQuarantineInspectionRepository",
     "PostgresShareLinkRepository",
@@ -148,7 +156,10 @@ __all__ = [
     "QuarantinePersistenceConflictError",
     "QuarantineRejectionCode",
     "QuarantineStatus",
+    "ResolvedDeliveryAsset",
     "S3DeliveryAdapter",
+    "S3StorageAdapter",
+    "S3StorageSettings",
     "S3UploadCompletionEvidence",
     "S3UploadSessionAdapter",
     "ShareLinkAuthorizationResult",

--- a/packages/python-core/src/lullabies_core/persistence/__init__.py
+++ b/packages/python-core/src/lullabies_core/persistence/__init__.py
@@ -15,6 +15,12 @@ from .approval_wait import (
 from .asset_provenance import AssetProvenancePersistResult, PostgresAssetProvenanceRepository
 from .circuit_breaker import CircuitBreakerConflictError, PostgresCircuitBreakerRepository
 from .control_surface import PostgresControlSurfaceRepository
+from .delivery_access import (
+    DeliveryPolicyResult,
+    DeliveryResolutionError,
+    PostgresDeliveryRepository,
+    ResolvedDeliveryAsset,
+)
 from .derivative import (
     DerivativePersistenceConflictError,
     DerivativePersistResult,
@@ -55,6 +61,8 @@ __all__ = [
     "ApprovalWaitVersionConflictError",
     "AssetProvenancePersistResult",
     "CircuitBreakerConflictError",
+    "DeliveryPolicyResult",
+    "DeliveryResolutionError",
     "DerivativePersistenceConflictError",
     "DerivativePersistResult",
     "JobIdempotencyConflictError",
@@ -71,6 +79,7 @@ __all__ = [
     "PostgresAssetProvenanceRepository",
     "PostgresCircuitBreakerRepository",
     "PostgresControlSurfaceRepository",
+    "PostgresDeliveryRepository",
     "PostgresDerivativeRepository",
     "PostgresJobControlRepository",
     "PostgresProductionRepository",
@@ -85,6 +94,7 @@ __all__ = [
     "ProviderCallbackConflictError",
     "QuarantinePersistResult",
     "QuarantinePersistenceConflictError",
+    "ResolvedDeliveryAsset",
     "ShareLinkAuthorizationResult",
     "ShareLinkPersistenceConflictError",
     "ShareLinkPersistResult",

--- a/packages/python-core/src/lullabies_core/persistence/delivery_access.py
+++ b/packages/python-core/src/lullabies_core/persistence/delivery_access.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, cast
+from uuid import UUID, uuid4
+
+from sqlalchemy import MetaData, Table, insert, select, update
+from sqlalchemy.engine import Connection, Engine, RowMapping
+
+from ..common import AuditFields
+from ..delivery import AssetAccessClass, DeliverySubject, bind_delivery_subject
+from ..production import Asset, RightsRecord
+from ..provenance import (
+    AssetProvenanceRecord,
+    AssetProvenanceSource,
+    evaluate_asset_usability,
+)
+from ..storage import StorageBackend, StorageObject
+from ._db import PersistenceConflictError, PersistenceNotFoundError, PersistenceReferenceError
+
+DeliveryPolicyAction = Literal["created", "reused", "updated"]
+
+
+class DeliveryResolutionError(PersistenceConflictError):
+    """Canonical rows cannot be resolved into one safe delivery authority."""
+
+
+@dataclass(frozen=True)
+class DeliveryPolicyResult:
+    action: DeliveryPolicyAction
+    asset_id: str
+    access_class: AssetAccessClass
+    revision: int
+
+
+@dataclass(frozen=True)
+class ResolvedDeliveryAsset:
+    subject: DeliverySubject
+    storage_object: StorageObject
+    provenance: AssetProvenanceRecord
+    rights_record: RightsRecord
+    access_class: AssetAccessClass
+
+
+class PostgresDeliveryRepository:
+    """Resolve canonical, rights-aware delivery subjects and persisted access policy."""
+
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+        metadata = MetaData()
+        metadata.reflect(bind=engine, schema="core")
+        required = {
+            "asset_delivery_policies",
+            "asset_provenance_records",
+            "assets",
+            "projects",
+            "rights_records",
+            "storage_objects",
+        }
+        missing = [name for name in required if f"core.{name}" not in metadata.tables]
+        if missing:
+            raise PersistenceReferenceError(
+                f"delivery persistence tables are not migrated: {', '.join(sorted(missing))}"
+            )
+        self.policies = metadata.tables["core.asset_delivery_policies"]
+        self.provenance = metadata.tables["core.asset_provenance_records"]
+        self.assets = metadata.tables["core.assets"]
+        self.projects = metadata.tables["core.projects"]
+        self.rights = metadata.tables["core.rights_records"]
+        self.storage = metadata.tables["core.storage_objects"]
+
+    def set_access_class(
+        self,
+        asset_id: str,
+        access_class: AssetAccessClass,
+        *,
+        now: datetime,
+    ) -> DeliveryPolicyResult:
+        with self.engine.begin() as connection:
+            asset = self._require_external(connection, self.assets, asset_id, "asset")
+            project_id = cast(UUID | None, asset["project_id"])
+            if project_id is None:
+                raise DeliveryResolutionError("delivery policy requires a project-scoped asset")
+            existing = connection.execute(
+                select(self.policies)
+                .where(self.policies.c.asset_id == asset["id"])
+                .with_for_update()
+            ).mappings().one_or_none()
+            if existing is None:
+                connection.execute(
+                    insert(self.policies).values(
+                        id=uuid4(),
+                        asset_id=asset["id"],
+                        project_id=project_id,
+                        access_class=access_class.value,
+                        created_at=now,
+                        updated_at=now,
+                        revision=1,
+                    )
+                )
+                return DeliveryPolicyResult("created", asset_id, access_class, 1)
+            if existing["project_id"] != project_id:
+                raise DeliveryResolutionError("delivery policy project does not match asset")
+            persisted = AssetAccessClass(str(existing["access_class"]))
+            if persisted is access_class:
+                return DeliveryPolicyResult(
+                    "reused",
+                    asset_id,
+                    persisted,
+                    int(existing["revision"]),
+                )
+            revision = int(existing["revision"]) + 1
+            connection.execute(
+                update(self.policies)
+                .where(self.policies.c.id == existing["id"])
+                .values(access_class=access_class.value, updated_at=now, revision=revision)
+            )
+            return DeliveryPolicyResult("updated", asset_id, access_class, revision)
+
+    def resolve(self, asset_id: str) -> ResolvedDeliveryAsset:
+        with self.engine.connect() as connection:
+            asset_row = self._require_external(connection, self.assets, asset_id, "asset")
+            if asset_row["project_id"] is None:
+                raise DeliveryResolutionError("delivery requires a project-scoped asset")
+
+            provenance_rows = list(
+                connection.execute(
+                    select(self.provenance)
+                    .where(self.provenance.c.asset_id == asset_row["id"])
+                    .where(self.provenance.c.storage_object_id.is_not(None))
+                    .order_by(self.provenance.c.created_at.desc(), self.provenance.c.id.desc())
+                ).mappings()
+            )
+            if not provenance_rows:
+                raise DeliveryResolutionError("asset has no storage-backed provenance")
+            if len(provenance_rows) != 1:
+                raise DeliveryResolutionError(
+                    "asset delivery provenance is ambiguous; exactly one storage-backed record is required"
+                )
+            provenance_row = provenance_rows[0]
+            storage_row = self._require_internal(
+                connection,
+                self.storage,
+                cast(UUID, provenance_row["storage_object_id"]),
+                "storage object",
+            )
+
+            rights_id = cast(UUID | None, asset_row["rights_record_id"])
+            if rights_id is None:
+                raise DeliveryResolutionError("delivery requires an asset rights record")
+            rights_row = self._require_internal(
+                connection,
+                self.rights,
+                rights_id,
+                "rights record",
+            )
+
+            asset = self._asset(connection, asset_row)
+            provenance = self._provenance(connection, provenance_row)
+            storage = self._storage(connection, storage_row)
+            rights = self._rights(rights_row)
+            decision = evaluate_asset_usability(asset, provenance, rights)
+            if not decision.usable:
+                reasons = ", ".join(item.value for item in decision.rejections)
+                raise DeliveryResolutionError(f"asset is not delivery-usable: {reasons}")
+
+            policy = connection.execute(
+                select(self.policies).where(self.policies.c.asset_id == asset_row["id"])
+            ).mappings().one_or_none()
+            access_class = AssetAccessClass.PRIVATE
+            if policy is not None:
+                if policy["project_id"] != asset_row["project_id"]:
+                    raise DeliveryResolutionError("delivery policy project does not match asset")
+                access_class = AssetAccessClass(str(policy["access_class"]))
+
+            subject = bind_delivery_subject(
+                asset,
+                provenance,
+                storage,
+                access_class=access_class,
+            )
+            return ResolvedDeliveryAsset(
+                subject=subject,
+                storage_object=storage,
+                provenance=provenance,
+                rights_record=rights,
+                access_class=access_class,
+            )
+
+    def _asset(self, connection: Connection, row: RowMapping) -> Asset:
+        return Asset(
+            schema_version=row["schema_version"],
+            asset_id=str(row["external_id"]),
+            project_id=self._external_for_internal(
+                connection,
+                self.projects,
+                cast(UUID, row["project_id"]),
+                "project",
+            ),
+            kind=row["kind"],
+            uri=str(row["uri"]),
+            sha256=str(row["sha256"]),
+            mime_type=str(row["mime_type"]),
+            size_bytes=int(row["size_bytes"]),
+            duration_seconds=(
+                float(row["duration_seconds"])
+                if row["duration_seconds"] is not None
+                else None
+            ),
+            width=(int(row["width"]) if row["width"] is not None else None),
+            height=(int(row["height"]) if row["height"] is not None else None),
+            provider_id=(str(row["provider_id"]) if row["provider_id"] is not None else None),
+            model_provider_id=(
+                str(row["model_provider_id"])
+                if row["model_provider_id"] is not None
+                else None
+            ),
+            provider_model_id=(
+                str(row["provider_model_id"])
+                if row["provider_model_id"] is not None
+                else None
+            ),
+            generation_attempt_id=self._optional_external_for_internal(
+                connection,
+                self._table("generation_attempts", connection),
+                cast(UUID | None, row["generation_attempt_id"]),
+                "generation attempt",
+            ),
+            rights_record_id=self._external_for_internal(
+                connection,
+                self.rights,
+                cast(UUID, row["rights_record_id"]),
+                "rights record",
+            ),
+            canonical_status=row["canonical_status"],
+            retention_class=str(row["retention_class"]),
+            audit=AuditFields(
+                created_at=row["created_at"],
+                updated_at=row["updated_at"],
+                created_by=row["created_by"],
+                revision=int(row["revision"]),
+            ),
+        )
+
+    def _provenance(
+        self,
+        connection: Connection,
+        row: RowMapping,
+    ) -> AssetProvenanceRecord:
+        return AssetProvenanceRecord(
+            schema_version=row["schema_version"],
+            provenance_record_id=str(row["external_id"]),
+            asset_id=self._external_for_internal(
+                connection,
+                self.assets,
+                cast(UUID, row["asset_id"]),
+                "asset",
+            ),
+            project_id=self._optional_external_for_internal(
+                connection,
+                self.projects,
+                cast(UUID | None, row["project_id"]),
+                "project",
+            ),
+            storage_object_id=self._optional_external_for_internal(
+                connection,
+                self.storage,
+                cast(UUID | None, row["storage_object_id"]),
+                "storage object",
+            ),
+            source_kind=AssetProvenanceSource(str(row["source_kind"])),
+            source_reference=(
+                str(row["source_reference"]) if row["source_reference"] is not None else None
+            ),
+            import_reference=(
+                str(row["import_reference"]) if row["import_reference"] is not None else None
+            ),
+            provider_reference=(
+                str(row["provider_reference"])
+                if row["provider_reference"] is not None
+                else None
+            ),
+            content_sha256=str(row["content_sha256"]),
+            rights_record_id=self._optional_external_for_internal(
+                connection,
+                self.rights,
+                cast(UUID | None, row["rights_record_id"]),
+                "rights record",
+            ),
+            created_at=row["created_at"],
+        )
+
+    def _storage(self, connection: Connection, row: RowMapping) -> StorageObject:
+        return StorageObject(
+            schema_version=row["schema_version"],
+            storage_object_id=str(row["external_id"]),
+            project_id=self._optional_external_for_internal(
+                connection,
+                self.projects,
+                cast(UUID | None, row["project_id"]),
+                "project",
+            ),
+            backend=StorageBackend(str(row["backend"])),
+            bucket=(str(row["bucket"]) if row["bucket"] is not None else None),
+            object_key=str(row["object_key"]),
+            sha256=str(row["sha256"]),
+            mime_type=str(row["mime_type"]),
+            size_bytes=int(row["size_bytes"]),
+            region=(str(row["region"]) if row["region"] is not None else None),
+            etag=(str(row["etag"]) if row["etag"] is not None else None),
+            version_id=(str(row["version_id"]) if row["version_id"] is not None else None),
+            original_filename=(
+                str(row["original_filename"])
+                if row["original_filename"] is not None
+                else None
+            ),
+            lifecycle_class=str(row["lifecycle_class"]),
+            audit=AuditFields(
+                created_at=row["created_at"],
+                updated_at=row["updated_at"],
+                created_by=row["created_by"],
+                revision=int(row["revision"]),
+            ),
+        )
+
+    @staticmethod
+    def _rights(row: RowMapping) -> RightsRecord:
+        return RightsRecord(
+            schema_version=row["schema_version"],
+            rights_record_id=str(row["external_id"]),
+            subject_type=str(row["subject_type"]),
+            subject_id=str(row["subject_id"]),
+            provider_id=(str(row["provider_id"]) if row["provider_id"] is not None else None),
+            model_provider_id=(
+                str(row["model_provider_id"])
+                if row["model_provider_id"] is not None
+                else None
+            ),
+            model_id=(str(row["model_id"]) if row["model_id"] is not None else None),
+            plan_or_tier=(
+                str(row["plan_or_tier"]) if row["plan_or_tier"] is not None else None
+            ),
+            commercial_use=row["commercial_use"],
+            watermark_required=row["watermark_required"],
+            source_basis=(
+                str(row["source_basis"]) if row["source_basis"] is not None else None
+            ),
+            consent_reference=(
+                str(row["consent_reference"])
+                if row["consent_reference"] is not None
+                else None
+            ),
+            evidence_urls=list(row["evidence_urls"]),
+            verified_at=row["verified_at"],
+            publication_blocked=bool(row["publication_blocked"]),
+            notes=list(row["notes"]),
+        )
+
+    def _table(self, name: str, connection: Connection) -> Table:
+        del connection
+        metadata = MetaData()
+        metadata.reflect(bind=self.engine, schema="core", only=[name])
+        key = f"core.{name}"
+        if key not in metadata.tables:
+            raise PersistenceReferenceError(f"missing required table {key}")
+        return metadata.tables[key]
+
+    @staticmethod
+    def _require_external(
+        connection: Connection,
+        table: Table,
+        external_id: str,
+        label: str,
+    ) -> RowMapping:
+        row = connection.execute(
+            select(table).where(table.c.external_id == external_id)
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceNotFoundError(f"{label} {external_id} was not found")
+        return row
+
+    @staticmethod
+    def _require_internal(
+        connection: Connection,
+        table: Table,
+        internal_id: UUID,
+        label: str,
+    ) -> RowMapping:
+        row = connection.execute(
+            select(table).where(table.c.id == internal_id)
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceReferenceError(f"missing {label} internal row {internal_id}")
+        return row
+
+    @staticmethod
+    def _external_for_internal(
+        connection: Connection,
+        table: Table,
+        internal_id: UUID,
+        label: str,
+    ) -> str:
+        value = connection.execute(
+            select(table.c.external_id).where(table.c.id == internal_id)
+        ).scalar_one_or_none()
+        if value is None:
+            raise PersistenceReferenceError(
+                f"missing {label} external identity for {internal_id}"
+            )
+        return str(value)
+
+    @classmethod
+    def _optional_external_for_internal(
+        cls,
+        connection: Connection,
+        table: Table,
+        internal_id: UUID | None,
+        label: str,
+    ) -> str | None:
+        if internal_id is None:
+            return None
+        return cls._external_for_internal(connection, table, internal_id, label)

--- a/packages/python-core/src/lullabies_core/persistence/delivery_access.py
+++ b/packages/python-core/src/lullabies_core/persistence/delivery_access.py
@@ -136,7 +136,8 @@ class PostgresDeliveryRepository:
                 raise DeliveryResolutionError("asset has no storage-backed provenance")
             if len(provenance_rows) != 1:
                 raise DeliveryResolutionError(
-                    "asset delivery provenance is ambiguous; exactly one storage-backed record is required"
+                    "asset delivery provenance is ambiguous; exactly one "
+                    "storage-backed record is required"
                 )
             provenance_row = provenance_rows[0]
             storage_row = self._require_internal(

--- a/packages/python-core/tests/test_delivery_resolution.py
+++ b/packages/python-core/tests/test_delivery_resolution.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from ai_automation_force_core import (
+    AssetAccessClass,
+    DeliveryResolutionError,
+    PostgresDeliveryRepository,
+)
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+ALEMBIC_INI = Path(__file__).parents[1] / "alembic.ini"
+NOW = datetime(2026, 9, 1, 21, 0, tzinfo=UTC)
+DIGEST = "a" * 64
+
+
+def alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
+
+
+def seed_deliverable(engine: object, *, suffix: str = "006401") -> tuple[str, str, str]:
+    project_id = f"PRJ-{suffix}"
+    asset_id = f"AST-{suffix}"
+    storage_id = f"STO-{suffix}"
+    rights_id = f"RGT-{suffix}"
+    provenance_id = f"PRV-{suffix}"
+    with engine.begin() as connection:  # type: ignore[attr-defined]
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.projects (
+                    id, external_id, title, status, audience, "cast", content_format,
+                    language, target_duration_seconds, output, creative, provider_policy,
+                    created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :project_id, 'Delivery fixture', 'draft',
+                    '{}'::jsonb, '{}'::jsonb, 'song', 'en', 120,
+                    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, :now, :now
+                )
+                """
+            ),
+            {"project_id": project_id, "now": NOW},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.rights_records (
+                    id, external_id, subject_type, subject_id, commercial_use,
+                    publication_blocked, verified_at
+                ) VALUES (
+                    gen_random_uuid(), :rights_id, 'asset', :asset_id,
+                    'allowed', false, :now
+                )
+                """
+            ),
+            {"rights_id": rights_id, "asset_id": asset_id, "now": NOW},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.assets (
+                    id, external_id, project_id, kind, uri, sha256, mime_type,
+                    size_bytes, rights_record_id, canonical_status,
+                    created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :asset_id,
+                    (SELECT id FROM core.projects WHERE external_id = :project_id),
+                    'image', :uri, :digest, 'image/png', 12,
+                    (SELECT id FROM core.rights_records WHERE external_id = :rights_id),
+                    'approved', :now, :now
+                )
+                """
+            ),
+            {
+                "asset_id": asset_id,
+                "project_id": project_id,
+                "uri": f"s3://canonical-private/source/{project_id}/{storage_id}",
+                "digest": DIGEST,
+                "rights_id": rights_id,
+                "now": NOW,
+            },
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.storage_objects (
+                    id, external_id, project_id, backend, bucket, object_key,
+                    sha256, mime_type, size_bytes, region, created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :storage_id,
+                    (SELECT id FROM core.projects WHERE external_id = :project_id),
+                    's3', 'canonical-private', :object_key, :digest,
+                    'image/png', 12, 'eu-central-1', :now, :now
+                )
+                """
+            ),
+            {
+                "storage_id": storage_id,
+                "project_id": project_id,
+                "object_key": f"source/{project_id}/{storage_id}",
+                "digest": DIGEST,
+                "now": NOW,
+            },
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.asset_provenance_records (
+                    id, external_id, asset_id, project_id, storage_object_id,
+                    source_kind, content_sha256, rights_record_id, created_at
+                ) VALUES (
+                    gen_random_uuid(), :provenance_id,
+                    (SELECT id FROM core.assets WHERE external_id = :asset_id),
+                    (SELECT id FROM core.projects WHERE external_id = :project_id),
+                    (SELECT id FROM core.storage_objects WHERE external_id = :storage_id),
+                    'upload', :digest,
+                    (SELECT id FROM core.rights_records WHERE external_id = :rights_id),
+                    :provenance_at
+                )
+                """
+            ),
+            {
+                "provenance_id": provenance_id,
+                "asset_id": asset_id,
+                "project_id": project_id,
+                "storage_id": storage_id,
+                "digest": DIGEST,
+                "rights_id": rights_id,
+                "provenance_at": NOW + timedelta(seconds=1),
+            },
+        )
+    return project_id, asset_id, storage_id
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_delivery_resolution_defaults_private_and_public_requires_explicit_policy() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    try:
+        project_id, asset_id, storage_id = seed_deliverable(engine)
+        repository = PostgresDeliveryRepository(engine)
+
+        resolved = repository.resolve(asset_id)
+        assert resolved.access_class is AssetAccessClass.PRIVATE
+        assert resolved.subject.project_id == project_id
+        assert resolved.subject.storage_object_id == storage_id
+        assert resolved.storage_object.bucket == "canonical-private"
+        assert resolved.storage_object.region == "eu-central-1"
+
+        public = repository.set_access_class(
+            asset_id,
+            AssetAccessClass.PUBLIC,
+            now=NOW + timedelta(minutes=1),
+        )
+        assert public.action == "created"
+        assert repository.resolve(asset_id).access_class is AssetAccessClass.PUBLIC
+
+        replay = repository.set_access_class(
+            asset_id,
+            AssetAccessClass.PUBLIC,
+            now=NOW + timedelta(minutes=2),
+        )
+        assert replay.action == "reused"
+        assert replay.revision == 1
+
+        private = repository.set_access_class(
+            asset_id,
+            AssetAccessClass.PRIVATE,
+            now=NOW + timedelta(minutes=3),
+        )
+        assert private.action == "updated"
+        assert private.revision == 2
+        assert repository.resolve(asset_id).access_class is AssetAccessClass.PRIVATE
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_delivery_resolution_fails_closed_for_rights_or_provenance_ambiguity() -> None:
+    assert DATABASE_URL is not None
+    config = alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+    try:
+        project_id, asset_id, storage_id = seed_deliverable(engine, suffix="006410")
+        repository = PostgresDeliveryRepository(engine)
+
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    UPDATE core.rights_records
+                    SET publication_blocked = true
+                    WHERE external_id = 'RGT-006410'
+                    """
+                )
+            )
+        with pytest.raises(DeliveryResolutionError, match="publication-blocked"):
+            repository.resolve(asset_id)
+
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    UPDATE core.rights_records
+                    SET publication_blocked = false
+                    WHERE external_id = 'RGT-006410'
+                    """
+                )
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO core.asset_provenance_records (
+                        id, external_id, asset_id, project_id, storage_object_id,
+                        source_kind, content_sha256, rights_record_id, created_at
+                    ) VALUES (
+                        gen_random_uuid(), 'PRV-006411',
+                        (SELECT id FROM core.assets WHERE external_id = :asset_id),
+                        (SELECT id FROM core.projects WHERE external_id = :project_id),
+                        (SELECT id FROM core.storage_objects WHERE external_id = :storage_id),
+                        'upload', :digest,
+                        (SELECT id FROM core.rights_records WHERE external_id = 'RGT-006410'),
+                        :created_at
+                    )
+                    """
+                ),
+                {
+                    "asset_id": asset_id,
+                    "project_id": project_id,
+                    "storage_id": storage_id,
+                    "digest": DIGEST,
+                    "created_at": NOW + timedelta(seconds=2),
+                },
+            )
+        with pytest.raises(DeliveryResolutionError, match="ambiguous"):
+            repository.resolve(asset_id)
+    finally:
+        engine.dispose()
+        command.downgrade(config, "base")

--- a/packages/python-core/tests/test_migrations.py
+++ b/packages/python-core/tests/test_migrations.py
@@ -39,6 +39,7 @@ EXPECTED_CORE_TABLES = {
     "asset_provenance_records",
     "derivative_records",
     "delivery_share_links",
+    "asset_delivery_policies",
     "storage_objects",
     "upload_sessions",
     "upload_parts",
@@ -88,7 +89,8 @@ M03_WP2_TABLES = {"upload_sessions", "upload_parts", "upload_session_commands"}
 M03_WP3_TABLES = {"quarantine_inspections"}
 M03_WP4_TABLES = {"asset_provenance_records"}
 M03_WP5_TABLES = {"derivative_records"}
-M03_WP6_TABLES = {"delivery_share_links"}
+M03_WP6_SHARE_TABLES = {"delivery_share_links"}
+M03_WP6_POLICY_TABLES = {"asset_delivery_policies"}
 
 
 def alembic_config() -> Config:
@@ -240,6 +242,18 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         }.issubset(share_link_columns)
         assert "token" not in share_link_columns
         assert "raw_token" not in share_link_columns
+        delivery_policy_columns = {
+            column["name"]
+            for column in db_inspector.get_columns("asset_delivery_policies", schema="core")
+        }
+        assert {
+            "asset_id",
+            "project_id",
+            "access_class",
+            "created_at",
+            "updated_at",
+            "revision",
+        }.issubset(delivery_policy_columns)
         approval_request_columns = {
             column["name"]
             for column in db_inspector.get_columns("approval_requests", schema="core")
@@ -273,7 +287,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         with engine.connect() as connection:
             result = connection.execute(text("SELECT version_num FROM alembic_version"))
             revision = result.scalar_one()
-        assert revision == "20260901_0013"
+        assert revision == "20260901_0014"
 
         project_id = uuid4()
         with engine.begin() as connection:
@@ -394,9 +408,14 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         command.upgrade(config, "head")
         assert set(inspect(engine).get_table_names(schema="core")) == EXPECTED_CORE_TABLES
 
+        command.downgrade(config, "20260901_0013")
+        m13_tables = set(inspect(engine).get_table_names(schema="core"))
+        pre_wp6_policy_tables = EXPECTED_CORE_TABLES - M03_WP6_POLICY_TABLES
+        assert m13_tables == pre_wp6_policy_tables
+
         command.downgrade(config, "20260831_0012")
         m12_tables = set(inspect(engine).get_table_names(schema="core"))
-        pre_wp6_tables = EXPECTED_CORE_TABLES - M03_WP6_TABLES
+        pre_wp6_tables = pre_wp6_policy_tables - M03_WP6_SHARE_TABLES
         assert m12_tables == pre_wp6_tables
 
         command.downgrade(config, "20260830_0011")


### PR DESCRIPTION
Final M03-WP6 application slice from the certified share-link authority promoted at `ec35dca`.

Implements:
- reversible Alembic `20260901_0014` persisted asset delivery policy with fail-safe private default and explicit public opt-in;
- rights-aware canonical delivery resolution across Asset, provenance, StorageObject and RightsRecord;
- fail-closed ambiguous provenance, rights/publication, project and storage integrity checks;
- FastAPI signed-delivery endpoint for download/stream grants;
- share bearer tokens hashed in memory before durable lookup; raw share tokens are never persisted;
- trusted project-context path with development/test-only explicit project header fallback; arbitrary project headers are rejected outside that boundary;
- signing from the exact canonical StorageObject S3 bucket/region rather than silently substituting a configured bucket;
- bounded short-lived signed URL TTL;
- explicit Range capability response (`supports_range`, `accept_ranges=bytes`);
- PostgreSQL resolution tests, policy default/public tests, rights/provenance fail-closed tests, API tenant/share/public acceptance and migration reversibility.

Security boundary:
- missing asset policy is private;
- public access requires an explicit persisted policy;
- signed URL is issued only after canonical resolution and authorization;
- wrong tenant/share mode/rights/provenance fails closed;
- raw bearer token is never canonical state;
- no production CDN/adaptive streaming scope is introduced.

If this slice certifies and lands, M03-WP6 exit criteria are satisfied and the milestone dashboard can advance to 6/8 landed (75%) before WP7 begins.