### PR TITLE
M03-WP7: execute approved deletion propagation safely

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -5,39 +5,32 @@ supervisor:
   main_branch: main
   review_and_merge_authority: true
   own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-retention-continuation
+  own_branch: supervisor/m03-wp7-deletion-execution
 
 active:
   - task_id: M03-WP7
     title: Retention/archive/delete/export primitives
     role: supervisor-module
     assigned_agent: supervisor-agent
-    branch: supervisor/m03-wp7-retention-continuation
-    base_sha: b3168d8742623390022be44cca51bacf21d92ef1
+    branch: supervisor/m03-wp7-deletion-execution
+    base_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     previous_submission:
-      pr: 54
-      head_sha: e15b05d51e46666cd2f6553b066466b3c092700e
-      merged_main_sha: b3168d8742623390022be44cca51bacf21d92ef1
-      scope: deletion propagation planning and delivery fail-closed integration
+      pr: 55
+      head_sha: 843f431ec85b798957e4c5cbb1cad06798b28a4d
+      merged_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
+      scope: supervisor reconciliation after deletion propagation planning promotion
     module: asset_lifecycle
-    status: active-continuation
+    status: active-deletion-execution
     writes:
-      - packages/python-core/src/lullabies_core/lifecycle.py
-      - packages/python-core/src/lullabies_core/persistence/asset_lifecycle.py
-      - packages/python-core/tests/test_asset_lifecycle.py
-    shared_requests:
-      - packages/python-core/src/lullabies_core/__init__.py
-      - packages/python-core/src/lullabies_core/persistence/__init__.py
-      - packages/python-core/src/lullabies_core/persistence/delivery_access.py
-      - packages/python-core/src/lullabies_core/storage.py
-      - packages/python-core/tests/test_migrations.py
-      - packages/python-core/migrations/**
+      - packages/python-core/src/lullabies_core/deletion_execution.py
+      - packages/python-core/tests/test_deletion_execution.py
+    shared_requests: []
     depends_on:
       - M03-WP6
     migration_reservation: null
     consent_scope: M03
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: b3168d8742623390022be44cca51bacf21d92ef1
+    last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     last_acknowledged_broadcast: 4
     required_broadcast: null
     remaining_scope:
@@ -52,7 +45,7 @@ active:
     role: module
     assigned_agent: acceptance-agent
     branch: agent/m03-wp8-acceptance
-    base_sha: b3168d8742623390022be44cca51bacf21d92ef1
+    base_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     module: m03_acceptance
     status: planning-only-waiting-on-wp7
     writes:
@@ -68,7 +61,7 @@ active:
     migration_reservation: null
     consent_scope: M03
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: b3168d8742623390022be44cca51bacf21d92ef1
+    last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     last_acknowledged_broadcast: 4
     required_broadcast: null
 

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -15,11 +15,11 @@
     {
       "slot_id": "SUPERVISOR-M03-WP7",
       "module": "asset_lifecycle",
-      "branch": "supervisor/m03-wp7-retention-continuation",
+      "branch": "supervisor/m03-wp7-deletion-execution",
       "status": "occupied",
       "assigned_agent": "supervisor-agent",
       "accepts_new_agent": false,
-      "start_status": "active-continuation"
+      "start_status": "active-deletion-execution"
     },
     {
       "slot_id": "M03-WP8",

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -44,7 +44,7 @@ All defined module slots are occupied. An additional new agent therefore receive
 
 | Lane | Slot | Assigned agent role | Branch | Module / scope | Current execution state | Promotion strategy |
 | --- | --- | --- | --- | --- | --- | --- |
-| Supervisor | occupied / not new-agent assignable | `supervisor-agent` | `supervisor/m03-wp7-retention-continuation` | M03-WP7 remaining retention/delete/export primitives | PR #51 lifecycle foundation landed; broadcast #3 synchronization required before continuation | finish WP7 remaining slices before M03-WP8 promotion |
+| Supervisor | occupied / not new-agent assignable | `supervisor-agent` | `supervisor/m03-wp7-deletion-execution` | M03-WP7 deletion propagation execution | approved-plan execution implementation + exact-head validation | finish this bounded execution slice before starting temp cleanup |
 | Acceptance | occupied | `acceptance-agent` | `agent/m03-wp8-acceptance` | M03-WP8 end-to-end acceptance | planning-only until all WP7 exit criteria land | promote after WP7, then close M03 if acceptance passes |
 | Character | occupied | `character-agent` | `agent/m04-character-library` | M04 Character and Entity Library | planning/contract preparation only | executable work waits for entry + consent gates |
 | Content | occupied | `content-agent` | `agent/m05-content-memory` | M05 Content Intelligence and Memory | planning/contract preparation only | promote after required M04 contracts are stable |
@@ -71,14 +71,15 @@ A `future_executable_writes` entry is informational only. It does not reserve or
 
 Default merge order is dependency-driven:
 
-1. `supervisor/m03-wp7-retention-continuation`
-2. `agent/m03-wp8-acceptance`
-3. M03 close/checkpoint reconciliation
-4. M04 Character/Entity public contract foundation
-5. M05 Content/Memory and M06 Audio when independently ready
-6. M07 Storyboard/Timeline after required upstream contracts land
-7. M08 Provider Router after relevant Character/Timeline contracts land
-8. Later milestones follow `DEPENDENCY-GRAPH.yaml`
+1. `supervisor/m03-wp7-deletion-execution`
+2. next bounded M03-WP7 branches (temporary cleanup, export staging, vector/index cleanup)
+3. `agent/m03-wp8-acceptance`
+4. M03 close/checkpoint reconciliation
+5. M04 Character/Entity public contract foundation
+6. M05 Content/Memory and M06 Audio when independently ready
+7. M07 Storyboard/Timeline after required upstream contracts land
+8. M08 Provider Router after relevant Character/Timeline contracts land
+9. Later milestones follow `DEPENDENCY-GRAPH.yaml`
 
 The QA/Security lane is continuous and may submit independent PRs when its authoritative write set is conflict-free.
 
@@ -142,9 +143,9 @@ Completion order never overrides dependency safety, contract compatibility, curr
 
 ## Current Supervisor assignment
 
-PR #51 landed the durable lifecycle foundation at `8ed99a094cb443b789929d71c468464e2e0bb72a`. The previous submission branch `supervisor/m03-wp7-retention` is retired for new executable work.
+PR #55 reconciled Supervisor coordination on `main@ddaf0547e1804945c6a585220f499b8efa614e5a`. The previous branch `supervisor/m03-wp7-retention-continuation` is retired for new executable work.
 
-The Supervisor continues M03-WP7 on `supervisor/m03-wp7-retention-continuation`, created from the PR #51 merged `main`. Remaining scope is deletion propagation/delivery blocking, bounded temp cleanup, export staging, vector/index cleanup hooks, and final WP7 acceptance/promotion.
+The Supervisor now owns the bounded deletion-propagation execution slice on `supervisor/m03-wp7-deletion-execution`, created from that current main. Its authoritative executable write set is limited to `packages/python-core/src/lullabies_core/deletion_execution.py` and `packages/python-core/tests/test_deletion_execution.py`; coordination files are maintained only to keep Supervisor plan/slot/state authority synchronized. Remaining WP7 scope after this slice is bounded temporary cleanup, export staging, vector/index cleanup hooks, and final WP7 acceptance/promotion.
 
 Migration `20260901_0015` is landed history and is no longer an active reservation.
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -2,18 +2,18 @@ version: 5
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: b3168d8742623390022be44cca51bacf21d92ef1
-  main_sha_last_reconciled: b3168d8742623390022be44cca51bacf21d92ef1
+  main_sha_last_promotion: ddaf0547e1804945c6a585220f499b8efa614e5a
+  main_sha_last_reconciled: ddaf0547e1804945c6a585220f499b8efa614e5a
   own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-retention-continuation
+  own_branch: supervisor/m03-wp7-deletion-execution
   current_mode: feature-development
   completion_signal: Work Done and Submitted
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 54
-  submitted_head_sha: e15b05d51e46666cd2f6553b066466b3c092700e
-  merged_main_sha: b3168d8742623390022be44cca51bacf21d92ef1
+  pr: 55
+  submitted_head_sha: 843f431ec85b798957e4c5cbb1cad06798b28a4d
+  merged_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
   result: success
 
 new_agent_onboarding:

--- a/packages/python-core/src/lullabies_core/deletion_execution.py
+++ b/packages/python-core/src/lullabies_core/deletion_execution.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Protocol
+
+from .delivery import ShareLinkConstraint
+from .derivatives import DerivativeRecord, DerivativeStatus, TERMINAL_DERIVATIVE_STATUSES
+from .lifecycle import (
+    AssetDeletionPropagationPlan,
+    AssetLifecycleSnapshot,
+    AssetLifecycleState,
+    StorageObjectPurgeTarget,
+)
+from .storage import StorageAdapter, StorageIntegrityError, StorageNotFoundError
+
+
+class DeletionPropagationExecutionError(RuntimeError):
+    """Approved hard-delete propagation cannot be executed safely."""
+
+
+class LifecycleExecutionRepository(Protocol):
+    def load(self, asset_id: str) -> AssetLifecycleSnapshot: ...
+
+    def plan_deletion_propagation(
+        self,
+        asset_id: str,
+        *,
+        planned_at: datetime,
+    ) -> AssetDeletionPropagationPlan: ...
+
+    def transition(
+        self,
+        asset_id: str,
+        target: AssetLifecycleState,
+        *,
+        operation_key: str,
+        actor: str,
+        occurred_at: datetime,
+        expected_revision: int,
+        reason: str | None = None,
+        recovery_until: datetime | None = None,
+    ) -> object: ...
+
+
+class ShareLinkExecutionRepository(Protocol):
+    def load(self, share_link_id: str) -> ShareLinkConstraint: ...
+
+    def revoke(
+        self,
+        share_link_id: str,
+        *,
+        revoked_at: datetime,
+    ) -> object: ...
+
+
+class DerivativeExecutionRepository(Protocol):
+    def load(self, derivative_record_id: str) -> DerivativeRecord: ...
+
+    def transition(
+        self,
+        derivative_record_id: str,
+        *,
+        expected_revision: int,
+        target_status: DerivativeStatus,
+        updated_at: datetime,
+        output_asset_id: str | None = None,
+        output_storage_object_id: str | None = None,
+        completed_at: datetime | None = None,
+        error_code: str | None = None,
+    ) -> object: ...
+
+
+StorageAdapterResolver = Callable[[StorageObjectPurgeTarget], StorageAdapter]
+
+
+@dataclass(frozen=True)
+class DeletionPropagationExecutionResult:
+    asset_id: str
+    project_id: str
+    plan_fingerprint: str
+    deleted_storage_object_ids: tuple[str, ...]
+    already_absent_storage_object_ids: tuple[str, ...]
+    revoked_share_link_ids: tuple[str, ...]
+    already_inactive_share_link_ids: tuple[str, ...]
+    cancelled_derivative_record_ids: tuple[str, ...]
+    already_terminal_derivative_record_ids: tuple[str, ...]
+    final_revision: int
+
+
+def execute_deletion_propagation(
+    approved_plan: AssetDeletionPropagationPlan,
+    *,
+    lifecycle: LifecycleExecutionRepository,
+    share_links: ShareLinkExecutionRepository,
+    derivatives: DerivativeExecutionRepository,
+    resolve_storage_adapter: StorageAdapterResolver,
+    executed_at: datetime,
+    actor: str,
+    operation_key: str,
+) -> DeletionPropagationExecutionResult:
+    """Execute one approved hard-delete plan with stale-plan and partial-retry guards.
+
+    The approved plan is treated as an upper bound. A live re-plan may contain fewer
+    still-active share links or open derivatives after a partial retry, but it may not
+    introduce new effects or change storage/retention/derived-asset ownership.
+    Physical storage is integrity-checked before deletion. The lifecycle reaches
+    ``deleted`` only after every approved propagation effect has completed or is already
+    in a terminal/idempotent state.
+    """
+
+    _validate_execution_request(approved_plan, executed_at, actor, operation_key)
+
+    current = lifecycle.load(approved_plan.asset_id)
+    _require_matching_lifecycle(current, approved_plan)
+
+    live_plan = lifecycle.plan_deletion_propagation(
+        approved_plan.asset_id,
+        planned_at=executed_at,
+    )
+    _require_compatible_live_plan(approved_plan, live_plan)
+
+    storage_work: list[tuple[StorageObjectPurgeTarget, StorageAdapter]] = []
+    already_absent_storage: list[str] = []
+    for target in approved_plan.storage_targets:
+        adapter = resolve_storage_adapter(target)
+        if adapter.backend is not target.backend:
+            raise DeletionPropagationExecutionError(
+                f"storage adapter backend mismatch for {target.storage_object_id}"
+            )
+        try:
+            stat = adapter.stat(target.object_key)
+        except StorageNotFoundError:
+            already_absent_storage.append(target.storage_object_id)
+            continue
+        if stat.backend is not target.backend or stat.bucket != target.bucket:
+            raise DeletionPropagationExecutionError(
+                f"storage location mismatch for {target.storage_object_id}"
+            )
+        if stat.object_key != target.object_key:
+            raise DeletionPropagationExecutionError(
+                f"storage object key mismatch for {target.storage_object_id}"
+            )
+        if stat.sha256 is None or stat.sha256 != target.sha256:
+            raise StorageIntegrityError(
+                f"storage hash mismatch for deletion target {target.storage_object_id}"
+            )
+        storage_work.append((target, adapter))
+
+    loaded_links: dict[str, ShareLinkConstraint] = {}
+    for share_link_id in approved_plan.share_link_ids:
+        link = share_links.load(share_link_id)
+        if link.project_id != approved_plan.project_id or link.asset_id != approved_plan.asset_id:
+            raise DeletionPropagationExecutionError(
+                f"share link {share_link_id} escaped the approved asset/project boundary"
+            )
+        loaded_links[share_link_id] = link
+
+    loaded_derivatives: dict[str, DerivativeRecord] = {}
+    for derivative_record_id in approved_plan.open_derivative_record_ids:
+        record = derivatives.load(derivative_record_id)
+        if (
+            record.project_id != approved_plan.project_id
+            or record.source_asset_id != approved_plan.asset_id
+        ):
+            raise DeletionPropagationExecutionError(
+                f"derivative {derivative_record_id} escaped the approved asset/project boundary"
+            )
+        if record.status not in TERMINAL_DERIVATIVE_STATUSES and executed_at < record.updated_at:
+            raise DeletionPropagationExecutionError(
+                f"execution time predates derivative {derivative_record_id} state"
+            )
+        loaded_derivatives[derivative_record_id] = record
+
+    deleted_storage: list[str] = []
+    for target, adapter in storage_work:
+        adapter.delete(target.object_key)
+        deleted_storage.append(target.storage_object_id)
+
+    revoked_links: list[str] = []
+    already_inactive_links: list[str] = []
+    for share_link_id in approved_plan.share_link_ids:
+        link = loaded_links[share_link_id]
+        if link.revoked_at is not None:
+            already_inactive_links.append(share_link_id)
+            continue
+        revoked_at = min(executed_at, link.expires_at)
+        share_links.revoke(share_link_id, revoked_at=revoked_at)
+        revoked_links.append(share_link_id)
+
+    cancelled_derivatives: list[str] = []
+    already_terminal_derivatives: list[str] = []
+    for derivative_record_id in approved_plan.open_derivative_record_ids:
+        record = loaded_derivatives[derivative_record_id]
+        if record.status in TERMINAL_DERIVATIVE_STATUSES:
+            already_terminal_derivatives.append(derivative_record_id)
+            continue
+        derivatives.transition(
+            derivative_record_id,
+            expected_revision=record.revision,
+            target_status=DerivativeStatus.CANCELLED,
+            updated_at=executed_at,
+        )
+        cancelled_derivatives.append(derivative_record_id)
+
+    lifecycle.transition(
+        approved_plan.asset_id,
+        AssetLifecycleState.DELETED,
+        operation_key=operation_key,
+        actor=actor,
+        occurred_at=executed_at,
+        expected_revision=approved_plan.lifecycle_revision,
+        reason=f"deletion-propagation:{approved_plan.fingerprint()}",
+    )
+    final = lifecycle.load(approved_plan.asset_id)
+    if final.state is not AssetLifecycleState.DELETED:
+        raise DeletionPropagationExecutionError(
+            f"asset {approved_plan.asset_id} did not reach deleted lifecycle state"
+        )
+
+    return DeletionPropagationExecutionResult(
+        asset_id=approved_plan.asset_id,
+        project_id=approved_plan.project_id,
+        plan_fingerprint=approved_plan.fingerprint(),
+        deleted_storage_object_ids=tuple(deleted_storage),
+        already_absent_storage_object_ids=tuple(already_absent_storage),
+        revoked_share_link_ids=tuple(revoked_links),
+        already_inactive_share_link_ids=tuple(already_inactive_links),
+        cancelled_derivative_record_ids=tuple(cancelled_derivatives),
+        already_terminal_derivative_record_ids=tuple(already_terminal_derivatives),
+        final_revision=final.revision,
+    )
+
+
+def _validate_execution_request(
+    plan: AssetDeletionPropagationPlan,
+    executed_at: datetime,
+    actor: str,
+    operation_key: str,
+) -> None:
+    if executed_at.utcoffset() is None:
+        raise ValueError("executed_at must be timezone-aware")
+    if executed_at < plan.planned_at:
+        raise DeletionPropagationExecutionError("execution cannot predate the approved plan")
+    if not 1 <= len(actor) <= 200:
+        raise ValueError("actor must contain between 1 and 200 characters")
+    if not 8 <= len(operation_key) <= 200:
+        raise ValueError("operation_key must contain between 8 and 200 characters")
+
+
+def _require_matching_lifecycle(
+    current: AssetLifecycleSnapshot,
+    approved: AssetDeletionPropagationPlan,
+) -> None:
+    if current.project_id != approved.project_id:
+        raise DeletionPropagationExecutionError("approved deletion plan project no longer matches")
+    if current.state is not AssetLifecycleState.HARD_DELETE_SCHEDULED:
+        raise DeletionPropagationExecutionError(
+            f"asset must remain hard-delete-scheduled, not {current.state.value}"
+        )
+    if current.revision != approved.lifecycle_revision:
+        raise DeletionPropagationExecutionError(
+            f"lifecycle revision moved from approved {approved.lifecycle_revision} "
+            f"to {current.revision}"
+        )
+
+
+def _require_compatible_live_plan(
+    approved: AssetDeletionPropagationPlan,
+    live: AssetDeletionPropagationPlan,
+) -> None:
+    if live.asset_id != approved.asset_id or live.project_id != approved.project_id:
+        raise DeletionPropagationExecutionError("live deletion plan identity changed")
+    if live.lifecycle_revision != approved.lifecycle_revision:
+        raise DeletionPropagationExecutionError("live deletion plan lifecycle revision changed")
+    if live.storage_targets != approved.storage_targets:
+        raise DeletionPropagationExecutionError("live storage purge targets changed after approval")
+    if live.retained_shared_storage != approved.retained_shared_storage:
+        raise DeletionPropagationExecutionError("live shared-storage retention set changed after approval")
+    if live.derived_asset_ids != approved.derived_asset_ids:
+        raise DeletionPropagationExecutionError("live derived-asset audit set changed after approval")
+    if not set(live.share_link_ids).issubset(approved.share_link_ids):
+        raise DeletionPropagationExecutionError("live deletion plan introduced a new share-link effect")
+    if not set(live.open_derivative_record_ids).issubset(
+        approved.open_derivative_record_ids
+    ):
+        raise DeletionPropagationExecutionError("live deletion plan introduced a new derivative effect")

--- a/packages/python-core/src/lullabies_core/deletion_execution.py
+++ b/packages/python-core/src/lullabies_core/deletion_execution.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Callable, Protocol
+from typing import Protocol
 
 from .delivery import ShareLinkConstraint
-from .derivatives import DerivativeRecord, DerivativeStatus, TERMINAL_DERIVATIVE_STATUSES
+from .derivatives import TERMINAL_DERIVATIVE_STATUSES, DerivativeRecord, DerivativeStatus
 from .lifecycle import (
     AssetDeletionPropagationPlan,
     AssetLifecycleSnapshot,
@@ -276,12 +277,20 @@ def _require_compatible_live_plan(
     if live.storage_targets != approved.storage_targets:
         raise DeletionPropagationExecutionError("live storage purge targets changed after approval")
     if live.retained_shared_storage != approved.retained_shared_storage:
-        raise DeletionPropagationExecutionError("live shared-storage retention set changed after approval")
+        raise DeletionPropagationExecutionError(
+            "live shared-storage retention set changed after approval"
+        )
     if live.derived_asset_ids != approved.derived_asset_ids:
-        raise DeletionPropagationExecutionError("live derived-asset audit set changed after approval")
+        raise DeletionPropagationExecutionError(
+            "live derived-asset audit set changed after approval"
+        )
     if not set(live.share_link_ids).issubset(approved.share_link_ids):
-        raise DeletionPropagationExecutionError("live deletion plan introduced a new share-link effect")
+        raise DeletionPropagationExecutionError(
+            "live deletion plan introduced a new share-link effect"
+        )
     if not set(live.open_derivative_record_ids).issubset(
         approved.open_derivative_record_ids
     ):
-        raise DeletionPropagationExecutionError("live deletion plan introduced a new derivative effect")
+        raise DeletionPropagationExecutionError(
+            "live deletion plan introduced a new derivative effect"
+        )

--- a/packages/python-core/tests/test_deletion_execution.py
+++ b/packages/python-core/tests/test_deletion_execution.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from lullabies_core.deletion_execution import (
+    DeletionPropagationExecutionError,
+    execute_deletion_propagation,
+)
+from lullabies_core.delivery import DeliveryMode, ShareLinkConstraint
+from lullabies_core.derivatives import (
+    DerivativeKind,
+    DerivativeRecord,
+    DerivativeSpec,
+    DerivativeStatus,
+    derivative_operation_fingerprint,
+)
+from lullabies_core.lifecycle import (
+    AssetDeletionPropagationPlan,
+    AssetLifecycleSnapshot,
+    AssetLifecycleState,
+    DeletionPropagationTargetKind,
+    StorageObjectPurgeTarget,
+)
+from lullabies_core.storage import (
+    StorageBackend,
+    StorageBlobStat,
+    StorageIntegrityError,
+    StorageNotFoundError,
+    StorageWriteResult,
+    sha256_bytes,
+)
+
+
+class FakeLifecycle:
+    def __init__(
+        self,
+        snapshot: AssetLifecycleSnapshot,
+        live_plan: AssetDeletionPropagationPlan,
+    ) -> None:
+        self.snapshot = snapshot
+        self.live_plan = live_plan
+        self.transitions: list[AssetLifecycleState] = []
+
+    def load(self, asset_id: str) -> AssetLifecycleSnapshot:
+        assert asset_id == self.snapshot.asset_id
+        return self.snapshot
+
+    def plan_deletion_propagation(
+        self,
+        asset_id: str,
+        *,
+        planned_at: datetime,
+    ) -> AssetDeletionPropagationPlan:
+        assert asset_id == self.snapshot.asset_id
+        assert planned_at >= self.live_plan.planned_at
+        return self.live_plan.model_copy(update={"planned_at": planned_at})
+
+    def transition(
+        self,
+        asset_id: str,
+        target: AssetLifecycleState,
+        *,
+        operation_key: str,
+        actor: str,
+        occurred_at: datetime,
+        expected_revision: int,
+        reason: str | None = None,
+        recovery_until: datetime | None = None,
+    ) -> object:
+        assert asset_id == self.snapshot.asset_id
+        assert operation_key
+        assert actor
+        assert occurred_at >= self.snapshot.updated_at
+        assert expected_revision == self.snapshot.revision
+        assert reason is not None and reason.startswith("deletion-propagation:")
+        assert recovery_until is None
+        self.transitions.append(target)
+        self.snapshot = self.snapshot.model_copy(
+            update={
+                "state": target,
+                "updated_at": occurred_at,
+                "revision": self.snapshot.revision + 1,
+            }
+        )
+        return object()
+
+
+class FakeShareLinks:
+    def __init__(self, links: dict[str, ShareLinkConstraint]) -> None:
+        self.links = links
+        self.revoked: list[str] = []
+
+    def load(self, share_link_id: str) -> ShareLinkConstraint:
+        return self.links[share_link_id]
+
+    def revoke(self, share_link_id: str, *, revoked_at: datetime) -> object:
+        current = self.links[share_link_id]
+        self.links[share_link_id] = current.model_copy(update={"revoked_at": revoked_at})
+        self.revoked.append(share_link_id)
+        return object()
+
+
+class FakeDerivatives:
+    def __init__(self, records: dict[str, DerivativeRecord]) -> None:
+        self.records = records
+        self.cancelled: list[str] = []
+
+    def load(self, derivative_record_id: str) -> DerivativeRecord:
+        return self.records[derivative_record_id]
+
+    def transition(
+        self,
+        derivative_record_id: str,
+        *,
+        expected_revision: int,
+        target_status: DerivativeStatus,
+        updated_at: datetime,
+        output_asset_id: str | None = None,
+        output_storage_object_id: str | None = None,
+        completed_at: datetime | None = None,
+        error_code: str | None = None,
+    ) -> object:
+        current = self.records[derivative_record_id]
+        assert expected_revision == current.revision
+        assert target_status is DerivativeStatus.CANCELLED
+        assert output_asset_id is None
+        assert output_storage_object_id is None
+        assert completed_at is None
+        assert error_code is None
+        self.records[derivative_record_id] = current.model_copy(
+            update={
+                "status": target_status,
+                "updated_at": updated_at,
+                "revision": current.revision + 1,
+            }
+        )
+        self.cancelled.append(derivative_record_id)
+        return object()
+
+
+class FakeStorage:
+    backend = StorageBackend.FILESYSTEM
+
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self.objects = objects
+        self.deleted: list[str] = []
+        self.stat_sha_override: str | None = None
+
+    def put_bytes(self, object_key: str, data: bytes, *, mime_type: str) -> StorageWriteResult:
+        self.objects[object_key] = data
+        return StorageWriteResult(
+            backend=self.backend,
+            object_key=object_key,
+            sha256=sha256_bytes(data),
+            mime_type=mime_type,
+            size_bytes=len(data),
+        )
+
+    def get_bytes(self, object_key: str) -> bytes:
+        try:
+            return self.objects[object_key]
+        except KeyError as exc:
+            raise StorageNotFoundError(object_key) from exc
+
+    def stat(self, object_key: str) -> StorageBlobStat:
+        try:
+            data = self.objects[object_key]
+        except KeyError as exc:
+            raise StorageNotFoundError(object_key) from exc
+        return StorageBlobStat(
+            backend=self.backend,
+            object_key=object_key,
+            size_bytes=len(data),
+            sha256=self.stat_sha_override or sha256_bytes(data),
+        )
+
+    def delete(self, object_key: str) -> None:
+        self.objects.pop(object_key, None)
+        self.deleted.append(object_key)
+
+
+def fixtures() -> tuple[
+    datetime,
+    AssetLifecycleSnapshot,
+    AssetDeletionPropagationPlan,
+    FakeShareLinks,
+    FakeDerivatives,
+    FakeStorage,
+]:
+    planned_at = datetime(2026, 9, 5, 12, 0, tzinfo=UTC)
+    asset_id = "AST-003040"
+    project_id = "PRJ-003040"
+    payload = b"delete-me"
+    object_key = "canonical/PRJ-003040/STO-003040"
+    target = StorageObjectPurgeTarget(
+        kind=DeletionPropagationTargetKind.SOURCE_STORAGE_OBJECT,
+        storage_object_id="STO-003040",
+        backend=StorageBackend.FILESYSTEM,
+        object_key=object_key,
+        sha256=sha256_bytes(payload),
+    )
+    snapshot = AssetLifecycleSnapshot(
+        asset_id=asset_id,
+        project_id=project_id,
+        state=AssetLifecycleState.HARD_DELETE_SCHEDULED,
+        updated_at=planned_at,
+        revision=4,
+    )
+    plan = AssetDeletionPropagationPlan(
+        asset_id=asset_id,
+        project_id=project_id,
+        lifecycle_revision=4,
+        planned_at=planned_at,
+        storage_targets=[target],
+        share_link_ids=["SHL-003040-active"],
+        open_derivative_record_ids=["DRV-003040"],
+    )
+    links = FakeShareLinks(
+        {
+            "SHL-003040-active": ShareLinkConstraint(
+                share_link_id="SHL-003040-active",
+                project_id=project_id,
+                asset_id=asset_id,
+                token_sha256="a" * 64,
+                allowed_modes=[DeliveryMode.STREAM],
+                expires_at=planned_at + timedelta(days=1),
+            )
+        }
+    )
+    spec = DerivativeSpec(
+        kind=DerivativeKind.VIDEO_POSTER,
+        width=1280,
+        height=720,
+        mime_type="image/png",
+    )
+    derivative = DerivativeRecord(
+        derivative_record_id="DRV-003040",
+        project_id=project_id,
+        source_asset_id=asset_id,
+        job_id="JOB-003040",
+        spec=spec,
+        operation_fingerprint=derivative_operation_fingerprint(
+            project_id=project_id,
+            source_asset_id=asset_id,
+            spec=spec,
+        ),
+        created_at=planned_at - timedelta(minutes=10),
+        updated_at=planned_at - timedelta(minutes=5),
+    )
+    derivatives = FakeDerivatives({derivative.derivative_record_id: derivative})
+    storage = FakeStorage({object_key: payload})
+    return planned_at, snapshot, plan, links, derivatives, storage
+
+
+def test_execute_deletion_propagation_completes_only_after_all_effects() -> None:
+    planned_at, snapshot, plan, links, derivatives, storage = fixtures()
+    lifecycle = FakeLifecycle(snapshot, plan)
+
+    result = execute_deletion_propagation(
+        plan,
+        lifecycle=lifecycle,
+        share_links=links,
+        derivatives=derivatives,
+        resolve_storage_adapter=lambda target: storage,
+        executed_at=planned_at + timedelta(minutes=1),
+        actor="wp7-worker",
+        operation_key="delete-exec-003040",
+    )
+
+    assert result.deleted_storage_object_ids == ("STO-003040",)
+    assert result.revoked_share_link_ids == ("SHL-003040-active",)
+    assert result.cancelled_derivative_record_ids == ("DRV-003040",)
+    assert result.final_revision == 5
+    assert lifecycle.snapshot.state is AssetLifecycleState.DELETED
+    assert lifecycle.transitions == [AssetLifecycleState.DELETED]
+    assert storage.objects == {}
+    assert links.revoked == ["SHL-003040-active"]
+    assert derivatives.cancelled == ["DRV-003040"]
+
+
+def test_execute_rejects_live_plan_expansion_before_any_side_effect() -> None:
+    planned_at, snapshot, plan, links, derivatives, storage = fixtures()
+    expanded = plan.model_copy(
+        update={"share_link_ids": ["SHL-003040-active", "SHL-003040-new"]}
+    )
+    lifecycle = FakeLifecycle(snapshot, expanded)
+
+    with pytest.raises(
+        DeletionPropagationExecutionError,
+        match="introduced a new share-link effect",
+    ):
+        execute_deletion_propagation(
+            plan,
+            lifecycle=lifecycle,
+            share_links=links,
+            derivatives=derivatives,
+            resolve_storage_adapter=lambda target: storage,
+            executed_at=planned_at + timedelta(minutes=1),
+            actor="wp7-worker",
+            operation_key="delete-exec-003040",
+        )
+
+    assert storage.deleted == []
+    assert links.revoked == []
+    assert derivatives.cancelled == []
+    assert lifecycle.transitions == []
+
+
+def test_execute_fails_closed_on_storage_hash_mismatch() -> None:
+    planned_at, snapshot, plan, links, derivatives, storage = fixtures()
+    lifecycle = FakeLifecycle(snapshot, plan)
+    storage.stat_sha_override = "f" * 64
+
+    with pytest.raises(StorageIntegrityError, match="storage hash mismatch"):
+        execute_deletion_propagation(
+            plan,
+            lifecycle=lifecycle,
+            share_links=links,
+            derivatives=derivatives,
+            resolve_storage_adapter=lambda target: storage,
+            executed_at=planned_at + timedelta(minutes=1),
+            actor="wp7-worker",
+            operation_key="delete-exec-003040",
+        )
+
+    assert storage.deleted == []
+    assert links.revoked == []
+    assert derivatives.cancelled == []
+    assert lifecycle.transitions == []
+
+
+def test_execute_can_resume_when_prior_effects_are_already_terminal() -> None:
+    planned_at, snapshot, plan, links, derivatives, storage = fixtures()
+    executed_at = planned_at + timedelta(minutes=1)
+    storage.objects.clear()
+    links.links["SHL-003040-active"] = links.links["SHL-003040-active"].model_copy(
+        update={"revoked_at": executed_at}
+    )
+    current_derivative = derivatives.records["DRV-003040"]
+    derivatives.records["DRV-003040"] = current_derivative.model_copy(
+        update={
+            "status": DerivativeStatus.CANCELLED,
+            "updated_at": executed_at,
+            "revision": current_derivative.revision + 1,
+        }
+    )
+    reduced_live = plan.model_copy(
+        update={"share_link_ids": [], "open_derivative_record_ids": []}
+    )
+    lifecycle = FakeLifecycle(snapshot, reduced_live)
+
+    result = execute_deletion_propagation(
+        plan,
+        lifecycle=lifecycle,
+        share_links=links,
+        derivatives=derivatives,
+        resolve_storage_adapter=lambda target: storage,
+        executed_at=executed_at,
+        actor="wp7-worker",
+        operation_key="delete-exec-003040",
+    )
+
+    assert result.already_absent_storage_object_ids == ("STO-003040",)
+    assert result.already_inactive_share_link_ids == ("SHL-003040-active",)
+    assert result.already_terminal_derivative_record_ids == ("DRV-003040",)
+    assert result.deleted_storage_object_ids == ()
+    assert result.revoked_share_link_ids == ()
+    assert result.cancelled_derivative_record_ids == ()
+    assert lifecycle.snapshot.state is AssetLifecycleState.DELETED


### PR DESCRIPTION
Implements the bounded M03-WP7 deletion propagation execution slice tracked by #56.

Key behavior:
- execution is bound to an approved `AssetDeletionPropagationPlan`, exact project/asset identity and lifecycle revision;
- live re-plan may only shrink already-completed share-link/derivative effects during idempotent retry; any new effect or storage/retention/derived-asset ownership change fails closed;
- every physical storage target is checked for backend/location/key and canonical SHA-256 before delete;
- already-absent storage is treated as idempotent partial-retry state;
- approved share links are revoked (or recognized as already inactive);
- approved nonterminal derivatives are cancelled (or recognized as already terminal);
- lifecycle reaches `deleted` only after propagation effects complete;
- invalid actor/operation-key/time evidence is rejected before side effects;
- tests cover success, stale/live-plan expansion rejection, hash-integrity failure, and partial retry.

Files are isolated to a new execution module + focused tests; no migration, API surface, provider spend, export staging, temp cleanup, or vector/index cleanup in this PR.

Issue: #56

Work Done and Submitted