### PR TITLE
Governance: parallel multi-agent development protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,30 +18,75 @@ The normal operator command is `next`.
 
 Before doing project work:
 
-1. Read `README.md`.
+1. Read `README.md`, including `Current agent working instructions`.
 2. Read `AGENTS.md`.
 3. Read `ai-native/DEVELOPMENT-CONSENT-GATE.md`.
 4. Read `ai-native/ENGINEERING-CONTRACT.md`.
 5. Read `ai-native/MASTER-PLAN.md`.
-6. Read `docs/architecture/DEVELOPMENT-PLAN.md` when development is relevant.
-7. Read `docs/architecture/TECH-STACK.md` when architecture/code is relevant.
-8. Read `config/project-taxonomy.yaml`.
-9. Read `config/execution-policy.yaml`.
-10. Read `config/content-policy.yaml` for child/content-policy work.
-11. Read `config/provider-registry.yaml`.
-12. Read `config/update-policy.yaml` when provider research/self-update is relevant.
-13. Read `ai-native/SYSTEM.md` and `ai-native/WORKFLOW.md` where applicable.
-14. Read `ai-native/QUALITY-GATES.md` and `ai-native/MEMORY-BANK.md`.
-15. Read `ai-native/AUDIO-ROUTER.md` when audio is relevant.
-16. Read `ai-native/VIDEO-CONTINUITY.md` when visual/video work is relevant.
-17. Read `ai-native/FREE-TIER-ROUTER.md` when provider routing/cost is relevant.
-18. Read product docs for character/timeline/project-option work.
-19. Read all machine-readable state/ledger files required for the current job.
-20. Inspect current implementation, tests and recent relevant Git history.
-21. Determine the first incomplete or highest-value eligible job.
-22. Before crossing from planning into executable development, verify that explicit operator consent exists for the exact development scope.
+6. For development/maintenance work, read `ai-native/parallel/MULTI-AGENT-PROTOCOL.md` and the relevant registries under `ai-native/parallel/`.
+7. Read `docs/architecture/DEVELOPMENT-PLAN.md` when development is relevant.
+8. Read `docs/architecture/TECH-STACK.md` when architecture/code is relevant.
+9. Read `config/project-taxonomy.yaml`.
+10. Read `config/execution-policy.yaml`.
+11. Read `config/content-policy.yaml` for child/content-policy work.
+12. Read `config/provider-registry.yaml`.
+13. Read `config/update-policy.yaml` when provider research/self-update is relevant.
+14. Read `ai-native/SYSTEM.md` and `ai-native/WORKFLOW.md` where applicable.
+15. Read `ai-native/QUALITY-GATES.md` and `ai-native/MEMORY-BANK.md`.
+16. Read `ai-native/AUDIO-ROUTER.md` when audio is relevant.
+17. Read `ai-native/VIDEO-CONTINUITY.md` when visual/video work is relevant.
+18. Read `ai-native/FREE-TIER-ROUTER.md` when provider routing/cost is relevant.
+19. Read product docs for character/timeline/project-option work.
+20. Read all machine-readable state/ledger files required for the current job.
+21. Inspect current implementation, tests and recent relevant Git/PR history.
+22. Determine the first incomplete or highest-value eligible job.
+23. Perform the mandatory working-instruction audit below.
+24. Before crossing from planning into executable development, verify that explicit operator consent exists for the exact development scope.
 
 Never rely only on chat memory when repository/runtime state exists.
+
+## Mandatory working-instruction audit
+
+Every agent must perform this audit on every start or resume, including when the operator only says `continue`, `next`, or `resume`.
+
+For development/maintenance work, compare the current repository state against the instructions under which the task previously operated. Check at minimum:
+- this file and the root README summary;
+- engineering and consent rules;
+- `ai-native/parallel/MULTI-AGENT-PROTOCOL.md`;
+- module ownership and active work claims;
+- dependency graph and public contract ownership;
+- shared-file rules;
+- migration reservation when schema/data work is possible;
+- relevant milestone/architecture docs;
+- current main/branch/PR/checkpoint evidence.
+
+The agent must determine whether the instructions it should follow have materially changed.
+
+If a material instruction change exists:
+1. update the affected canonical instruction/registry/task record before proceeding where permitted;
+2. re-evaluate scope, owned paths, dependencies, migration reservation, contracts, required checks and consent;
+3. stop or re-plan if the active assignment is no longer valid;
+4. ensure the root README `Current agent working instructions` summary is updated in the same integration cycle;
+5. record what changed and why in the relevant PR/checkpoint/integration record.
+
+If there is no material change, do not churn README just to refresh a timestamp. Continue using the verified current instructions.
+
+The README is a concise human-visible summary; canonical detailed rules remain in `AGENTS.md`, engineering/consent docs, and `ai-native/parallel/`.
+
+## Parallel agent coordination
+
+Parallel development is governed by `ai-native/parallel/MULTI-AGENT-PROTOCOL.md`.
+
+Core rules:
+- an agent may read the whole repository but may write only its claimed paths;
+- task branches are named for work packages, not AI/model identity;
+- overlapping active write claims are blocked until Integration Agent resolution;
+- shared files and generated artifacts are centrally coordinated unless explicitly granted;
+- migration identifiers are reserved before creation;
+- consumers depend on stable public contracts rather than another agent's private implementation;
+- every task pins an exact base commit when executable work starts;
+- exact-head promotion CI remains required where repository policy requires it;
+- parallel readiness never bypasses development consent.
 
 ## Mandatory development consent gate
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,45 @@ Every engineering agent must follow:
 - `AGENTS.md`
 - `ai-native/ENGINEERING-CONTRACT.md`
 - `ai-native/MASTER-PLAN.md`
