### PR TITLE
M03-WP7: bound temporary upload cleanup

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -5,36 +5,36 @@ supervisor:
   main_branch: main
   review_and_merge_authority: true
   own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-deletion-execution
+  own_branch: supervisor/m03-wp7-temp-cleanup
 
 active:
   - task_id: M03-WP7
     title: Retention/archive/delete/export primitives
     role: supervisor-module
     assigned_agent: supervisor-agent
-    branch: supervisor/m03-wp7-deletion-execution
-    base_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
+    branch: supervisor/m03-wp7-temp-cleanup
+    base_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
     previous_submission:
-      pr: 55
-      head_sha: 843f431ec85b798957e4c5cbb1cad06798b28a4d
-      merged_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
-      scope: supervisor reconciliation after deletion propagation planning promotion
+      pr: 57
+      head_sha: da0e67a9297956ab34b664a736d6739d4742996a
+      merged_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
+      scope: approved deletion propagation execution
     module: asset_lifecycle
-    status: active-deletion-execution
+    status: active-temp-cleanup
     writes:
-      - packages/python-core/src/lullabies_core/deletion_execution.py
-      - packages/python-core/tests/test_deletion_execution.py
+      - packages/python-core/src/lullabies_core/temporary_cleanup.py
+      - packages/python-core/src/lullabies_core/persistence/temporary_cleanup.py
+      - packages/python-core/tests/test_temporary_cleanup.py
     shared_requests: []
     depends_on:
       - M03-WP6
     migration_reservation: null
     consent_scope: M03
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
-    last_acknowledged_broadcast: 4
+    last_synced_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
+    last_acknowledged_broadcast: 6
     required_broadcast: null
     remaining_scope:
-      - deletion propagation execution
       - bounded temporary cleanup
       - export staging
       - vector/index cleanup hooks
@@ -47,7 +47,7 @@ active:
     branch: agent/m03-wp8-acceptance
     base_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     module: m03_acceptance
-    status: planning-only-waiting-on-wp7
+    status: sync-required-planning-only-waiting-on-wp7
     writes:
       - docs/milestones/M03/WP8-ACCEPTANCE-MATRIX.md
       - ai-native/parallel/checkpoints/M03-WP8.md
@@ -63,7 +63,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     last_acknowledged_broadcast: 4
-    required_broadcast: null
+    required_broadcast: 6
 
   - task_id: M04-PARALLEL-LANE
     title: Character and Entity Library planning/contracts
@@ -72,7 +72,7 @@ active:
     branch: agent/m04-character-library
     base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: characters_entities
