### PR TITLE
chore(supervisor): reconcile M03-WP7 state after PR #54

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -13,12 +13,12 @@ active:
     role: supervisor-module
     assigned_agent: supervisor-agent
     branch: supervisor/m03-wp7-retention-continuation
-    base_sha: 8ed99a094cb443b789929d71c468464e2e0bb72a
+    base_sha: b3168d8742623390022be44cca51bacf21d92ef1
     previous_submission:
-      pr: 51
-      head_sha: 745cc22e5680e164aa875631190c30b1c50aba76
-      merged_main_sha: 8ed99a094cb443b789929d71c468464e2e0bb72a
-      scope: durable asset lifecycle foundation
+      pr: 54
+      head_sha: e15b05d51e46666cd2f6553b066466b3c092700e
+      merged_main_sha: b3168d8742623390022be44cca51bacf21d92ef1
+      scope: deletion propagation planning and delivery fail-closed integration
     module: asset_lifecycle
     status: active-continuation
     writes:
@@ -37,11 +37,11 @@ active:
     migration_reservation: null
     consent_scope: M03
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
+    last_synced_main_sha: b3168d8742623390022be44cca51bacf21d92ef1
     last_acknowledged_broadcast: 4
     required_broadcast: null
     remaining_scope:
-      - deletion propagation and delivery fail-closed integration
+      - deletion propagation execution
       - bounded temporary cleanup
       - export staging
       - vector/index cleanup hooks
@@ -52,7 +52,7 @@ active:
     role: module
     assigned_agent: acceptance-agent
     branch: agent/m03-wp8-acceptance
-    base_sha: 486c294f7be53aad49ee362465968e766a80899a
+    base_sha: b3168d8742623390022be44cca51bacf21d92ef1
     module: m03_acceptance
     status: planning-only-waiting-on-wp7
     writes:
@@ -68,7 +68,7 @@ active:
     migration_reservation: null
     consent_scope: M03
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
+    last_synced_main_sha: b3168d8742623390022be44cca51bacf21d92ef1
     last_acknowledged_broadcast: 4
     required_broadcast: null
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -2,8 +2,8 @@ version: 5
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: a8e987ce8e0697fdff5bf891e82daec2b28dd096
-  main_sha_last_reconciled: d4cd69c53af832a75285650453ba480744afbd04
+  main_sha_last_promotion: b3168d8742623390022be44cca51bacf21d92ef1
+  main_sha_last_reconciled: b3168d8742623390022be44cca51bacf21d92ef1
   own_task_id: M03-WP7
   own_branch: supervisor/m03-wp7-retention-continuation
   current_mode: feature-development
@@ -11,9 +11,9 @@ supervisor:
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 52
-  submitted_head_sha: 31454da596ee590e443452cba98139bf80384029
-  merged_main_sha: a8e987ce8e0697fdff5bf891e82daec2b28dd096
+  pr: 54
+  submitted_head_sha: e15b05d51e46666cd2f6553b066466b3c092700e
+  merged_main_sha: b3168d8742623390022be44cca51bacf21d92ef1
   result: success
 
 new_agent_onboarding:


### PR DESCRIPTION
Reconciles repository-native Supervisor coordination after merged PR #54 (`b3168d8742623390022be44cca51bacf21d92ef1`).

Changes are coordination-only:
- records PR #54 as the latest successful WP7 promotion;
- updates Supervisor reconciled/promotion SHA to current `main`;
- updates WP7 previous submission to the deletion-propagation planning + delivery fail-closed slice;
- removes that landed slice from WP7 remaining scope and leaves only deletion propagation execution, bounded temporary cleanup, export staging, vector/index cleanup hooks, and final WP7 acceptance/promotion;
- rebinds WP7/WP8 coordination base/sync evidence to current main;
- keeps WP8 planning-only until WP7 completes;
- does not alter product code, migrations, runtime behavior, permissions, or governance enforcement.

Live repository rulesets remain absent, so Issue #36 stays open and this PR must not be used as protection evidence.