+- `ai-native/parallel/MULTI-AGENT-PROTOCOL.md` for development/maintenance work;
 - relevant product/architecture documentation.
 
 The engineering constitution requires architecture-first development, current official-source research when material, security, tests, durable recovery, provenance, clear Git/checkpoints, and no fake completion.
+
+## Current agent working instructions
+
+This is the concise human-visible summary. Canonical details live in `AGENTS.md`, `ai-native/ENGINEERING-CONTRACT.md`, `ai-native/DEVELOPMENT-CONSENT-GATE.md`, and `ai-native/parallel/`.
+
+Current rules:
+- on **every start or resume**, including `continue`/`next`/`resume`, perform a working-instruction audit before proceeding;
+- read current repository/PR/checkpoint state rather than relying on chat memory;
+- for development work, read `MULTI-AGENT-PROTOCOL.md`, module ownership, active-work, dependency, migration, shared-file and contract registries;
+- an agent may **read the entire repository but write only its claimed paths**;
+- use task/work-package branches and pin an exact base commit when implementation starts;
+- overlapping active write claims are not allowed until the Integration Agent resolves/splits ownership;
+- shared files, generated artifacts, public export surfaces, repository-wide CI and global contracts are integration-owned unless a task receives a scoped grant;
+- reserve migration identifiers before creating migrations;
+- define/freeze shared contracts before fanning dependent implementations out to multiple agents;
+- parallel readiness does not bypass development consent;
+- scoped CI may accelerate feedback, but required exact-head full promotion CI remains mandatory before merge;
+- if a material governance/ownership/dependency/contract/CI/consent instruction changes how agents should work, update affected task instructions and **synchronize this README section in the same integration cycle**;
+- if the instruction audit finds no material change, do not churn README only to refresh a date.
+
+Parallel capacity guidance:
+- current/default: **4–5 active agents** including Integration and QA/planning lanes;
+- after stable module/contract boundaries: **6–8 implementation/review agents + 1 Integration Agent**;
+- mature repository: **8–12 active agents** only when the dependency graph exposes enough independent ready work.
+
+Canonical coordination files:
+- `ai-native/parallel/MULTI-AGENT-PROTOCOL.md`
+- `ai-native/parallel/MODULE-OWNERSHIP.yaml`
+- `ai-native/parallel/ACTIVE-WORK.yaml`
+- `ai-native/parallel/DEPENDENCY-GRAPH.yaml`
+- `ai-native/parallel/MIGRATION-REGISTRY.yaml`
+- `ai-native/parallel/SHARED-FILES.yaml`
+- `ai-native/parallel/CONTRACT-REGISTRY.yaml`
+- `ai-native/parallel/AGENT-TASK-SCHEMA.yaml`
+- `ai-native/parallel/INTEGRATION-PROTOCOL.md`
 
 ## Daily provider research
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The table below tracks the currently active implementation milestone. Completed 
 
 | Phase / Module | Scope | Start date | End date | Status | Progress |
 | --- | --- | --- | --- | --- | --- |
-| **M03 Overall** | Asset Storage and Provenance — 8 work packages | 2026-08-29 | TBD | 🟡 In progress | `██████▎░░░` **62.5% landed (5/8)** |
+| **M03 Overall** | Asset Storage and Provenance — 8 work packages | 2026-08-29 | TBD | 🟡 In progress | `███████▌░░` **75% landed (6/8)** |
 | **M03-WP1** | Storage adapter and object metadata | 2026-08-29 | 2026-08-29 | ✅ Complete / landed | `██████████` **100%** |
 | **M03-WP2** | Upload sessions | 2026-08-29 | 2026-08-29 | ✅ Complete / landed | `██████████` **100%** |
 | **M03-WP3** | Quarantine/probe/security | 2026-08-29 | 2026-08-30 | ✅ Complete / landed | `██████████` **100%** |
@@ -196,16 +196,19 @@ The table below tracks the currently active implementation milestone. Completed 
 | **M03-WP5** | Derivatives/proxies | 2026-08-31 | 2026-09-01 | ✅ Complete / promoted to `main` | `██████████` **100%** |
 | ↳ **PR #41** | WP5 deterministic derivative foundation promotion | 2026-09-01 | 2026-09-01 | ✅ Merged | `██████████` **100%** |
 | ↳ **PR #42** | WP5 executable resource-bounded derivative worker promotion | 2026-09-01 | 2026-09-01 | ✅ Merged — fresh Governance/Core/Durable green | `██████████` **100%** |
-| **M03-WP6** | Signed delivery | 2026-09-01 | TBD | 🟡 Active — authorized delivery foundation | `░░░░░░░░░░` **0% landed; implementation active** |
-| **M03-WP7** | Retention/archive/delete/export primitives | TBD | TBD | ⚪ Pending | `░░░░░░░░░░` **0%** |
+| **M03-WP6** | Signed delivery | 2026-09-01 | 2026-09-01 | ✅ Complete / promoted to `main` | `██████████` **100%** |
+| ↳ **PR #43** | Signed-delivery authorization and S3 grant foundation | 2026-09-01 | 2026-09-01 | ✅ Merged | `██████████` **100%** |
+| ↳ **PR #44** | Durable share-link authority and atomic use accounting | 2026-09-01 | 2026-09-01 | ✅ Merged — fresh Governance/Core/Durable green | `██████████` **100%** |
+| ↳ **PR #46** | Signed-delivery API, access policy and Range acceptance | 2026-09-01 | 2026-09-01 | ✅ Merged — fresh Governance/Core/Durable green | `██████████` **100%** |
+| **M03-WP7** | Retention/archive/delete/export primitives | 2026-09-01 | TBD | 🟡 Active — architecture/persistence audit | `░░░░░░░░░░` **0% landed; implementation active** |
 | **M03-WP8** | Acceptance | TBD | TBD | ⚪ Pending | `░░░░░░░░░░` **0%** |
 
 ### Current engineering checkpoint
 