-    status: planning-only
+    status: sync-required-planning-only
     writes:
       - docs/milestones/M04/**
       - ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md
@@ -84,7 +84,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: null
+    required_broadcast: 6
 
   - task_id: M05-PARALLEL-LANE
     title: Content Intelligence and Memory planning/contracts
@@ -93,7 +93,7 @@ active:
     branch: agent/m05-content-memory
     base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: content_memory
-    status: planning-only
+    status: sync-required-planning-only
     writes:
       - docs/milestones/M05/**
       - ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md
@@ -105,7 +105,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: null
+    required_broadcast: 6
 
   - task_id: M06-PARALLEL-LANE
     title: Hybrid Audio Production planning/contracts
@@ -114,7 +114,7 @@ active:
     branch: agent/m06-audio-production
     base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: audio
-    status: planning-only
+    status: sync-required-planning-only
     writes:
       - docs/milestones/M06/**
       - ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md
@@ -126,7 +126,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: null
+    required_broadcast: 6
 
   - task_id: M07-PARALLEL-LANE
     title: Storyboard and Timeline planning/contracts
@@ -135,7 +135,7 @@ active:
     branch: agent/m07-storyboard-timeline
     base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: timeline_storyboard
-    status: planning-only
+    status: sync-required-planning-only
     writes:
       - docs/milestones/M07/**
       - ai-native/parallel/checkpoints/M07-PARALLEL-LANE.md
@@ -149,7 +149,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: null
+    required_broadcast: 6
 
   - task_id: M08-PARALLEL-LANE
     title: Hybrid Image/Video Provider Router planning/contracts
@@ -158,7 +158,7 @@ active:
     branch: agent/m08-video-provider-router
     base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: providers
-    status: planning-only
+    status: sync-required-planning-only
     writes:
       - docs/milestones/M08/**
       - ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md
@@ -171,7 +171,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: null
+    required_broadcast: 6
 
   - task_id: CROSS-CUTTING-QA
     title: Cross-cutting adversarial QA and security
@@ -180,7 +180,7 @@ active:
     branch: agent/cross-cutting-qa-security
     base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: media_qa
-    status: active-audit-planning
+    status: sync-required-active-audit-planning
     writes:
       - docs/qa/**
       - ai-native/parallel/checkpoints/CROSS-CUTTING-QA.md
@@ -192,7 +192,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: null
+    required_broadcast: 6
 
 rules:
   - Supervisor owns updates to this registry and all merge decisions.

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -15,11 +15,11 @@
     {
       "slot_id": "SUPERVISOR-M03-WP7",
       "module": "asset_lifecycle",
-      "branch": "supervisor/m03-wp7-deletion-execution",
+      "branch": "supervisor/m03-wp7-temp-cleanup",
       "status": "occupied",
       "assigned_agent": "supervisor-agent",
       "accepts_new_agent": false,
-      "start_status": "active-deletion-execution"
+      "start_status": "active-temp-cleanup"
     },
     {
       "slot_id": "M03-WP8",

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
 version: 4
-latest_sequence: 4
+latest_sequence: 6
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -120,45 +120,99 @@ broadcasts:
       - agent/cross-cutting-qa-security
     mandatory: true
 
+  - sequence: 5
+    trigger: supervisor-merge
+    merged_pr: 55
+    merged_branch: supervisor/m03-wp7-retention-continuation
+    submitted_head_sha: 843f431ec85b798957e4c5cbb1cad06798b28a4d
+    merged_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-supervisor-reconciliation-sync
+    changed_areas:
+      - Supervisor state reconciliation after PR 54
+      - WP7 remaining-scope authority
+      - WP8 planning dependency state
+    contract_changes: []
+    schema_migration_changes: []
+    recipients:
+      - supervisor/m03-wp7-deletion-execution
+      - agent/m03-wp8-acceptance
+      - agent/m04-character-library
+      - agent/m05-content-memory
+      - agent/m06-audio-production
+      - agent/m07-storyboard-timeline
+      - agent/m08-video-provider-router
+      - agent/cross-cutting-qa-security
+    mandatory: true
+
+  - sequence: 6
+    trigger: supervisor-merge
+    merged_pr: 57
+    merged_branch: supervisor/m03-wp7-deletion-execution
+    submitted_head_sha: da0e67a9297956ab34b664a736d6739d4742996a
+    merged_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-wp7-deletion-execution-sync
+    changed_areas:
+      - approved deletion propagation execution
+      - fail-closed live-plan and lifecycle revision binding
+      - storage integrity verification before purge
+      - idempotent partial-retry semantics
+      - share-link revocation and derivative cancellation propagation
+      - Supervisor branch/slot/plan reconciliation
+    contract_changes:
+      - deletion execution internal primitive
+    schema_migration_changes: []
+    recipients:
+      - supervisor/m03-wp7-temp-cleanup
+      - agent/m03-wp8-acceptance
+      - agent/m04-character-library
+      - agent/m05-content-memory
+      - agent/m06-audio-production
+      - agent/m07-storyboard-timeline
+      - agent/m08-video-provider-router
+      - agent/cross-cutting-qa-security
+    mandatory: true
+
 recipient_states:
-  supervisor/m03-wp7-retention-continuation:
+  supervisor/m03-wp7-temp-cleanup:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 4
-    last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
+    last_acknowledged_sequence: 6
+    last_synced_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
   agent/m03-wp8-acceptance:
-    state: synchronized-before-agent-start
-    required_sequence: null
+    state: sync-required
+    required_sequence: 6
     last_acknowledged_sequence: 4
-    last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
+    last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
   agent/m04-character-library:
-    state: synchronized-before-agent-start
-    required_sequence: null
+    state: sync-required
+    required_sequence: 6
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m05-content-memory:
-    state: synchronized-before-agent-start
-    required_sequence: null
+    state: sync-required
+    required_sequence: 6
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m06-audio-production:
-    state: synchronized-before-agent-start
-    required_sequence: null
+    state: sync-required
+    required_sequence: 6
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m07-storyboard-timeline:
-    state: synchronized-before-agent-start
-    required_sequence: null
+    state: sync-required
+    required_sequence: 6
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m08-video-provider-router:
-    state: synchronized-before-agent-start
-    required_sequence: null
+    state: sync-required
+    required_sequence: 6
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/cross-cutting-qa-security:
-    state: synchronized-before-agent-start
-    required_sequence: null
+    state: sync-required
+    required_sequence: 6
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
 

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -44,14 +44,14 @@ All defined module slots are occupied. An additional new agent therefore receive
 
 | Lane | Slot | Assigned agent role | Branch | Module / scope | Current execution state | Promotion strategy |
 | --- | --- | --- | --- | --- | --- | --- |
-| Supervisor | occupied / not new-agent assignable | `supervisor-agent` | `supervisor/m03-wp7-deletion-execution` | M03-WP7 deletion propagation execution | approved-plan execution implementation + exact-head validation | finish this bounded execution slice before starting temp cleanup |
-| Acceptance | occupied | `acceptance-agent` | `agent/m03-wp8-acceptance` | M03-WP8 end-to-end acceptance | planning-only until all WP7 exit criteria land | promote after WP7, then close M03 if acceptance passes |
-| Character | occupied | `character-agent` | `agent/m04-character-library` | M04 Character and Entity Library | planning/contract preparation only | executable work waits for entry + consent gates |
-| Content | occupied | `content-agent` | `agent/m05-content-memory` | M05 Content Intelligence and Memory | planning/contract preparation only | promote after required M04 contracts are stable |
-| Audio | occupied | `audio-agent` | `agent/m06-audio-production` | M06 provider-neutral audio production | planning/contract preparation only | executable work waits for entry + consent gates |
-| Timeline | occupied | `timeline-agent` | `agent/m07-storyboard-timeline` | M07 storyboard/hierarchy/timeline engine | planning-only | ordered after required Character/Content/Audio contracts |
-| Provider | occupied | `provider-agent` | `agent/m08-video-provider-router` | M08 hybrid image/video provider router | planning-only | ordered after relevant Character/Timeline contracts |
-| QA / Security | occupied | `qa-security-agent` | `agent/cross-cutting-qa-security` | adversarial QA/security planning and audits | audit/planning may run; executable writes require applicable ownership + consent | independent conflict-free QA work may promote when eligible |
+| Supervisor | occupied / not new-agent assignable | `supervisor-agent` | `supervisor/m03-wp7-temp-cleanup` | M03-WP7 bounded temporary upload cleanup | executable cleanup slice on current `main@6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6` | finish terminal abandoned upload/quarantine cleanup before export staging |
+| Acceptance | occupied | `acceptance-agent` | `agent/m03-wp8-acceptance` | M03-WP8 end-to-end acceptance | sync-required; planning-only until all WP7 exit criteria land | synchronize broadcast 6 before any promotion, then promote after WP7 |
+| Character | occupied | `character-agent` | `agent/m04-character-library` | M04 Character and Entity Library | sync-required planning/contract preparation only | synchronize before any promotion; executable work waits for entry + consent gates |
+| Content | occupied | `content-agent` | `agent/m05-content-memory` | M05 Content Intelligence and Memory | sync-required planning/contract preparation only | synchronize before any promotion; then follow M04 contracts |
+| Audio | occupied | `audio-agent` | `agent/m06-audio-production` | M06 provider-neutral audio production | sync-required planning/contract preparation only | synchronize before any promotion; executable work waits for entry + consent gates |
+| Timeline | occupied | `timeline-agent` | `agent/m07-storyboard-timeline` | M07 storyboard/hierarchy/timeline engine | sync-required planning-only | synchronize before any promotion; ordered after Character/Content/Audio contracts |
+| Provider | occupied | `provider-agent` | `agent/m08-video-provider-router` | M08 hybrid image/video provider router | sync-required planning-only | synchronize before any promotion; ordered after Character/Timeline contracts |
+| QA / Security | occupied | `qa-security-agent` | `agent/cross-cutting-qa-security` | adversarial QA/security planning and audits | sync-required audit/planning | synchronize before any promotion; independent conflict-free QA work may resume afterward |
 
 ## Write-claim isolation
 
@@ -67,21 +67,29 @@ Planning lanes use dedicated milestone directories and exact per-task checkpoint
 
 A `future_executable_writes` entry is informational only. It does not reserve or authorize those paths until the Supervisor explicitly promotes the task to executable state and rechecks collisions.
 
+The active Supervisor write set for this bounded slice is limited to:
+- `packages/python-core/src/lullabies_core/temporary_cleanup.py`;
+- `packages/python-core/src/lullabies_core/persistence/temporary_cleanup.py`;
+- `packages/python-core/tests/test_temporary_cleanup.py`.
+
+Coordination files are maintained only by the Supervisor to keep branch/slot/broadcast authority synchronized and are not shared implementation lanes.
+
 ## Current merge order
 
 Default merge order is dependency-driven:
 
-1. `supervisor/m03-wp7-deletion-execution`
-2. next bounded M03-WP7 branches (temporary cleanup, export staging, vector/index cleanup)
-3. `agent/m03-wp8-acceptance`
-4. M03 close/checkpoint reconciliation
-5. M04 Character/Entity public contract foundation
-6. M05 Content/Memory and M06 Audio when independently ready
-7. M07 Storyboard/Timeline after required upstream contracts land
-8. M08 Provider Router after relevant Character/Timeline contracts land
-9. Later milestones follow `DEPENDENCY-GRAPH.yaml`
+1. `supervisor/m03-wp7-temp-cleanup`
+2. next bounded M03-WP7 export-staging branch
+3. next bounded M03-WP7 vector/index cleanup branch
+4. `agent/m03-wp8-acceptance` after synchronization and WP7 completion
+5. M03 close/checkpoint reconciliation
+6. M04 Character/Entity public contract foundation
+7. M05 Content/Memory and M06 Audio when independently ready
+8. M07 Storyboard/Timeline after required upstream contracts land
+9. M08 Provider Router after relevant Character/Timeline contracts land
+10. Later milestones follow `DEPENDENCY-GRAPH.yaml`
 
-The QA/Security lane is continuous and may submit independent PRs when its authoritative write set is conflict-free.
+The QA/Security lane is continuous but is currently sync-required by broadcast 6 and cannot seek promotion until it records synchronization.
 
 If a new dependency appears, `DEPENDENCY-GRAPH.yaml` and affected task instructions are updated before further work. Contract-owner branches promote before consumers that require those contracts.
 
@@ -143,9 +151,13 @@ Completion order never overrides dependency safety, contract compatibility, curr
 
 ## Current Supervisor assignment
 
-PR #55 reconciled Supervisor coordination on `main@ddaf0547e1804945c6a585220f499b8efa614e5a`. The previous branch `supervisor/m03-wp7-retention-continuation` is retired for new executable work.
+PR #57 merged the approved deletion-propagation execution slice at `main@6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6`. The completed branch `supervisor/m03-wp7-deletion-execution` is retired for new executable work.
 
-The Supervisor now owns the bounded deletion-propagation execution slice on `supervisor/m03-wp7-deletion-execution`, created from that current main. Its authoritative executable write set is limited to `packages/python-core/src/lullabies_core/deletion_execution.py` and `packages/python-core/tests/test_deletion_execution.py`; coordination files are maintained only to keep Supervisor plan/slot/state authority synchronized. Remaining WP7 scope after this slice is bounded temporary cleanup, export staging, vector/index cleanup hooks, and final WP7 acceptance/promotion.
+The Supervisor now owns Issue #58 on `supervisor/m03-wp7-temp-cleanup`, created from that exact current main. This slice may clean only `ABORTED` or `EXPIRED` upload/quarantine state after an explicit grace cutoff. It must fail closed when canonical storage metadata exists for either the upload storage-object identity or exact physical location, must preserve project/key boundaries, must not touch `OPEN`, `UPLOADING`, or `COMPLETED` sessions, and must treat missing temporary backend state as idempotent cleanup success. Incomplete S3 multipart uploads are aborted before orphan quarantine object deletion when an UploadId exists.
+
+No migration, export staging, vector/index cleanup, provider integration, production credential change, or cost-bearing scope is authorized in this slice. Remaining WP7 scope after it lands is export staging, vector/index cleanup hooks, and final WP7 acceptance/promotion.
+
+Broadcast sequence 6 is current. The Supervisor temp-cleanup branch is synchronized to sequence 6/current main; all other occupied planning/QA lanes listed in `ACTIVE-WORK.yaml` are sync-required and cannot seek promotion until they acknowledge sequence 6.
 
 Migration `20260901_0015` is landed history and is no longer an active reservation.
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -2,18 +2,18 @@ version: 5
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: ddaf0547e1804945c6a585220f499b8efa614e5a
-  main_sha_last_reconciled: ddaf0547e1804945c6a585220f499b8efa614e5a
+  main_sha_last_promotion: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
+  main_sha_last_reconciled: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
   own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-deletion-execution
+  own_branch: supervisor/m03-wp7-temp-cleanup
   current_mode: feature-development
   completion_signal: Work Done and Submitted
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 55
-  submitted_head_sha: 843f431ec85b798957e4c5cbb1cad06798b28a4d
-  merged_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
+  pr: 57
+  submitted_head_sha: da0e67a9297956ab34b664a736d6739d4742996a
+  merged_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
   result: success
 
 new_agent_onboarding:
@@ -58,8 +58,15 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 4
-  agents_with_mandatory_sync: []
+  latest_broadcast_sequence: 6
+  agents_with_mandatory_sync:
+    - agent/m03-wp8-acceptance
+    - agent/m04-character-library
+    - agent/m05-content-memory
+    - agent/m06-audio-production
+    - agent/m07-storyboard-timeline
+    - agent/m08-video-provider-router
+    - agent/cross-cutting-qa-security
   policy: branches-with-unacknowledged-mandatory-broadcast-cannot-seek-promotion
 
 rules:

--- a/packages/python-core/src/lullabies_core/persistence/temporary_cleanup.py
+++ b/packages/python-core/src/lullabies_core/persistence/temporary_cleanup.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import MetaData, and_, exists, func, or_, select
+from sqlalchemy.engine import Connection, Engine, RowMapping
+
+from ..storage import StorageBackend
+from ..temporary_cleanup import (
+    TemporaryCleanupCandidate,
+    TemporaryCleanupConflictError,
+    temporary_cleanup_cutoff,
+)
+from ..upload_session import UploadMode, UploadSessionStatus
+from ._db import PersistenceNotFoundError, PersistenceReferenceError
+
+
+class PostgresTemporaryCleanupRepository:
+    """Read/revalidate bounded abandoned-upload cleanup targets without widening schema."""
+
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+        metadata = MetaData()
+        metadata.reflect(bind=engine, schema="core")
+        required = {"upload_sessions", "storage_objects", "projects"}
+        missing = [name for name in required if f"core.{name}" not in metadata.tables]
+        if missing:
+            raise PersistenceReferenceError(
+                f"temporary cleanup tables are not migrated: {', '.join(sorted(missing))}"
+            )
+        self.uploads = metadata.tables["core.upload_sessions"]
+        self.storage = metadata.tables["core.storage_objects"]
+        self.projects = metadata.tables["core.projects"]
+
+    def list_candidates(
+        self,
+        *,
+        now: datetime,
+        grace_period: timedelta,
+        limit: int = 100,
+    ) -> list[TemporaryCleanupCandidate]:
+        if limit < 1 or limit > 1000:
+            raise ValueError("temporary cleanup limit must be between 1 and 1000")
+        cutoff = temporary_cleanup_cutoff(now=now, grace_period=grace_period)
+        canonical_exists = exists(
+            select(self.storage.c.id).where(
+                or_(
+                    self.storage.c.external_id == self.uploads.c.storage_object_external_id,
+                    and_(
+                        self.storage.c.backend == self.uploads.c.backend,
+                        func.coalesce(self.storage.c.bucket, "")
+                        == func.coalesce(self.uploads.c.bucket, ""),
+                        self.storage.c.object_key == self.uploads.c.object_key,
+                    ),
+                )
+            )
+        )
+        statement = (
+            select(self.uploads, self.projects.c.external_id.label("project_external_id"))
+            .join(self.projects, self.projects.c.id == self.uploads.c.project_id)
+            .where(
+                self.uploads.c.status.in_(
+                    [UploadSessionStatus.ABORTED.value, UploadSessionStatus.EXPIRED.value]
+                ),
+                self.uploads.c.updated_at <= cutoff,
+                ~canonical_exists,
+            )
+            .order_by(self.uploads.c.updated_at.asc(), self.uploads.c.id.asc())
+            .limit(limit)
+        )
+        with self.engine.connect() as connection:
+            rows = connection.execute(statement).mappings().all()
+        return [self._candidate_from_row(row) for row in rows]
+
+    def revalidate(
+        self,
+        candidate: TemporaryCleanupCandidate,
+        *,
+        cutoff: datetime,
+    ) -> TemporaryCleanupCandidate:
+        if cutoff.tzinfo is None or cutoff.utcoffset() is None:
+            raise ValueError("temporary cleanup cutoff must be timezone-aware")
+        with self.engine.begin() as connection:
+            row = (
+                connection.execute(
+                    select(
+                        self.uploads,
+                        self.projects.c.external_id.label("project_external_id"),
+                    )
+                    .join(self.projects, self.projects.c.id == self.uploads.c.project_id)
+                    .where(self.uploads.c.external_id == candidate.upload_session_id)
+                    .with_for_update()
+                )
+                .mappings()
+                .one_or_none()
+            )
+            if row is None:
+                raise PersistenceNotFoundError(
+                    f"upload session {candidate.upload_session_id} was not found"
+                )
+            current = self._candidate_from_row(row)
+            if current != candidate:
+                raise TemporaryCleanupConflictError(
+                    "temporary cleanup candidate changed since it was selected"
+                )
+            if current.terminal_at > cutoff or row["updated_at"] > cutoff:
+                raise TemporaryCleanupConflictError(
+                    "temporary cleanup candidate has not completed the grace window"
+                )
+            if self._canonical_storage_exists(connection, row):
+                raise TemporaryCleanupConflictError(
+                    "temporary cleanup target is now represented by canonical storage metadata"
+                )
+            return current
+
+    def _canonical_storage_exists(self, connection: Connection, row: RowMapping) -> bool:
+        storage_id = connection.execute(
+            select(self.storage.c.id)
+            .where(
+                or_(
+                    self.storage.c.external_id == row["storage_object_external_id"],
+                    and_(
+                        self.storage.c.backend == row["backend"],
+                        func.coalesce(self.storage.c.bucket, "")
+                        == (row["bucket"] or ""),
+                        self.storage.c.object_key == row["object_key"],
+                    ),
+                )
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+        return storage_id is not None
+
+    @staticmethod
+    def _candidate_from_row(row: RowMapping) -> TemporaryCleanupCandidate:
+        status = UploadSessionStatus(str(row["status"]))
+        if status not in {UploadSessionStatus.ABORTED, UploadSessionStatus.EXPIRED}:
+            raise TemporaryCleanupConflictError(
+                f"upload session is not cleanup-terminal: {status.value}"
+            )
+        terminal_at = row["aborted_at"] if status is UploadSessionStatus.ABORTED else row["updated_at"]
+        if terminal_at is None:
+            raise TemporaryCleanupConflictError("terminal upload session is missing terminal time")
+        return TemporaryCleanupCandidate(
+            upload_session_id=str(row["external_id"]),
+            project_id=str(row["project_external_id"]),
+            storage_object_id=str(row["storage_object_external_id"]),
+            backend=StorageBackend(str(row["backend"])),
+            bucket=str(row["bucket"]) if row["bucket"] is not None else None,
+            object_key=str(row["object_key"]),
+            mode=UploadMode(str(row["mode"])),
+            backend_upload_id=(
+                str(row["backend_upload_id"])
+                if row["backend_upload_id"] is not None
+                else None
+            ),
+            status=status,
+            terminal_at=terminal_at,
+            revision=int(row["revision"]),
+        )

--- a/packages/python-core/src/lullabies_core/persistence/temporary_cleanup.py
+++ b/packages/python-core/src/lullabies_core/persistence/temporary_cleanup.py
@@ -138,7 +138,11 @@ class PostgresTemporaryCleanupRepository:
             raise TemporaryCleanupConflictError(
                 f"upload session is not cleanup-terminal: {status.value}"
             )
-        terminal_at = row["aborted_at"] if status is UploadSessionStatus.ABORTED else row["updated_at"]
+        terminal_at = (
+            row["aborted_at"]
+            if status is UploadSessionStatus.ABORTED
+            else row["updated_at"]
+        )
         if terminal_at is None:
             raise TemporaryCleanupConflictError("terminal upload session is missing terminal time")
         return TemporaryCleanupCandidate(

--- a/packages/python-core/src/lullabies_core/temporary_cleanup.py
+++ b/packages/python-core/src/lullabies_core/temporary_cleanup.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Protocol
+
+from botocore.exceptions import ClientError
+
+from .storage import FilesystemStorageAdapter, StorageBackend
+from .storage_s3 import S3StorageAdapter
+from .upload_session import UploadMode, UploadSessionStatus, build_upload_object_key
+
+
+class TemporaryCleanupError(RuntimeError):
+    """Base class for fail-closed temporary cleanup failures."""
+
+
+class TemporaryCleanupConflictError(TemporaryCleanupError):
+    """The cleanup target is stale, unsafe, or no longer eligible."""
+
+
+@dataclass(frozen=True)
+class TemporaryCleanupCandidate:
+    upload_session_id: str
+    project_id: str
+    storage_object_id: str
+    backend: StorageBackend
+    bucket: str | None
+    object_key: str
+    mode: UploadMode
+    backend_upload_id: str | None
+    status: UploadSessionStatus
+    terminal_at: datetime
+    revision: int
+
+    def __post_init__(self) -> None:
+        if self.status not in {UploadSessionStatus.ABORTED, UploadSessionStatus.EXPIRED}:
+            raise ValueError("temporary cleanup accepts only aborted or expired upload sessions")
+        if self.terminal_at.tzinfo is None or self.terminal_at.utcoffset() is None:
+            raise ValueError("temporary cleanup terminal_at must be timezone-aware")
+        if self.revision < 1:
+            raise ValueError("temporary cleanup revision must be positive")
+        expected_key = build_upload_object_key(self.project_id, self.storage_object_id)
+        if self.object_key != expected_key:
+            raise ValueError("temporary cleanup object_key is not the canonical quarantine key")
+        if self.backend is StorageBackend.S3 and self.bucket is None:
+            raise ValueError("S3 temporary cleanup candidates require a bucket")
+        if self.backend is StorageBackend.FILESYSTEM and self.bucket is not None:
+            raise ValueError("filesystem temporary cleanup candidates cannot carry a bucket")
+        if self.mode is UploadMode.SINGLE and self.backend_upload_id is not None:
+            raise ValueError("single-upload cleanup cannot carry a multipart UploadId")
+
+
+@dataclass(frozen=True)
+class TemporaryCleanupBackendResult:
+    multipart_abort_attempted: bool
+    object_delete_attempted: bool
+
+
+@dataclass(frozen=True)
+class TemporaryCleanupResult:
+    upload_session_id: str
+    status: UploadSessionStatus
+    revision: int
+    multipart_abort_attempted: bool
+    object_delete_attempted: bool
+
+
+class TemporaryCleanupRepository(Protocol):
+    def revalidate(
+        self,
+        candidate: TemporaryCleanupCandidate,
+        *,
+        cutoff: datetime,
+    ) -> TemporaryCleanupCandidate: ...
+
+
+class TemporaryCleanupBackendExecutor(Protocol):
+    def purge(self, candidate: TemporaryCleanupCandidate) -> TemporaryCleanupBackendResult: ...
+
+
+def temporary_cleanup_cutoff(*, now: datetime, grace_period: timedelta) -> datetime:
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("temporary cleanup now must be timezone-aware")
+    if grace_period <= timedelta(0):
+        raise ValueError("temporary cleanup grace_period must be positive")
+    return now - grace_period
+
+
+@dataclass
+class AdapterTemporaryCleanupBackend:
+    filesystem: FilesystemStorageAdapter | None = None
+    s3: S3StorageAdapter | None = None
+
+    def purge(self, candidate: TemporaryCleanupCandidate) -> TemporaryCleanupBackendResult:
+        multipart_abort_attempted = False
+        if candidate.backend is StorageBackend.FILESYSTEM:
+            if self.filesystem is None:
+                raise TemporaryCleanupConflictError(
+                    "filesystem cleanup requested without a filesystem adapter"
+                )
+            if self.filesystem.backend is not StorageBackend.FILESYSTEM:
+                raise TemporaryCleanupConflictError("filesystem cleanup adapter has wrong backend")
+            self.filesystem.delete(candidate.object_key)
+            return TemporaryCleanupBackendResult(
+                multipart_abort_attempted=False,
+                object_delete_attempted=True,
+            )
+
+        if self.s3 is None:
+            raise TemporaryCleanupConflictError("S3 cleanup requested without an S3 adapter")
+        if candidate.bucket != self.s3.settings.bucket:
+            raise TemporaryCleanupConflictError(
+                "S3 cleanup candidate bucket does not match the configured adapter"
+            )
+        if candidate.mode is UploadMode.MULTIPART and candidate.backend_upload_id is not None:
+            multipart_abort_attempted = True
+            try:
+                self.s3.client.abort_multipart_upload(
+                    Bucket=candidate.bucket,
+                    Key=candidate.object_key,
+                    UploadId=candidate.backend_upload_id,
+                )
+            except ClientError as exc:
+                code = str((exc.response.get("Error") or {}).get("Code") or "")
+                if code not in {"NoSuchUpload", "404"}:
+                    raise
+        self.s3.delete(candidate.object_key)
+        return TemporaryCleanupBackendResult(
+            multipart_abort_attempted=multipart_abort_attempted,
+            object_delete_attempted=True,
+        )
+
+
+@dataclass
+class TemporaryCleanupExecutor:
+    repository: TemporaryCleanupRepository
+    backend: TemporaryCleanupBackendExecutor
+
+    def execute(
+        self,
+        candidate: TemporaryCleanupCandidate,
+        *,
+        now: datetime,
+        grace_period: timedelta,
+    ) -> TemporaryCleanupResult:
+        cutoff = temporary_cleanup_cutoff(now=now, grace_period=grace_period)
+        current = self.repository.revalidate(candidate, cutoff=cutoff)
+        if current != candidate:
+            raise TemporaryCleanupConflictError(
+                "temporary cleanup candidate changed during revalidation"
+            )
+        if current.terminal_at > cutoff:
+            raise TemporaryCleanupConflictError(
+                "temporary cleanup candidate has not completed the grace window"
+            )
+        backend_result = self.backend.purge(current)
+        return TemporaryCleanupResult(
+            upload_session_id=current.upload_session_id,
+            status=current.status,
+            revision=current.revision,
+            multipart_abort_attempted=backend_result.multipart_abort_attempted,
+            object_delete_attempted=backend_result.object_delete_attempted,
+        )

--- a/packages/python-core/tests/test_temporary_cleanup.py
+++ b/packages/python-core/tests/test_temporary_cleanup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -7,7 +8,14 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
 
+from lullabies_core.common import AuditFields
+from lullabies_core.persistence.temporary_cleanup import PostgresTemporaryCleanupRepository
+from lullabies_core.persistence.upload_session import PostgresUploadSessionRepository
 from lullabies_core.storage import FilesystemStorageAdapter, StorageBackend
 from lullabies_core.storage_s3 import S3StorageAdapter
 from lullabies_core.temporary_cleanup import (
@@ -17,7 +25,15 @@ from lullabies_core.temporary_cleanup import (
     TemporaryCleanupConflictError,
     TemporaryCleanupExecutor,
 )
-from lullabies_core.upload_session import UploadMode, UploadSessionStatus, build_upload_object_key
+from lullabies_core.upload_session import (
+    UploadMode,
+    UploadSession,
+    UploadSessionStatus,
+    build_upload_object_key,
+)
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+ALEMBIC_INI = Path(__file__).parents[1] / "alembic.ini"
 
 
 def candidate(
@@ -195,3 +211,126 @@ def test_s3_multipart_aborts_before_quarantine_delete() -> None:
     assert fake_s3.calls == ["abort", "delete"]
     assert result.multipart_abort_attempted is True
     assert result.object_delete_attempted is True
+
+
+def _alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
+
+
+def _insert_project(engine: Engine, external_id: str) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.projects (
+                    id, external_id, title, status, audience, "cast", content_format,
+                    language, target_duration_seconds, output, creative, provider_policy,
+                    created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :external_id, :title, 'draft',
+                    '{}'::jsonb, '{}'::jsonb, 'song', 'en', 120,
+                    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, now(), now()
+                )
+                """
+            ),
+            {"external_id": external_id, "title": f"Cleanup fixture {external_id}"},
+        )
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_postgres_cleanup_requires_grace_and_rejects_canonical_storage() -> None:
+    assert DATABASE_URL is not None
+    config = _alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+
+    try:
+        project_id = "PRJ-009901"
+        storage_object_id = "STO-009901"
+        upload_session_id = "UPS-009901"
+        object_key = build_upload_object_key(project_id, storage_object_id)
+        started = datetime(2026, 9, 5, 8, 0, tzinfo=UTC)
+        aborted_at = started + timedelta(minutes=10)
+        _insert_project(engine, project_id)
+
+        upload_repository = PostgresUploadSessionRepository(engine)
+        upload_repository.create(
+            UploadSession(
+                upload_session_id=upload_session_id,
+                project_id=project_id,
+                storage_object_id=storage_object_id,
+                backend=StorageBackend.S3,
+                bucket="aaf-private",
+                object_key=object_key,
+                expected_size_bytes=10,
+                expected_mime_type="video/mp4",
+                original_filename="abandoned.mp4",
+                mode=UploadMode.SINGLE,
+                creation_idempotency_key="create-UPS-009901",
+                expires_at=started + timedelta(hours=1),
+                audit=AuditFields(
+                    created_at=started,
+                    updated_at=started,
+                    created_by="temporary-cleanup-test",
+                ),
+            )
+        )
+        upload_repository.abort(
+            upload_session_id,
+            idempotency_key="abort-UPS-009901",
+            aborted_at=aborted_at,
+        )
+
+        cleanup_repository = PostgresTemporaryCleanupRepository(engine)
+        assert cleanup_repository.list_candidates(
+            now=aborted_at + timedelta(minutes=30),
+            grace_period=timedelta(hours=1),
+        ) == []
+
+        selected = cleanup_repository.list_candidates(
+            now=aborted_at + timedelta(hours=2),
+            grace_period=timedelta(hours=1),
+        )
+        assert len(selected) == 1
+        assert selected[0].upload_session_id == upload_session_id
+        assert selected[0].status is UploadSessionStatus.ABORTED
+
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO core.storage_objects (
+                        id, external_id, schema_version, project_id, backend, bucket,
+                        object_key, sha256, mime_type, size_bytes, original_filename,
+                        lifecycle_class, created_at, updated_at, created_by, revision
+                    )
+                    SELECT
+                        gen_random_uuid(), :storage_object_id, 1, p.id, 's3', :bucket,
+                        :object_key, :sha256, 'video/mp4', 10, 'accepted.mp4',
+                        'canonical', now(), now(), 'temporary-cleanup-test', 1
+                    FROM core.projects p
+                    WHERE p.external_id = :project_id
+                    """
+                ),
+                {
+                    "storage_object_id": storage_object_id,
+                    "project_id": project_id,
+                    "bucket": "aaf-private",
+                    "object_key": object_key,
+                    "sha256": "a" * 64,
+                },
+            )
+
+        assert cleanup_repository.list_candidates(
+            now=aborted_at + timedelta(hours=2),
+            grace_period=timedelta(hours=1),
+        ) == []
+        with pytest.raises(TemporaryCleanupConflictError, match="canonical storage metadata"):
+            cleanup_repository.revalidate(
+                selected[0],
+                cutoff=aborted_at + timedelta(hours=1),
+            )
+    finally:
+        engine.dispose()

--- a/packages/python-core/tests/test_temporary_cleanup.py
+++ b/packages/python-core/tests/test_temporary_cleanup.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from lullabies_core.storage import FilesystemStorageAdapter, StorageBackend
+from lullabies_core.storage_s3 import S3StorageAdapter
+from lullabies_core.temporary_cleanup import (
+    AdapterTemporaryCleanupBackend,
+    TemporaryCleanupBackendResult,
+    TemporaryCleanupCandidate,
+    TemporaryCleanupConflictError,
+    TemporaryCleanupExecutor,
+)
+from lullabies_core.upload_session import UploadMode, UploadSessionStatus, build_upload_object_key
+
+
+def candidate(
+    *,
+    status: UploadSessionStatus = UploadSessionStatus.EXPIRED,
+    backend: StorageBackend = StorageBackend.FILESYSTEM,
+    mode: UploadMode = UploadMode.SINGLE,
+    bucket: str | None = None,
+    backend_upload_id: str | None = None,
+    terminal_at: datetime | None = None,
+) -> TemporaryCleanupCandidate:
+    project_id = "PRJ-000001"
+    storage_object_id = "STO-000001"
+    return TemporaryCleanupCandidate(
+        upload_session_id="UPS-000001",
+        project_id=project_id,
+        storage_object_id=storage_object_id,
+        backend=backend,
+        bucket=bucket,
+        object_key=build_upload_object_key(project_id, storage_object_id),
+        mode=mode,
+        backend_upload_id=backend_upload_id,
+        status=status,
+        terminal_at=terminal_at or datetime(2026, 9, 5, 8, 0, tzinfo=UTC),
+        revision=3,
+    )
+
+
+@dataclass
+class FakeRepository:
+    current: TemporaryCleanupCandidate
+    stale: bool = False
+    observed_cutoff: datetime | None = None
+
+    def revalidate(
+        self,
+        selected: TemporaryCleanupCandidate,
+        *,
+        cutoff: datetime,
+    ) -> TemporaryCleanupCandidate:
+        self.observed_cutoff = cutoff
+        if self.stale or selected != self.current:
+            raise TemporaryCleanupConflictError("stale cleanup candidate")
+        return self.current
+
+
+@dataclass
+class FakeBackend:
+    calls: list[str] = field(default_factory=list)
+
+    def purge(self, selected: TemporaryCleanupCandidate) -> TemporaryCleanupBackendResult:
+        self.calls.append(selected.upload_session_id)
+        return TemporaryCleanupBackendResult(
+            multipart_abort_attempted=(
+                selected.mode is UploadMode.MULTIPART
+                and selected.backend_upload_id is not None
+            ),
+            object_delete_attempted=True,
+        )
+
+
+def test_executor_requires_completed_grace_window() -> None:
+    selected = candidate()
+    repository = FakeRepository(selected)
+    backend = FakeBackend()
+    executor = TemporaryCleanupExecutor(repository=repository, backend=backend)
+
+    with pytest.raises(TemporaryCleanupConflictError, match="grace window"):
+        executor.execute(
+            selected,
+            now=datetime(2026, 9, 5, 8, 30, tzinfo=UTC),
+            grace_period=timedelta(hours=1),
+        )
+
+    assert backend.calls == []
+    assert repository.observed_cutoff == datetime(2026, 9, 5, 7, 30, tzinfo=UTC)
+
+
+def test_executor_revalidates_exact_candidate_before_purge() -> None:
+    selected = candidate()
+    repository = FakeRepository(selected, stale=True)
+    backend = FakeBackend()
+    executor = TemporaryCleanupExecutor(repository=repository, backend=backend)
+
+    with pytest.raises(TemporaryCleanupConflictError, match="stale cleanup candidate"):
+        executor.execute(
+            selected,
+            now=datetime(2026, 9, 5, 10, 0, tzinfo=UTC),
+            grace_period=timedelta(hours=1),
+        )
+
+    assert backend.calls == []
+
+
+def test_executor_purges_terminal_candidate_after_grace() -> None:
+    selected = candidate(status=UploadSessionStatus.ABORTED)
+    repository = FakeRepository(selected)
+    backend = FakeBackend()
+    result = TemporaryCleanupExecutor(repository=repository, backend=backend).execute(
+        selected,
+        now=datetime(2026, 9, 5, 10, 0, tzinfo=UTC),
+        grace_period=timedelta(hours=1),
+    )
+
+    assert backend.calls == ["UPS-000001"]
+    assert result.status is UploadSessionStatus.ABORTED
+    assert result.revision == 3
+    assert result.object_delete_attempted is True
+
+
+def test_candidate_rejects_nonterminal_and_noncanonical_targets() -> None:
+    with pytest.raises(ValueError, match="aborted or expired"):
+        candidate(status=UploadSessionStatus.COMPLETED)
+
+    with pytest.raises(ValueError, match="canonical quarantine key"):
+        TemporaryCleanupCandidate(
+            upload_session_id="UPS-000001",
+            project_id="PRJ-000001",
+            storage_object_id="STO-000001",
+            backend=StorageBackend.FILESYSTEM,
+            bucket=None,
+            object_key="uploads/quarantine/PRJ-000001/STO-999999",
+            mode=UploadMode.SINGLE,
+            backend_upload_id=None,
+            status=UploadSessionStatus.EXPIRED,
+            terminal_at=datetime(2026, 9, 5, 8, 0, tzinfo=UTC),
+            revision=1,
+        )
+
+
+def test_filesystem_cleanup_is_idempotent(tmp_path: Path) -> None:
+    selected = candidate()
+    filesystem = FilesystemStorageAdapter(tmp_path)
+    filesystem.put_bytes(selected.object_key, b"temporary", mime_type="application/octet-stream")
+    backend = AdapterTemporaryCleanupBackend(filesystem=filesystem)
+
+    first = backend.purge(selected)
+    second = backend.purge(selected)
+
+    assert first.object_delete_attempted is True
+    assert second.object_delete_attempted is True
+    assert not (tmp_path / Path(*selected.object_key.split("/"))).exists()
+
+
+class FakeS3Client:
+    def __init__(self, calls: list[str]) -> None:
+        self.calls = calls
+
+    def abort_multipart_upload(self, **_: object) -> None:
+        self.calls.append("abort")
+
+
+class FakeS3:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.settings = SimpleNamespace(bucket="temp-bucket")
+        self.client = FakeS3Client(self.calls)
+
+    def delete(self, _: str) -> None:
+        self.calls.append("delete")
+
+
+def test_s3_multipart_aborts_before_quarantine_delete() -> None:
+    selected = candidate(
+        backend=StorageBackend.S3,
+        bucket="temp-bucket",
+        mode=UploadMode.MULTIPART,
+        backend_upload_id="upload-123",
+    )
+    fake_s3 = FakeS3()
+    backend = AdapterTemporaryCleanupBackend(s3=cast(S3StorageAdapter, fake_s3))
+
+    result = backend.purge(selected)
+
+    assert fake_s3.calls == ["abort", "delete"]
+    assert result.multipart_abort_attempted is True
+    assert result.object_delete_attempted is True


### PR DESCRIPTION
Implements Issue #58 as the next bounded M03-WP7 slice after deletion propagation execution.

Safety contract:
- only ABORTED or EXPIRED upload sessions are eligible;
- an explicit positive grace window is mandatory;
- candidate identity is rebound to exact project/storage-object/quarantine key/revision before side effects;
- Postgres eligibility fails closed if canonical storage metadata exists for either the upload storage-object identity or the same backend/bucket/object-key location;
- OPEN, UPLOADING and COMPLETED sessions are never cleanup candidates;
- filesystem cleanup is idempotent for already-missing quarantine objects;
- S3 multipart cleanup aborts an incomplete UploadId before deleting the orphan quarantine object and tolerates NoSuchUpload as idempotent retry state;
- S3 bucket identity must match the configured adapter;
- no migration, export staging, vector/index cleanup, provider integration, production credential or cost-bearing scope is included.

Supervisor coordination was reconciled to broadcast sequence 6/current main before implementation; other occupied planning/QA lanes remain sync-required and cannot promote stale work.

Issue: #58

Work Done and Submitted