### PR TITLE
Governance: new-agent onboarding and slot validation

### DIFF
--- a/.github/workflows/repository-governance.yml
+++ b/.github/workflows/repository-governance.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/**"
       - "scripts/apply_main_protection.ps1"
       - "scripts/verify_main_protection.ps1"
+      - "scripts/validate_parallel_governance.py"
+      - "ai-native/parallel/**"
+      - "README.md"
       - "docs/governance/**"
   workflow_dispatch:
 
@@ -64,3 +67,6 @@ jobs:
           if ($apply.Contains('"validate"')) { throw 'Protection applicator must not require ambiguous legacy validate context.' }
 
           Write-Host 'Repository governance static contract PASS.'
+
+      - name: Validate Supervisor multi-agent governance
+        run: python3 scripts/validate_parallel_governance.py

--- a/README.md
+++ b/README.md
@@ -131,10 +131,13 @@ This is the concise human-visible summary. Canonical details live in `AGENTS.md`
 Current rules:
 - on **every start or resume**, including `continue`/`next`/`resume`, perform a working-instruction audit before proceeding;
 - read current repository/PR/checkpoint state rather than relying on chat memory;
-- in multi-agent Supervisor mode, the agent controlling the main integration lane is the **Supervisor** and owns review/merge authority;
+- in multi-agent Supervisor mode, the agent controlling the main integration lane is the **Supervisor** and owns assignment/review/merge authority;
 - when a new multi-agent orchestration assignment specifies parallel modules, the Supervisor's **first repository action is to create every intended module branch, including its own module branch, before documenting/starting the work**;
-- branch creation does not bypass dependency or development-consent gates; future/blocked lanes remain planning/contract-only;
-- for development work, read `MULTI-AGENT-PROTOCOL.md`, `SUPERVISOR-PLAN.md`, module ownership, active-work, dependency, migration, shared-file, contract, merge-queue, Supervisor-state, and broadcast registries;
+- every **new agent must start from current `main`** and may not start directly from a feature branch or self-assign a module;
+- on a new-agent arrival, the Supervisor checks `AGENT-SLOTS.json` + `SUPERVISOR-PLAN.md`; if an eligible `open` slot exists, the Supervisor assigns that module/branch and records the occupied agent/start state before work begins;
+- if all eligible module slots are occupied, the Supervisor stops the new agent immediately and says exactly **`Go Home Come Back Next Time`**; that agent receives no module/branch and starts no work;
+- branch creation or slot assignment does not bypass dependency or development-consent gates; future/blocked lanes remain planning/contract-only;
+- for development work, read `MULTI-AGENT-PROTOCOL.md`, `SUPERVISOR-PLAN.md`, `AGENT-SLOTS.json`, module ownership, active-work, dependency, migration, shared-file, contract, merge-queue, Supervisor-state, and broadcast registries;
 - an agent may **read the entire repository but write only its claimed paths**;
 - use task/work-package branches and pin an exact base commit when implementation starts;
 - overlapping active write claims are not allowed until the Supervisor resolves/splits ownership;
@@ -143,22 +146,25 @@ Current rules:
 - define/freeze shared contracts before fanning dependent implementations out to multiple agents;
 - every agent must announce exactly **`Work Done and Submitted`** when its bounded branch submission is ready for Supervisor review;
 - when another agent submits, the Supervisor checkpoints/pauses its own module work, reviews the submission, promotes only after required synchronization and exact-head gates, records the merge, then resumes its saved checkpoint;
-- after a merge that active agents must observe, the Supervisor emits and records exactly: **`New changes have been merged — please merge these changes into your branch first, then resume your own work.`**;
+- after a promotion merge that active agents must observe, the Supervisor emits and records exactly: **`New changes have been merged — please merge these changes into your branch first, then resume your own work.`**;
 - affected agents must synchronize the new `main`, rerun the working-instruction audit, revalidate contracts/dependencies/migration state, acknowledge the broadcast, and only then resume;
 - an unacknowledged mandatory merge broadcast places a branch in `sync-required` and blocks submission/promotion;
 - parallel readiness does not bypass development consent;
 - scoped CI may accelerate feedback, but required exact-head full promotion CI remains mandatory before merge;
+- Repository Governance validates Supervisor/slot state, slot-to-plan/task consistency, exact completion/broadcast phrases, broadcast sequence consistency, and duplicate migration reservations;
 - if a material governance/ownership/dependency/contract/CI/consent/Supervisor-workflow instruction changes how agents should work, update affected task instructions and **synchronize this README section in the same integration cycle**;
 - if the instruction audit finds no material change, do not churn README only to refresh a date.
 
 Parallel capacity guidance:
 - current/default: **4–5 active agents** including Supervisor and QA/planning lanes;
 - after stable module/contract boundaries: **6–8 implementation/review agents + 1 Supervisor**;
-- mature repository: **8–12 active agents** only when the dependency graph exposes enough independent ready work.
+- mature repository: **8–12 active agents** only when the dependency graph exposes enough independent ready work;
+- current defined slot registry is fully occupied, so an extra agent currently receives **`Go Home Come Back Next Time`** until a slot is explicitly released/opened.
 
 Canonical coordination files:
 - `ai-native/parallel/MULTI-AGENT-PROTOCOL.md`
 - `ai-native/parallel/SUPERVISOR-PLAN.md`
+- `ai-native/parallel/AGENT-SLOTS.json`
 - `ai-native/parallel/SUPERVISOR-STATE.yaml`
 - `ai-native/parallel/SUPERVISOR-BROADCASTS.yaml`
 - `ai-native/parallel/MERGE-QUEUE.yaml`
@@ -213,7 +219,7 @@ The table below tracks the currently active implementation milestone. Completed 
 | ↳ **PR #43** | Signed-delivery authorization and S3 grant foundation | 2026-09-01 | 2026-09-01 | ✅ Merged | `██████████` **100%** |
 | ↳ **PR #44** | Durable share-link authority and atomic use accounting | 2026-09-01 | 2026-09-01 | ✅ Merged — fresh Governance/Core/Durable green | `██████████` **100%** |
 | ↳ **PR #46** | Signed-delivery API, access policy and Range acceptance | 2026-09-01 | 2026-09-01 | ✅ Merged — fresh Governance/Core/Durable green | `██████████` **100%** |
-| **M03-WP7** | Retention/archive/delete/export primitives | 2026-09-01 | TBD | 🟡 Active — architecture/persistence audit | `░░░░░░░░░░` **0% landed; implementation active** |
+| **M03-WP7** | Retention/archive/delete/export primitives | 2026-09-01 | TBD | 🟡 Active — lifecycle foundation synchronized; promotion pending | `░░░░░░░░░░` **0% landed; implementation active** |
 | **M03-WP8** | Acceptance | TBD | TBD | ⚪ Pending | `░░░░░░░░░░` **0%** |
 
 ### Current engineering checkpoint
@@ -224,4 +230,4 @@ WP7 must preserve canonical media safety while adding lifecycle transitions: tem
 
 Current continuation order:
 
-`WP7 lifecycle contract -> archive/restore state -> soft/hard deletion propagation -> temp cleanup -> export staging -> vector/index cleanup hooks -> exact-head CI -> WP7 promotion -> WP8`
+`WP7 lifecycle foundation promotion -> deletion propagation -> temp cleanup -> export staging -> vector/index cleanup hooks -> exact-head CI -> WP7 promotion -> WP8`

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -1,1 +1,87 @@
-{}
+{
+  "version": 1,
+  "source_branch_required": "main",
+  "assignment_authority": "supervisor",
+  "no_slot_response": "Go Home Come Back Next Time",
+  "policy": {
+    "new_agent_must_start_from_main": true,
+    "supervisor_assigns_first_open_slot": true,
+    "agent_may_not_self_assign": true,
+    "assignment_updates_plan_before_work": true,
+    "no_open_slot_blocks_all_work": true
+  },
+  "slots": [
+    {
+      "slot_id": "SUPERVISOR-M03-WP7",
+      "module": "asset_lifecycle",
+      "branch": "supervisor/m03-wp7-retention",
+      "status": "occupied",
+      "assigned_agent": "supervisor-agent",
+      "accepts_new_agent": false,
+      "start_status": "active"
+    },
+    {
+      "slot_id": "M03-WP8",
+      "module": "m03_acceptance",
+      "branch": "agent/m03-wp8-acceptance",
+      "status": "occupied",
+      "assigned_agent": "acceptance-agent",
+      "accepts_new_agent": true,
+      "start_status": "planning-only-waiting-on-wp7"
+    },
+    {
+      "slot_id": "M04-CHARACTER",
+      "module": "characters_entities",
+      "branch": "agent/m04-character-library",
+      "status": "occupied",
+      "assigned_agent": "character-agent",
+      "accepts_new_agent": true,
+      "start_status": "planning-only"
+    },
+    {
+      "slot_id": "M05-CONTENT",
+      "module": "content_memory",
+      "branch": "agent/m05-content-memory",
+      "status": "occupied",
+      "assigned_agent": "content-agent",
+      "accepts_new_agent": true,
+      "start_status": "planning-only"
+    },
+    {
+      "slot_id": "M06-AUDIO",
+      "module": "audio",
+      "branch": "agent/m06-audio-production",
+      "status": "occupied",
+      "assigned_agent": "audio-agent",
+      "accepts_new_agent": true,
+      "start_status": "planning-only"
+    },
+    {
+      "slot_id": "M07-TIMELINE",
+      "module": "timeline_storyboard",
+      "branch": "agent/m07-storyboard-timeline",
+      "status": "occupied",
+      "assigned_agent": "timeline-agent",
+      "accepts_new_agent": true,
+      "start_status": "planning-only"
+    },
+    {
+      "slot_id": "M08-PROVIDER",
+      "module": "providers",
+      "branch": "agent/m08-video-provider-router",
+      "status": "occupied",
+      "assigned_agent": "provider-agent",
+      "accepts_new_agent": true,
+      "start_status": "planning-only"
+    },
+    {
+      "slot_id": "CROSS-CUTTING-QA",
+      "module": "media_qa",
+      "branch": "agent/cross-cutting-qa-security",
+      "status": "occupied",
+      "assigned_agent": "qa-security-agent",
+      "accepts_new_agent": true,
+      "start_status": "active-audit-planning"
+    }
+  ]
+}

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-This is the canonical human-readable plan for Supervisor-led multi-agent development. It binds module branches, agent lanes, dependency state, completion signals, review order, synchronization behavior, and merge strategy.
+This is the canonical human-readable plan for Supervisor-led multi-agent development. It binds module branches, agent lanes, slot occupancy, dependency state, completion signals, review order, synchronization behavior, onboarding, and merge strategy.
 
-The Supervisor is the agent operating the main repository/integration lane. The Supervisor is the only normal authority that reviews and promotes incoming agent branches to `main`.
+The Supervisor is the agent operating the main repository/integration lane. The Supervisor is the only normal authority that assigns incoming agents, reviews submitted work, and promotes incoming agent branches to `main`.
 
-This plan supplements `MULTI-AGENT-PROTOCOL.md`, `INTEGRATION-PROTOCOL.md`, `ACTIVE-WORK.yaml`, `DEPENDENCY-GRAPH.yaml`, `MIGRATION-REGISTRY.yaml`, and the repository development consent gate.
+This plan supplements `MULTI-AGENT-PROTOCOL.md`, `INTEGRATION-PROTOCOL.md`, `ACTIVE-WORK.yaml`, `AGENT-SLOTS.json`, `DEPENDENCY-GRAPH.yaml`, `MIGRATION-REGISTRY.yaml`, and the repository development consent gate.
 
 ## Mandatory branch-bootstrap-first rule
 
@@ -14,18 +14,50 @@ When a Supervisor orchestration request requires multiple parallel module agents
 
 Branch creation does not grant executable development permission. A branch whose dependencies or consent are not ready remains planning/contract-only until the applicable gate becomes satisfied.
 
+## New Agent Onboarding — mandatory
+
+Every new agent must begin from the current `main` branch. A new agent is not allowed to start from an existing feature branch, stale checkpoint branch, another agent's branch, or chat-only state.
+
+On arrival, before the new agent writes any project file:
+
+1. the new agent reads/checks out current `main` and performs the startup/working-instruction audit;
+2. the Supervisor loads this plan and `AGENT-SLOTS.json`;
+3. the Supervisor checks for a slot where `status` is `open` and `accepts_new_agent` is `true`;
+4. if an eligible slot exists, the Supervisor assigns that exact module/branch to the new agent;
+5. before work starts, the Supervisor updates `AGENT-SLOTS.json`, this plan/task state, the assigned agent identity, occupancy, start status, and the relevant `ACTIVE-WORK.yaml` record;
+6. only after that repository state is recorded may the new agent switch from `main` to the assigned branch and begin the allowed work.
+
+A new agent may never self-select or steal a module because its branch already exists.
+
+If there is no eligible open slot, the Supervisor stops onboarding immediately and responds exactly:
+
+> **Go Home Come Back Next Time**
+
+When this response is required:
+- no module is assigned;
+- no branch is assigned;
+- no code, documentation, research, planning, or repository mutation is started by that new agent;
+- the rejected arrival does not replace an occupied agent;
+- the rejected arrival does not create an extra branch merely to increase concurrency.
+
+`AGENT-SLOTS.json` is the machine-readable occupancy authority. This document is the human-readable assignment/merge plan. Both must remain synchronized.
+
+### Current onboarding capacity
+
+At the time of this plan update, all defined module slots are occupied. Therefore an additional new agent arriving now must receive **Go Home Come Back Next Time** unless the Supervisor first intentionally opens/releases an existing slot in canonical repository state.
+
 ## Current branch matrix
 
-| Lane | Assigned agent role | Branch | Module / scope | Current execution state | Promotion strategy |
-| --- | --- | --- | --- | --- | --- |
-| Supervisor | `supervisor-agent` | `supervisor/m03-wp7-retention` | M03-WP7 retention/archive/delete/export primitives | executable work authorized under existing M03 scope; instruction/main sync required before promotion | highest current feature priority; promote before M03-WP8 |
-| Acceptance | `acceptance-agent` | `agent/m03-wp8-acceptance` | M03-WP8 end-to-end acceptance, recovery, lineage, delivery/lifecycle verification | planning/test-matrix only until WP7 is landed | promote after WP7, then close M03 if all acceptance gates pass |
-| Character | `character-agent` | `agent/m04-character-library` | M04 Character and Entity Library | planning/contract preparation only until milestone entry and consent gates allow executable work | contract-owner work lands before dependent M05/M07/M08 consumers |
-| Content | `content-agent` | `agent/m05-content-memory` | M05 Content Intelligence and Memory | planning/contract preparation only until entry/consent gates | promote after required character/public contracts are stable; may run independently from audio where dependency graph allows |
-| Audio | `audio-agent` | `agent/m06-audio-production` | M06 provider-neutral audio production | planning/contract preparation only until entry/consent gates | contract foundation may promote independently once eligible; runtime waits on required contracts |
-| Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | M07 storyboard/hierarchy/timeline engine | planning-only until required Character/Content/Audio contracts are stable | ordered after required upstream contracts |
-| Provider | `provider-agent` | `agent/m08-video-provider-router` | M08 hybrid image/video provider router | planning-only until Character/Timeline/provider capability boundaries are ready | ordered after relevant M04/M07 contracts; adapters may fan out later |
-| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security` | adversarial tests, security, races, recovery, compatibility | may audit immediately; writes require claimed QA/test paths and must not collide with feature branch ownership | independent QA-only PRs may promote at any safe point; feature-coupled findings return to owning branch |
+| Lane | Slot | Assigned agent role | Branch | Module / scope | Current execution state | Promotion strategy |
+| --- | --- | --- | --- | --- | --- | --- |
+| Supervisor | occupied / not new-agent assignable | `supervisor-agent` | `supervisor/m03-wp7-retention` | M03-WP7 retention/archive/delete/export primitives | executable work authorized under existing M03 scope; broadcast #1/instruction sync completed | highest current feature priority; promote before M03-WP8 |
+| Acceptance | occupied | `acceptance-agent` | `agent/m03-wp8-acceptance` | M03-WP8 end-to-end acceptance, recovery, lineage, delivery/lifecycle verification | planning/test-matrix only until WP7 is landed | promote after WP7, then close M03 if all acceptance gates pass |
+| Character | occupied | `character-agent` | `agent/m04-character-library` | M04 Character and Entity Library | planning/contract preparation only until milestone entry and consent gates allow executable work | contract-owner work lands before dependent M05/M07/M08 consumers |
+| Content | occupied | `content-agent` | `agent/m05-content-memory` | M05 Content Intelligence and Memory | planning/contract preparation only until entry/consent gates | promote after required character/public contracts are stable; may run independently from audio where dependency graph allows |
+| Audio | occupied | `audio-agent` | `agent/m06-audio-production` | M06 provider-neutral audio production | planning/contract preparation only until entry/consent gates | contract foundation may promote independently once eligible; runtime waits on required contracts |
+| Timeline | occupied | `timeline-agent` | `agent/m07-storyboard-timeline` | M07 storyboard/hierarchy/timeline engine | planning-only until required Character/Content/Audio contracts are stable | ordered after required upstream contracts |
+| Provider | occupied | `provider-agent` | `agent/m08-video-provider-router` | M08 hybrid image/video provider router | planning-only until Character/Timeline/provider capability boundaries are ready | ordered after relevant M04/M07 contracts; adapters may fan out later |
+| QA / Security | occupied | `qa-security-agent` | `agent/cross-cutting-qa-security` | adversarial tests, security, races, recovery, compatibility | may audit immediately; writes require claimed QA/test paths and must not collide with feature branch ownership | independent QA-only PRs may promote at any safe point; feature-coupled findings return to owning branch |
 
 ## Current merge order
 
@@ -76,7 +108,7 @@ A review interruption never permits the Supervisor to discard uncommitted concep
 
 ## Mandatory post-merge broadcast
 
-After each Supervisor merge, the canonical alert text is:
+After each Supervisor promotion merge, the canonical alert text is:
 
 > **New changes have been merged — please merge these changes into your branch first, then resume your own work.**
 
@@ -119,15 +151,17 @@ Never merge merely because an agent finished first. Dependency safety, contract 
 
 ## Current Supervisor assignment
 
-The Supervisor's own module is M03-WP7 on `supervisor/m03-wp7-retention`, preserving the implementation already present on the prior WP7 branch. Before that branch can be promoted it must incorporate/reconcile the Supervisor governance changes now on `main` and complete the mandatory working-instruction audit.
+The Supervisor's own module is M03-WP7 on `supervisor/m03-wp7-retention`. The original WP7 implementation history has already been semantically reconciled with Supervisor governance and broadcast #1; the remaining promotion requirement is synchronization with the newest `main` head plus fresh exact-head PR verification.
 
-## Branch retirement
+## Branch retirement and slot release
 
 After a branch is merged:
 - mark its task complete/landed;
 - release migration reservations or mark them landed;
 - update dependencies/contracts/checkpoints;
 - emit the merge broadcast;
-- retire/delete the branch when repository policy permits and no recovery need remains.
+- decide whether the module slot remains occupied for a next bounded task or becomes `open`;
+- if opened, clear `assigned_agent` in `AGENT-SLOTS.json` before a future new agent may claim it;
+- retire/delete the completed task branch when repository policy permits and no recovery need remains.
 
 Long-lived module names may be reused as planning concepts, but each executable work package should normally use a bounded task branch so stale submissions cannot silently absorb unrelated future work.

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -1,14 +1,31 @@
-version: 1
+version: 2
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_at_plan_creation: 486c294f7be53aad49ee362465968e766a80899a
+  main_sha_last_reconciled: 0589b1b86953c267be77b643efcc31006f56a88e
   own_task_id: M03-WP7
   own_branch: supervisor/m03-wp7-retention
-  own_branch_head_at_plan_creation: 1583845c3ddd9865ca2528c7dbd02ca14ba5b89f
+  own_branch_head_after_broadcast_1_sync: eba42c024b4a861014f4de22136adc21b55b0c11
   current_mode: governance-integration
   completion_signal: Work Done and Submitted
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+
+new_agent_onboarding:
+  source_branch_required: main
+  slot_registry: ai-native/parallel/AGENT-SLOTS.json
+  assignment_authority: supervisor
+  current_open_slots: 0
+  no_slot_response: Go Home Come Back Next Time
+  actions:
+    - new-agent-starts-from-main
+    - supervisor-loads-slot-registry-and-supervisor-plan
+    - assign-first-valid-open-slot-or-reject
+    - update-slot-and-plan-before-agent-work
+    - agent-checks-out-assigned-branch-only-after-assignment
+  rejection_behavior:
+    stop_agent_immediately: true
+    branch_assignment: false
+    work_permitted: false
 
 interrupt_policy:
   enabled: true
@@ -35,14 +52,17 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 0
+  latest_broadcast_sequence: 1
   agents_with_mandatory_sync: []
   policy: branches-with-unacknowledged-mandatory-broadcast-cannot-seek-promotion
 
 rules:
   - The Supervisor reviews and merges incoming module PRs; module agents do not merge themselves.
   - Supervisor implementation occurs on its own module branch, never by mixing feature work directly into main.
+  - A new agent always begins onboarding from main and may not self-assign a module or branch.
+  - Supervisor assigns only a slot whose AGENT-SLOTS.json status is open and accepts_new_agent is true.
+  - If no eligible open slot exists, Supervisor replies exactly Go Home Come Back Next Time and the agent starts no work.
   - A submission signal means ready for review, not merged or production-ready.
   - Supervisor records pause state before interrupting its own feature work.
-  - Every successful merge produces a broadcast record before Supervisor resumes feature implementation.
-  - Main SHA and queue state are reconciled after every promotion event.
+  - Every successful promotion merge produces a broadcast record before Supervisor resumes feature implementation.
+  - Main SHA, queue state, slot state, and broadcast state are reconciled after every promotion event.

--- a/scripts/validate_parallel_governance.py
+++ b/scripts/validate_parallel_governance.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SLOTS_PATH = ROOT / "ai-native" / "parallel" / "AGENT-SLOTS.json"
+PLAN_PATH = ROOT / "ai-native" / "parallel" / "SUPERVISOR-PLAN.md"
+ACTIVE_PATH = ROOT / "ai-native" / "parallel" / "ACTIVE-WORK.yaml"
+STATE_PATH = ROOT / "ai-native" / "parallel" / "SUPERVISOR-STATE.yaml"
+BROADCASTS_PATH = ROOT / "ai-native" / "parallel" / "SUPERVISOR-BROADCASTS.yaml"
+MIGRATIONS_PATH = ROOT / "ai-native" / "parallel" / "MIGRATION-REGISTRY.yaml"
+README_PATH = ROOT / "README.md"
+
+REJECTION = "Go Home Come Back Next Time"
+COMPLETION = "Work Done and Submitted"
+ALERT = (
+    "New changes have been merged — please merge these changes into your branch first, "
+    "then resume your own work."
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def load_text(path: Path) -> str:
+    require(path.is_file(), f"missing governance file: {path.relative_to(ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> None:
+    slots = json.loads(load_text(SLOTS_PATH))
+    plan = load_text(PLAN_PATH)
+    active = load_text(ACTIVE_PATH)
+    state = load_text(STATE_PATH)
+    broadcasts = load_text(BROADCASTS_PATH)
+    migrations = load_text(MIGRATIONS_PATH)
+    readme = load_text(README_PATH)
+
+    require(slots.get("source_branch_required") == "main", "new agents must start from main")
+    require(slots.get("assignment_authority") == "supervisor", "Supervisor must own assignment")
+    require(slots.get("no_slot_response") == REJECTION, "no-slot response drifted")
+
+    records = slots.get("slots")
+    require(isinstance(records, list) and records, "slot registry must contain slots")
+
+    seen_ids: set[str] = set()
+    seen_branches: set[str] = set()
+    seen_agents: set[str] = set()
+    open_slots = 0
+
+    for slot in records:
+        require(isinstance(slot, dict), "slot entries must be objects")
+        slot_id = str(slot.get("slot_id", ""))
+        branch = str(slot.get("branch", ""))
+        module = str(slot.get("module", ""))
+        status = slot.get("status")
+        agent = slot.get("assigned_agent")
+        accepts_new = slot.get("accepts_new_agent")
+
+        require(slot_id and slot_id not in seen_ids, f"duplicate/empty slot_id: {slot_id}")
+        require(branch and branch not in seen_branches, f"duplicate/empty slot branch: {branch}")
+        require(module, f"slot {slot_id} missing module")
+        require(status in {"open", "occupied"}, f"slot {slot_id} has invalid status")
+        require(isinstance(accepts_new, bool), f"slot {slot_id} missing accepts_new_agent bool")
+        seen_ids.add(slot_id)
+        seen_branches.add(branch)
+
+        require(branch in plan, f"slot branch missing from Supervisor plan: {branch}")
+        require(module in active, f"slot module missing from active-work state: {module}")
+
+        if status == "occupied":
+            require(isinstance(agent, str) and agent, f"occupied slot {slot_id} missing agent")
+            require(agent not in seen_agents, f"agent assigned to multiple slots: {agent}")
+            seen_agents.add(agent)
+            require(agent in plan, f"assigned agent missing from Supervisor plan: {agent}")
+            require(branch in active, f"occupied branch missing from active-work: {branch}")
+            require(agent in active, f"occupied agent missing from active-work: {agent}")
+        else:
+            require(accepts_new is True, f"open slot {slot_id} must accept new agents")
+            require(agent is None, f"open slot {slot_id} must not have assigned_agent")
+            open_slots += 1
+
+    require(REJECTION in plan and REJECTION in readme, "new-agent rejection phrase must be visible")
+    require(COMPLETION in plan and COMPLETION in state, "completion signal drifted")
+    require(ALERT in plan and ALERT in state and ALERT in broadcasts, "post-merge alert drifted")
+    require("latest_broadcast_sequence: 1" in state, "Supervisor state broadcast sequence is stale")
+
+    revisions: list[str] = []
+    for raw in migrations.splitlines():
+        line = raw.strip()
+        if line.startswith("- revision:"):
+            revisions.append(line.split(":", 1)[1].strip())
+    require(len(revisions) == len(set(revisions)), "duplicate migration reservations detected")
+
+    if open_slots == 0:
+        print(f"Parallel governance PASS: all module slots occupied; response='{REJECTION}'")
+    else:
+        print(f"Parallel governance PASS: {open_slots} open module slot(s) available")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements the requested New Agent Onboarding contract and closes remaining Supervisor-governance automation gaps.

Rules added:
- every new agent starts from current `main`;
- Supervisor alone assigns work after checking the AI-Native plan + machine slot registry;
- eligible `open` slot -> assign exact module/branch and record agent/start state before work;
- no eligible slot -> exact response `Go Home Come Back Next Time`, no branch/module/work assignment;
- agents may not self-assign or replace occupied slots.

Machine enforcement:
- `AGENT-SLOTS.json` is the occupancy authority;
- all currently defined slots are occupied;
- `scripts/validate_parallel_governance.py` validates slot uniqueness/occupancy, plan + active-work consistency, exact completion/broadcast/rejection phrases, Supervisor broadcast sequence, and duplicate migration reservations;
- Repository Governance runs that validator on PRs and relevant main pushes;
- stale Supervisor state is reconciled from broadcast sequence 0 to 1;
- README working instructions are synchronized.

Note: an empty `AGENT-SLOTS.json` placeholder was accidentally created directly on main immediately before this branch. This PR replaces it with the valid canonical registry and adds CI validation so that state cannot silently remain malformed.

No product runtime, API, database schema, or provider behavior is changed.