-The active development frontier is **M03-WP6 — Signed delivery**. WP5 is fully promoted to `main`: PR #41 landed the deterministic derivative contract foundation and PR #42 landed the executable resource-bounded worker after fresh Repository Governance, Core Domain Contracts and Durable Control Plane verification.
+The active development frontier is **M03-WP7 — Retention/archive/delete/export primitives**. WP6 is fully promoted to `main`: PR #43 landed the authorization/signing foundation, PR #44 landed durable share-link authority with atomic use accounting, and PR #46 landed the signed-delivery API plus explicit access policy and Range acceptance after fresh Repository Governance, Core Domain Contracts and Durable Control Plane verification.
 
-WP6 remains fail-closed around tenant boundaries: private media must use authorized short-lived access, public exposure must be explicit, and share-link behavior must stay constrained rather than becoming an alternate authorization bypass.
+WP7 must preserve canonical media safety while adding lifecycle transitions: temporary cleanup must be bounded, archive/restore must be reversible, soft deletion must precede destructive deletion, hard-delete propagation must be explicit and auditable, export staging must not widen delivery authority, and vector/index cleanup must be represented as deterministic hooks rather than hidden side effects.
 
 Current continuation order:
 
-`WP6 delivery/access contract -> S3 signed GET adapter -> tenant/share-link authorization -> Range strategy acceptance -> exact-head CI -> WP6 promotion -> WP7`
+`WP7 lifecycle contract -> archive/restore state -> soft/hard deletion propagation -> temp cleanup -> export staging -> vector/index cleanup hooks -> exact-head CI -> WP7 promotion -> WP8`

--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -22,7 +22,7 @@ active:
       - packages/python-core/migrations/**
     depends_on:
       - M03-WP6
-    migration_reservation: 20260902_0015
+    migration_reservation: 20260901_0015
     consent_scope: M03
 
   - task_id: PARALLEL-GOVERNANCE-001

--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -1,0 +1,49 @@
+version: 1
+integration_owner:
+  role: integration
+  required: true
+
+active:
+  - task_id: M03-WP7
+    title: Retention/archive/delete/export primitives
+    role: module
+    branch: agent/20260901-ai-automation-force-m03-wp7-retention
+    base_policy: pin-exact-main-at-task-start
+    module: asset_lifecycle
+    status: active
+    writes:
+      - packages/python-core/src/lullabies_core/asset_lifecycle.py
+      - packages/python-core/src/lullabies_core/persistence/asset_lifecycle.py
+      - packages/python-core/tests/test_asset_lifecycle*.py
+    shared_requests:
+      - README.md
+      - packages/python-core/src/lullabies_core/__init__.py
+      - packages/python-core/src/ai_automation_force_core/__init__.py
+      - packages/python-core/migrations/**
+    depends_on:
+      - M03-WP6
+    migration_reservation: 20260902_0015
+    consent_scope: M03
+
+  - task_id: PARALLEL-GOVERNANCE-001
+    title: Repository-wide parallel multi-agent development governance
+    role: integration
+    branch: docs/multi-agent-parallel-development
+    module: repository_governance
+    status: active
+    writes:
+      - ai-native/parallel/**
+      - docs/architecture/DEVELOPMENT-PLAN.md
+      - AGENTS.md
+      - README.md
+    shared_requests: []
+    depends_on: []
+    migration_reservation: null
+    consent_scope: documentation-only
+
+rules:
+  - Integration Agent owns updates to this registry.
+  - Completed/merged tasks are removed or moved to repository checkpoints/history.
+  - Before claiming a new task, compare its write set with every active entry.
+  - Overlapping write sets block parallel execution unless Integration Agent splits/reassigns ownership.
+  - Every resume must revalidate branch head, base/current main, dependencies, working instructions, and consent.

--- a/ai-native/parallel/AGENT-TASK-SCHEMA.yaml
+++ b/ai-native/parallel/AGENT-TASK-SCHEMA.yaml
@@ -1,0 +1,52 @@
+version: 1
+required_fields:
+  - task_id
+  - title
+  - role
+  - branch
+  - base_sha
+  - status
+  - owned_paths
+  - dependencies
+  - consumed_contracts
+  - produced_contracts
+  - shared_file_requests
+  - migration_reservation
+  - consent_scope
+  - required_checks
+  - working_instruction_review
+
+template:
+  task_id: EXAMPLE-WP1
+  title: Example bounded work package
+  role: module
+  branch: agent/example-wp1
+  base_sha: PIN_EXACT_SHA
+  status: planned
+  owned_paths:
+    - path/to/module/**
+  read_only_paths:
+    - path/to/dependency/**
+  dependencies: []
+  consumed_contracts: []
+  produced_contracts: []
+  shared_file_requests: []
+  migration_reservation: null
+  consent_scope: REQUIRED_SCOPE_OR_DOCS_ONLY
+  required_checks:
+    - lint
+    - type-check
+    - relevant-tests
+    - exact-head-promotion-ci
+  working_instruction_review:
+    reviewed_at: YYYY-MM-DD
+    material_delta: false
+    readme_sync_required: false
+    notes: null
+
+validation_rules:
+  - owned_paths must not overlap another active task without Integration Agent approval.
+  - base_sha must be an exact commit, not an ambiguous moving branch, when executable work starts.
+  - migration_reservation must exist in MIGRATION-REGISTRY.yaml before a migration is created.
+  - material working-instruction changes require README synchronization in the same integration cycle.
+  - consent_scope is descriptive evidence only; the development consent gate remains authoritative.

--- a/ai-native/parallel/CONTRACT-REGISTRY.yaml
+++ b/ai-native/parallel/CONTRACT-REGISTRY.yaml
@@ -1,0 +1,61 @@
+version: 1
+owner_role: integration
+policy:
+  contract_changes_require_dependency_review: true
+  breaking_changes_require_explicit_coordination: true
+  consumers_should_depend_on_public_contracts_not_private_implementation: true
+
+contracts:
+  Asset:
+    owner_module: storage_and_assets
+    stability: established
+    consumers:
+      - asset_lifecycle
+      - timeline_storyboard
+      - media_qa
+      - assembly
+      - publishing_analytics
+
+  StorageObject:
+    owner_module: storage_and_assets
+    stability: established
+    consumers:
+      - asset_lifecycle
+      - assembly
+
+  AssetProvenanceRecord:
+    owner_module: storage_and_assets
+    stability: established
+    consumers:
+      - asset_lifecycle
+      - media_qa
+      - publishing_analytics
+
+  DeliverySubject:
+    owner_module: storage_and_assets
+    stability: established
+    consumers:
+      - control_plane
+
+  Character:
+    owner_module: characters_entities
+    stability: existing-foundation
+    consumers:
+      - content_memory
+      - timeline_storyboard
+      - providers
+      - media_qa
+
+  Timeline:
+    owner_module: timeline_storyboard
+    stability: existing-foundation
+    consumers:
+      - providers
+      - media_qa
+      - assembly
+
+rules:
+  - Add new public contracts before assigning multiple consumers in parallel.
+  - A contract owner may not silently break consumers; update dependency state and affected task instructions first.
+  - Private helpers are not cross-agent integration contracts.
+  - Generated schema/OpenAPI updates remain shared integration work unless explicitly granted.

--- a/ai-native/parallel/DEPENDENCY-GRAPH.yaml
+++ b/ai-native/parallel/DEPENDENCY-GRAPH.yaml
@@ -1,0 +1,35 @@
+version: 1
+owner_role: integration
+policy:
+  update_when_dependencies_change: true
+  parallelize_only_independent_ready_nodes: true
+
+current:
+  M03-WP7:
+    state: active
+    depends_on:
+      - M03-WP6
+    unlocks:
+      - M03-WP8
+
+  M03-WP8:
+    state: waiting
+    depends_on:
+      - M03-WP7
+
+future_planning_lanes:
+  M04:
+    state: planning-only-until-current-entry-gates-are-satisfied
+    first_boundary: character-and-entity-contracts
+  M05:
+    state: planning-only-until-current-entry-gates-are-satisfied
+    first_boundary: content-and-memory-contracts
+  M06:
+    state: planning-only-until-current-entry-gates-are-satisfied
+    first_boundary: audio-contracts
+
+rules:
+  - This registry describes dependency readiness and does not grant development consent.
+  - Integration Agent updates it before assigning newly unblocked work.
+  - Independent planning lanes may run in parallel where repository governance permits.
+  - Do not serialize independent work only because milestone numbers are sequential.

--- a/ai-native/parallel/INTEGRATION-PROTOCOL.md
+++ b/ai-native/parallel/INTEGRATION-PROTOCOL.md
@@ -1,0 +1,92 @@
+# Integration Agent Protocol
+
+## Mission
+
+The Integration Agent is the single coordination authority for a parallel development window. Its job is to maximize safe throughput without becoming a bottleneck or weakening repository gates.
+
+## Start-of-cycle checks
+
+Before allocating work:
+1. inspect current `main` head and open relevant PRs;
+2. read `AGENTS.md`, engineering/consent rules, and `MULTI-AGENT-PROTOCOL.md`;
+3. run the working-instruction audit;
+4. reconcile `ACTIVE-WORK.yaml` with actual branches/PRs;
+5. reconcile `MIGRATION-REGISTRY.yaml` with current main and active branches;
+6. check module/path ownership and shared-file claims;
+7. inspect dependency/contract changes that may invalidate active assignments;
+8. update the README working-instruction summary when a material instruction delta exists.
+
+## Allocation
+
+For each candidate work package:
+- confirm it is ready in the dependency graph;
+- confirm applicable development consent;
+- choose the smallest coherent write set;
+- pin exact base SHA;
+- assign a task branch;
+- record consumed/produced contracts;
+- reserve any migration identifier;
+- list required scoped and promotion checks;
+- reject or split the task if its write set overlaps another active task.
+
+## Shared-file integration
+
+Module agents normally do not edit shared files. The Integration Agent batches compatible deltas for:
+- README/checkpoints;
+- public package exports;
+- generated schemas/OpenAPI;
+- migration chain reconciliation;
+- dependency manifests;
+- repository-wide configuration/CI.
+
+Do not batch unrelated behavior changes merely to reduce PR count.
+
+## PR queue
+
+Classify each PR:
+- independent: may promote in any order after current-main sync;
+- ordered: must land after named predecessor;
+- contract owner: may unblock several dependent PRs;
+- integration-only: shared-file/generated-artifact reconciliation;
+- blocked: cannot promote until dependency/conflict is resolved.
+
+## Promotion
+
+Before merging an executable PR:
+1. verify intended scope and changed files;
+2. verify head/base relation against current main;
+3. reconcile any dependency or shared-contract drift;
+4. ensure migration reservation/parent is still valid;
+5. run required exact-head promotion CI;
+6. verify required checks are green, not skipped or stale;
+7. merge using expected-head protection where available;
+8. update registries/checkpoints and unblock dependents.
+
+## Working instructions
+
+The Integration Agent owns human-visible synchronization of materially changed agent instructions.
+
+When any governance, architecture, module ownership, dependency, shared-file, migration, CI, consent, or contract rule changes how an agent should work:
+- update canonical instruction source(s);
+- update task manifests/active-work records affected by the change;
+- update the root README `Current agent working instructions` section in the same integration cycle;
+- identify active tasks needing re-review;
+- do not allow an agent to continue on stale instructions when the delta changes its scope or safety obligations.
+
+If no material delta exists, do not edit README merely to refresh a date.
+
+## Throughput rule
+
+The Integration Agent should continuously look for independent ready work rather than waiting for the current critical-path implementation to finish before preparing the next safe lanes. However, future executable work still respects development consent and milestone entry gates.
+
+## Failure handling
+
+If two branches conflict semantically:
+- stop automatic promotion;
+- identify contract/state owner;
+- choose one canonical direction;
+- update affected task instructions;
+- rebase/rework dependent branches;
+- rerun tests on exact candidate heads.
+
+Never solve semantic conflicts by accepting both incompatible implementations.

--- a/ai-native/parallel/MIGRATION-REGISTRY.yaml
+++ b/ai-native/parallel/MIGRATION-REGISTRY.yaml
@@ -1,0 +1,23 @@
+version: 1
+owner_role: integration
+policy:
+  reservation_required_before_creation: true
+  duplicate_active_revision_forbidden: true
+  abandoned_reservations_must_be_released: true
+  migration_dependency_must_match_landed_or_declared_parent: true
+
+reservations:
+  - revision: 20260901_0015
+    task_id: M03-WP7
+    branch: agent/20260901-ai-automation-force-m03-wp7-retention
+    parent_revision: 20260901_0014
+    purpose: asset lifecycle state and event authority
+    status: in-use-unmerged
+
+next_allocation:
+  rule: integration-agent-assigns-next-unique-revision-after-current-main-and-active-reservations-are-reconciled
+
+notes:
+  - Never infer the next revision only from the current branch; inspect current main plus active reservations.
+  - Parallel migrations may require an explicit dependency/merge ordering even when their SQL domains are independent.
+  - If a branch is rebased after another migration lands, Integration Agent decides whether to renumber/re-parent before promotion.

--- a/ai-native/parallel/MODULE-OWNERSHIP.yaml
+++ b/ai-native/parallel/MODULE-OWNERSHIP.yaml
@@ -1,0 +1,122 @@
+version: 1
+policy:
+  read_scope: repository-wide
+  default_write_scope: claimed-paths-only
+  shared_files_require_integration_owner: true
+  overlapping_active_write_claims_allowed: false
+
+modules:
+  control_plane:
+    paths:
+      - apps/api/**
+      - apps/worker/**
+      - packages/python-core/src/lullabies_core/control_surface.py
+      - packages/python-core/src/lullabies_core/job_control.py
+      - packages/python-core/src/lullabies_core/workflow_runtime.py
+    contracts:
+      - Job
+      - WorkflowExecutionRef
+
+  storage_and_assets:
+    paths:
+      - packages/python-core/src/lullabies_core/storage.py
+      - packages/python-core/src/lullabies_core/storage_s3.py
+      - packages/python-core/src/lullabies_core/provenance.py
+      - packages/python-core/src/lullabies_core/delivery.py
+      - packages/python-core/src/lullabies_core/delivery_s3.py
+      - packages/python-core/src/lullabies_core/persistence/storage_object.py
+      - packages/python-core/src/lullabies_core/persistence/asset_provenance.py
+      - packages/python-core/src/lullabies_core/persistence/delivery_access.py
+      - packages/python-core/src/lullabies_core/persistence/share_link.py
+    contracts:
+      - Asset
+      - StorageObject
+      - AssetProvenanceRecord
+      - DeliverySubject
+
+  asset_lifecycle:
+    paths:
+      - packages/python-core/src/lullabies_core/asset_lifecycle.py
+      - packages/python-core/src/lullabies_core/persistence/asset_lifecycle.py
+      - packages/python-core/tests/test_asset_lifecycle*.py
+    contracts:
+      - AssetLifecycleState
+      - AssetLifecycleEvent
+
+  characters_entities:
+    paths:
+      - packages/python-core/src/lullabies_core/character.py
+      - packages/python-core/src/lullabies_core/entities.py
+    contracts:
+      - Character
+      - CharacterVersion
+      - CharacterLook
+      - World
+      - Location
+      - Prop
+
+  content_memory:
+    paths:
+      - packages/python-core/src/lullabies_core/content.py
+      - automation/**
+    contracts:
+      - Content
+      - ContentVersion
+
+  audio:
+    paths:
+      - packages/python-core/src/**/audio/**
+      - apps/worker/src/**/audio/**
+    contracts: []
+
+  timeline_storyboard:
+    paths:
+      - packages/python-core/src/lullabies_core/timeline.py
+      - packages/python-core/src/**/storyboard/**
+    contracts:
+      - Timeline
+      - Act
+      - Sequence
+      - Scene
+      - Shot
+      - Take
+
+  providers:
+    paths:
+      - packages/python-core/src/**/providers/**
+      - config/provider-registry.yaml
+    contracts: []
+
+  media_qa:
+    paths:
+      - packages/python-core/src/**/qa/**
+      - packages/python-core/src/lullabies_core/media_security.py
+    contracts:
+      - QARecord
+      - QuarantineInspection
+
+  assembly:
+    paths:
+      - packages/python-core/src/**/assembly/**
+      - apps/worker/src/**/assembly/**
+    contracts: []
+
+  web:
+    paths:
+      - apps/web/**
+    contracts: []
+
+  publishing_analytics:
+    paths:
+      - packages/python-core/src/**/publishing/**
+      - packages/python-core/src/**/analytics/**
+    contracts: []
+
+shared_ownership:
+  owner_role: integration
+  registry: ai-native/parallel/SHARED-FILES.yaml
+
+notes:
+  - Module paths may be refined as new packages are introduced.
+  - A task manifest overrides ownership only when the Integration Agent explicitly records the exception.
+  - Existing broad legacy files should be split behind stable contracts over time rather than rewritten only to satisfy this map.

--- a/ai-native/parallel/MULTI-AGENT-PROTOCOL.md
+++ b/ai-native/parallel/MULTI-AGENT-PROTOCOL.md
@@ -1,0 +1,248 @@
+# Parallel Multi-Agent Development Protocol
+
+## Purpose
+
+Make repository development safely parallel so multiple AI or human agents can work at the same time without silently overwriting, duplicating, or invalidating each other's work.
+
+This protocol is repository-wide and applies to current and future milestones. It supplements `AGENTS.md`, `ai-native/ENGINEERING-CONTRACT.md`, the development consent gate, milestone plans, and CI rules. It does not weaken any existing security, testing, consent, or exact-head verification requirement.
+
+## Target concurrency
+
+Use concurrency according to repository maturity and dependency independence:
+
+- current/default safe target: 4-5 active agents including integration/QA lanes;
+- after module ownership and contract boundaries are stable: 6-8 implementation/review agents plus one integration agent;
+- mature target: 8-12 active agents only when the dependency graph contains enough independent ready work;
+- never create parallel work merely to reach an agent count.
+
+The scheduler must prefer fewer independent agents over many overlapping agents.
+
+## Core model
+
+Parallel development is dependency-aware and contract-first:
+
+`plan -> contract/freeze boundary -> identify independent ready work -> claim scopes -> isolated branches -> scoped CI -> integration queue -> current-main sync -> full promotion CI -> merge`
+
+A work package is parallel-safe only when its write set, schema/migration ownership, public contracts, and dependencies are known.
+
+## Mandatory roles
+
+### Integration Agent
+
+Exactly one integration authority owns repository-wide coordination for a promotion window.
+
+Responsibilities:
+- allocate/confirm work claims;
+- maintain `ACTIVE-WORK.yaml`;
+- reserve migration identifiers;
+- arbitrate shared-file edits;
+- preserve public contract compatibility;
+- track PR dependencies/blockers;
+- reconcile generated schemas/public exports/checkpoints/README;
+- require current-main synchronization before promotion;
+- run/verify full exact-head CI;
+- merge only certified candidates.
+
+The Integration Agent should not become the default feature implementer when independent module work can be delegated.
+
+### Module Agents
+
+A module agent may read the entire repository but may write only its claimed paths plus explicitly granted shared files.
+
+A module agent must:
+- work from a pinned base commit;
+- use a task/work-package branch, not an agent-personality branch;
+- preserve public contracts unless the task explicitly owns the contract change;
+- avoid opportunistic refactors outside scope;
+- report any needed shared-file changes to the Integration Agent;
+- keep its PR small enough to review and rebase safely.
+
+### QA / Adversarial Agent
+
+A QA agent independently evaluates implementation assumptions, race conditions, tenant/security boundaries, crash/retry behavior, migration reversibility, compatibility, and regression risk. QA may propose tests/fixes but must still claim write paths before modifying them.
+
+### Planning / Contract Agent
+
+A planning/contract agent may prepare future dependency-ready work without touching executable behavior unless applicable development consent exists. Contract changes that affect executable behavior follow the consent gate.
+
+## Write ownership rule
+
+Default rule:
+
+> Every agent may READ the whole repository. Every agent may WRITE only the paths explicitly claimed for its task.
+
+If two active tasks need the same non-shared write path, they are not parallel-safe until the work is split or ownership is reassigned.
+
+## Shared files
+
+Shared/high-conflict files are centrally coordinated. Canonical list: `SHARED-FILES.yaml`.
+
+Examples include:
+- root `README.md`;
+- `AGENTS.md`;
+- public package `__init__.py` export surfaces;
+- dependency manifests/lock files;
+- generated schemas/OpenAPI artifacts;
+- migration chain/head metadata;
+- repository-wide CI workflows;
+- common/global domain contracts;
+- global configuration used by multiple modules.
+
+Module agents should normally record requested shared-file deltas in the PR description instead of editing shared files directly. The Integration Agent may grant temporary ownership when a shared edit is intrinsic to the task.
+
+## Migration reservation
+
+No agent invents a migration identifier independently.
+
+Before creating a migration:
+1. inspect `MIGRATION-REGISTRY.yaml`;
+2. obtain/reserve the next identifier through the integration lane;
+3. record owner task, branch, dependency/base revision, and status;
+4. create only the reserved migration;
+5. release/cancel reservations that will not be used.
+
+Two active branches must never own the same migration identifier.
+
+## Contract-first parallelization
+
+When several implementations depend on the same boundary, define and freeze the minimal contract first.
+
+Example:
+
+`Character contract -> persistence | API | QA | UI client work in parallel`
+
+Agents consume the public contract rather than another agent's private implementation details. A contract-breaking change invalidates dependent work and must be coordinated before merge.
+
+Canonical contract inventory: `CONTRACT-REGISTRY.yaml`.
+
+## Dependency graph
+
+Canonical dependency state lives in `DEPENDENCY-GRAPH.yaml`.
+
+A task is eligible only when:
+- required predecessor contracts/landed work exist;
+- required development consent exists;
+- its write set does not conflict with another active claim;
+- any migration slot is reserved;
+- no shared-file ownership conflict is unresolved.
+
+Blocked work may still perform read-only research/planning when permitted.
+
+## Branching
+
+Use task identity, not model/agent identity:
+
+- good: `agent/M06-WP2-audio-persistence`
+- good: `agent/M04-WP1-character-contracts`
+- avoid: `agent/gpt-work`
+- avoid: `agent/claude-2`
+
+Every task record carries its exact `base_sha`.
+
+## Synchronization and promotion
+
+Before promotion:
+1. verify the PR still represents the intended task scope;
+2. compare against current `main`;
+3. resolve contract/schema/shared-file changes through the integration lane;
+4. synchronize/rebase/merge current main as repository policy permits;
+5. rerun required full CI on the exact candidate head;
+6. merge with an expected-head guard where available;
+7. update active-work/dependency/contract/migration state and checkpoints.
+
+Passing scoped CI earlier does not replace exact-head promotion CI.
+
+## CI strategy
+
+Two layers are permitted:
+
+### Scoped agent CI
+Fast feedback on affected modules:
+- format/lint;
+- typing;
+- module unit tests;
+- relevant contract/database tests;
+- relevant security checks.
+
+### Promotion CI
+Required before merge for executable work:
+- repository governance;
+- full applicable core/API/worker tests;
+- PostgreSQL/migration checks;
+- Temporal/workflow checks where applicable;
+- generated schema/OpenAPI synchronization;
+- compile/build/security checks required by repository policy.
+
+Path-scoped CI may accelerate feedback but must never weaken the promotion gate.
+
+## Working-instruction audit — mandatory on every start/resume
+
+Before an agent starts or resumes work, it must explicitly determine the current working instructions for that task.
+
+The audit must check at minimum:
+- `AGENTS.md`;
+- `ai-native/ENGINEERING-CONTRACT.md`;
+- `ai-native/DEVELOPMENT-CONSENT-GATE.md`;
+- this protocol;
+- relevant milestone/architecture docs;
+- `MODULE-OWNERSHIP.yaml`;
+- `ACTIVE-WORK.yaml`;
+- `DEPENDENCY-GRAPH.yaml`;
+- `MIGRATION-REGISTRY.yaml` when data/schema work is possible;
+- `SHARED-FILES.yaml`;
+- `CONTRACT-REGISTRY.yaml`;
+- relevant recent Git/PR/checkpoint state.
+
+The agent must decide whether its previous working instructions are still correct.
+
+If instructions changed materially, the agent must:
+1. update its task/PR/checkpoint instructions before continuing;
+2. update the root README `Current agent working instructions` summary in the same integration cycle;
+3. record what changed and why;
+4. re-evaluate scope, ownership, dependencies, migration reservation, test obligations, and consent;
+5. stop or re-plan if the change invalidates the active assignment.
+
+If instructions did not change, no README churn is required; the agent records/notes that the instruction audit found no material delta where checkpoint reporting is applicable.
+
+The README is a human-visible summary. Canonical detailed rules remain in repository governance/parallel files.
+
+## Task manifest
+
+Every implementation task should conform to `AGENT-TASK-SCHEMA.yaml` and identify:
+- task/work-package ID;
+- role/owner lane;
+- pinned base SHA;
+- branch;
+- owned write paths;
+- read-only dependencies;
+- shared-file requests;
+- consumed/produced contracts;
+- dependency IDs;
+- migration reservation if any;
+- required verification;
+- consent state;
+- current status.
+
+## Conflict policy
+
+A conflict is not only a Git textual conflict. Treat these as conflicts too:
+- two agents changing the same public contract differently;
+- duplicate migration numbers;
+- one PR depending on unmerged implementation internals from another;
+- incompatible schema/OpenAPI changes;
+- simultaneous global dependency changes;
+- competing generated-artifact updates;
+- two agents claiming authority over the same canonical state machine/table;
+- stale-base implementation that violates newly landed invariants.
+
+Such conflicts are resolved before promotion, not hidden by a textual merge.
+
+## Speed principle
+
+Parallelism should reduce critical-path idle time. Prefer independent lanes such as implementation, tests, future contract planning, provider research, frontend preparation, and adversarial QA when they do not share mutable ownership.
+
+Do not parallelize tightly coupled sequential state transitions merely for speed. Contract definition, destructive migrations, global auth changes, and shared architecture changes often require a short serialized integration window before fan-out.
+
+## Completion
+
+A parallel task is not complete merely because its branch is coded. Completion requires the same evidence as any other repository work: relevant tests, security/data review, documentation/checkpointing, current-main compatibility, and exact-head promotion evidence where required.

--- a/ai-native/parallel/SHARED-FILES.yaml
+++ b/ai-native/parallel/SHARED-FILES.yaml
@@ -1,0 +1,33 @@
+version: 1
+owner_role: integration
+policy:
+  default_module_agent_write: false
+  temporary_write_grant_requires_task_record: true
+  generated_artifacts_updated_at_integration: true
+
+paths:
+  - README.md
+  - AGENTS.md
+  - ROADMAP.md
+  - ai-native/ENGINEERING-CONTRACT.md
+  - ai-native/DEVELOPMENT-CONSENT-GATE.md
+  - ai-native/parallel/**
+  - packages/python-core/src/lullabies_core/__init__.py
+  - packages/python-core/src/ai_automation_force_core/__init__.py
+  - packages/python-core/src/lullabies_core/common.py
+  - packages/python-core/pyproject.toml
+  - packages/python-core/alembic.ini
+  - packages/python-core/migrations/versions/**
+  - packages/python-core/migrations/sql/**
+  - schemas/generated/**
+  - .github/workflows/**
+  - config/project-taxonomy.yaml
+  - config/execution-policy.yaml
+  - config/content-policy.yaml
+
+rules:
+  - A module agent needing one of these paths records the required delta in its task/PR.
+  - Migration files require an explicit reservation in MIGRATION-REGISTRY.yaml before creation.
+  - Integration may grant scoped temporary ownership when the shared edit is inseparable from the feature.
+  - A temporary grant does not permit unrelated cleanup or refactoring.
+  - README working-instruction summary is synchronized whenever material agent instructions change.

--- a/docs/architecture/DEVELOPMENT-PLAN.md
+++ b/docs/architecture/DEVELOPMENT-PLAN.md
@@ -27,6 +27,39 @@ Use vertical slices to prove architecture:
 
 Do not attempt a three-hour generated movie as the first acceptance test.
 
+## Parallel multi-agent development strategy
+
+Development is dependency-aware, contract-first, and parallel by default where scopes are genuinely independent.
+
+Canonical protocol and registries live under `ai-native/parallel/`:
+- `MULTI-AGENT-PROTOCOL.md`;
+- `MODULE-OWNERSHIP.yaml`;
+- `ACTIVE-WORK.yaml`;
+- `DEPENDENCY-GRAPH.yaml`;
+- `MIGRATION-REGISTRY.yaml`;
+- `SHARED-FILES.yaml`;
+- `CONTRACT-REGISTRY.yaml`;
+- `AGENT-TASK-SCHEMA.yaml`;
+- `INTEGRATION-PROTOCOL.md`.
+
+Operating model:
+
+`contract/freeze boundary -> identify independent ready work -> claim scopes -> isolated task branches -> scoped CI -> integration queue -> current-main synchronization -> full exact-head promotion CI -> merge`
+
+Concurrency guidance:
+- current/default safe target: **4–5 active agents**, including integration and QA/planning lanes;
+- after ownership and contract boundaries are stable: **6–8 implementation/review agents plus one Integration Agent**;
+- mature repository target: **8–12 active agents** only when enough independent ready nodes exist;
+- never split tightly coupled work merely to increase agent count.
+
+The plan's milestone numbering is an architecture/dependency guide, not a requirement that all work be executed serially. Independent planning, contract preparation, QA, frontend preparation, provider research, or module implementation may run in parallel when dependencies, ownership, consent, and shared-file rules permit.
+
+Every agent may read the full repository but may write only its claimed paths. Shared files, generated artifacts, public export surfaces, migration identifiers, global contracts, and repository-wide CI are coordinated by the Integration Agent unless a task receives an explicit scoped grant.
+
+Before every start/resume, the agent must perform the working-instruction audit defined in `MULTI-AGENT-PROTOCOL.md`. If a material change alters how agents must work, the canonical instruction source and affected task records must be updated, and the root README `Current agent working instructions` summary must be synchronized in the same integration cycle. If no material instruction delta exists, README should not be churned merely to refresh a date.
+
+Development consent remains scoped and authoritative. Parallel readiness or a dependency-graph `ready` state never grants executable-development permission by itself.
+
 ---
 
 ## Milestone 0 — Architecture and contract lock


### PR DESCRIPTION
Repository-wide documentation/governance change to make current and future development safely parallel across multiple agents.

Adds:
- canonical parallel multi-agent protocol;
- module ownership and active-work registries;
- dependency graph;
- migration reservation registry;
- shared-file ownership registry;
- public contract registry;
- agent task manifest schema;
- Integration Agent protocol;
- development-plan concurrency guidance (4–5 current, 6–8 + integration after stable boundaries, 8–12 mature only when independent work exists);
- mandatory start/resume working-instruction audit in AGENTS.md;
- root README `Current agent working instructions` summary with mandatory synchronization when material instructions change;
- README milestone reconciliation to the already-landed WP6 state and current WP7 frontier.

Core safety rules:
- agents may read the repository but write only claimed paths;
- shared files/generated artifacts/migration allocation are integration-coordinated;
- task branches pin exact base commits;
- contract-first fan-out for parallel consumers;
- parallel readiness never bypasses development consent;
- scoped CI may accelerate feedback but exact-head promotion CI remains authoritative.

This PR changes no runtime/application/database behavior and introduces no dependency or CI workflow changes.