### PR TITLE
M03-WP7: add bounded private export staging

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -5,37 +5,40 @@ supervisor:
   main_branch: main
   review_and_merge_authority: true
   own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-temp-cleanup
+  own_branch: supervisor/m03-wp7-export-staging
 
 active:
   - task_id: M03-WP7
     title: Retention/archive/delete/export primitives
     role: supervisor-module
     assigned_agent: supervisor-agent
-    branch: supervisor/m03-wp7-temp-cleanup
-    base_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
+    branch: supervisor/m03-wp7-export-staging
+    base_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
     previous_submission:
-      pr: 57
-      head_sha: da0e67a9297956ab34b664a736d6739d4742996a
-      merged_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
-      scope: approved deletion propagation execution
+      pr: 59
+      head_sha: a46f2d80d4d5022e62bcbdf3294d4fc489a7fe6f
+      merged_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
+      scope: bounded temporary upload and quarantine cleanup
     module: asset_lifecycle
-    status: active-temp-cleanup
+    status: active-export-staging
     writes:
-      - packages/python-core/src/lullabies_core/temporary_cleanup.py
-      - packages/python-core/src/lullabies_core/persistence/temporary_cleanup.py
-      - packages/python-core/tests/test_temporary_cleanup.py
+      - packages/python-core/src/lullabies_core/export_staging.py
+      - packages/python-core/src/lullabies_core/persistence/export_staging.py
+      - packages/python-core/migrations/versions/20260901_0016_export_staging.py
+      - packages/python-core/migrations/sql/0016_export_staging_up.sql
+      - packages/python-core/migrations/sql/0016_export_staging_down.sql
+      - packages/python-core/tests/test_export_staging.py
+      - packages/python-core/tests/test_migrations.py
     shared_requests: []
     depends_on:
       - M03-WP6
-    migration_reservation: null
+    migration_reservation: 20260901_0016
     consent_scope: M03
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
-    last_acknowledged_broadcast: 6
+    last_synced_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
+    last_acknowledged_broadcast: 7
     required_broadcast: null
     remaining_scope:
-      - bounded temporary cleanup
       - export staging
       - vector/index cleanup hooks
       - final WP7 acceptance and promotion
@@ -63,7 +66,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     last_acknowledged_broadcast: 4
-    required_broadcast: 6
+    required_broadcast: 7
 
   - task_id: M04-PARALLEL-LANE
     title: Character and Entity Library planning/contracts
@@ -84,7 +87,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 6
+    required_broadcast: 7
 
   - task_id: M05-PARALLEL-LANE
     title: Content Intelligence and Memory planning/contracts
@@ -105,7 +108,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 6
+    required_broadcast: 7
 
   - task_id: M06-PARALLEL-LANE
     title: Hybrid Audio Production planning/contracts
@@ -126,7 +129,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 6
+    required_broadcast: 7
 
   - task_id: M07-PARALLEL-LANE
     title: Storyboard and Timeline planning/contracts
@@ -149,7 +152,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 6
+    required_broadcast: 7
 
   - task_id: M08-PARALLEL-LANE
     title: Hybrid Image/Video Provider Router planning/contracts
@@ -171,7 +174,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 6
+    required_broadcast: 7
 
   - task_id: CROSS-CUTTING-QA
     title: Cross-cutting adversarial QA and security
@@ -192,7 +195,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 6
+    required_broadcast: 7
 
 rules:
   - Supervisor owns updates to this registry and all merge decisions.

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -15,11 +15,11 @@
     {
       "slot_id": "SUPERVISOR-M03-WP7",
       "module": "asset_lifecycle",
-      "branch": "supervisor/m03-wp7-temp-cleanup",
+      "branch": "supervisor/m03-wp7-export-staging",
       "status": "occupied",
       "assigned_agent": "supervisor-agent",
       "accepts_new_agent": false,
-      "start_status": "active-temp-cleanup"
+      "start_status": "active-export-staging"
     },
     {
       "slot_id": "M03-WP8",

--- a/ai-native/parallel/MIGRATION-REGISTRY.yaml
+++ b/ai-native/parallel/MIGRATION-REGISTRY.yaml
@@ -7,7 +7,13 @@ policy:
   migration_dependency_must_match_landed_or_declared_parent: true
   merge_alert_requires_migration_revalidation: true
 
-reservations: []
+reservations:
+  - revision: 20260901_0016
+    task_id: M03-WP7
+    branch: supervisor/m03-wp7-export-staging
+    parent_revision: 20260901_0015
+    purpose: durable export staging object provenance and expiry authority
+    status: reserved
 
 landed:
   - revision: 20260901_0015

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
 version: 4
-latest_sequence: 6
+latest_sequence: 7
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -174,45 +174,74 @@ broadcasts:
       - agent/cross-cutting-qa-security
     mandatory: true
 
+  - sequence: 7
+    trigger: supervisor-merge
+    merged_pr: 59
+    merged_branch: supervisor/m03-wp7-temp-cleanup
+    submitted_head_sha: a46f2d80d4d5022e62bcbdf3294d4fc489a7fe6f
+    merged_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-wp7-temp-cleanup-sync
+    changed_areas:
+      - bounded abandoned upload and quarantine cleanup
+      - explicit terminal grace-window enforcement
+      - canonical storage identity and location collision guard
+      - idempotent filesystem cleanup
+      - S3 multipart abort-before-delete behavior
+      - Supervisor branch and ownership reconciliation
+    contract_changes:
+      - temporary cleanup internal primitive
+    schema_migration_changes: []
+    recipients:
+      - supervisor/m03-wp7-export-staging
+      - agent/m03-wp8-acceptance
+      - agent/m04-character-library
+      - agent/m05-content-memory
+      - agent/m06-audio-production
+      - agent/m07-storyboard-timeline
+      - agent/m08-video-provider-router
+      - agent/cross-cutting-qa-security
+    mandatory: true
+
 recipient_states:
-  supervisor/m03-wp7-temp-cleanup:
+  supervisor/m03-wp7-export-staging:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 6
-    last_synced_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
+    last_acknowledged_sequence: 7
+    last_synced_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
   agent/m03-wp8-acceptance:
     state: sync-required
-    required_sequence: 6
+    required_sequence: 7
     last_acknowledged_sequence: 4
     last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
   agent/m04-character-library:
     state: sync-required
-    required_sequence: 6
+    required_sequence: 7
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m05-content-memory:
     state: sync-required
-    required_sequence: 6
+    required_sequence: 7
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m06-audio-production:
     state: sync-required
-    required_sequence: 6
+    required_sequence: 7
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m07-storyboard-timeline:
     state: sync-required
-    required_sequence: 6
+    required_sequence: 7
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m08-video-provider-router:
     state: sync-required
-    required_sequence: 6
+    required_sequence: 7
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/cross-cutting-qa-security:
     state: sync-required
-    required_sequence: 6
+    required_sequence: 7
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
 

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -1,174 +1,71 @@
 # AI-Native Supervisor Parallel Development Plan
 
-## Purpose
+## Authority
 
-This is the canonical human-readable plan for Supervisor-led multi-agent development. It binds module branches, agent lanes, slot occupancy, dependency state, write ownership, completion signals, review order, synchronization behavior, onboarding, and merge strategy.
+The Supervisor owns assignment, coordination-state mutation, review order, and promotion to `main`. New executable slices always start from current `main`; completed executable branches are retired before the next bounded slice.
 
-The Supervisor is the only normal authority that assigns incoming agents, reviews submitted work, changes shared coordination state, and promotes incoming agent branches to `main`.
-
-This plan supplements `MULTI-AGENT-PROTOCOL.md`, `INTEGRATION-PROTOCOL.md`, `ACTIVE-WORK.yaml`, `AGENT-SLOTS.json`, `DEPENDENCY-GRAPH.yaml`, `MIGRATION-REGISTRY.yaml`, `MODULE-OWNERSHIP.yaml`, `SHARED-FILES.yaml`, and the repository development consent gate.
-
-## Mandatory branch-bootstrap-first rule
-
-When a Supervisor orchestration request requires multiple parallel module agents, the Supervisor creates the dedicated branch for every intended module lane before implementation begins. Branch creation never grants executable development permission; dependency and consent gates remain authoritative.
-
-Each new bounded executable submission uses a branch based on current `main`. A branch whose previous submission has merged is retired or replaced before the next bounded executable slice begins.
-
-## New Agent Onboarding — mandatory
-
-Every new agent begins from current `main`. A new agent may not start from a feature branch, stale checkpoint branch, another agent's branch, or chat-only state.
-
-Before the new agent writes any project file:
-
-1. the new agent starts from current `main` and performs the working-instruction audit;
-2. the Supervisor loads this plan and `AGENT-SLOTS.json`;
-3. the Supervisor checks for a slot whose `status` is `open` and `accepts_new_agent` is `true`;
-4. when a valid slot exists, the Supervisor assigns that exact module/branch and records agent identity, occupancy, start status, and `ACTIVE-WORK.yaml` state before work starts;
-5. only after the assignment is recorded may the agent switch from `main` to the assigned branch and work within its claimed paths.
-
-A new agent may never self-select, replace an occupied agent, or claim a branch merely because it exists.
-
-If there is no eligible open slot, the Supervisor stops onboarding immediately and responds exactly:
-
-> **Go Home Come Back Next Time**
-
-That response means no module, branch, research, planning, code, documentation, or repository mutation is assigned to the rejected arrival.
-
-`AGENT-SLOTS.json` is the machine-readable occupancy authority. This document is the human-readable assignment/merge plan. Both must remain synchronized.
-
-### Current onboarding capacity
-
-All defined module slots are occupied. An additional new agent therefore receives **Go Home Come Back Next Time** until the Supervisor intentionally opens/releases a slot in canonical repository state.
+New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after Supervisor assignment. All defined slots are currently occupied, so an additional arrival receives exactly **Go Home Come Back Next Time**.
 
 ## Current branch matrix
 
-| Lane | Slot | Assigned agent role | Branch | Module / scope | Current execution state | Promotion strategy |
-| --- | --- | --- | --- | --- | --- | --- |
-| Supervisor | occupied / not new-agent assignable | `supervisor-agent` | `supervisor/m03-wp7-temp-cleanup` | M03-WP7 bounded temporary upload cleanup | executable cleanup slice on current `main@6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6` | finish terminal abandoned upload/quarantine cleanup before export staging |
-| Acceptance | occupied | `acceptance-agent` | `agent/m03-wp8-acceptance` | M03-WP8 end-to-end acceptance | sync-required; planning-only until all WP7 exit criteria land | synchronize broadcast 6 before any promotion, then promote after WP7 |
-| Character | occupied | `character-agent` | `agent/m04-character-library` | M04 Character and Entity Library | sync-required planning/contract preparation only | synchronize before any promotion; executable work waits for entry + consent gates |
-| Content | occupied | `content-agent` | `agent/m05-content-memory` | M05 Content Intelligence and Memory | sync-required planning/contract preparation only | synchronize before any promotion; then follow M04 contracts |
-| Audio | occupied | `audio-agent` | `agent/m06-audio-production` | M06 provider-neutral audio production | sync-required planning/contract preparation only | synchronize before any promotion; executable work waits for entry + consent gates |
-| Timeline | occupied | `timeline-agent` | `agent/m07-storyboard-timeline` | M07 storyboard/hierarchy/timeline engine | sync-required planning-only | synchronize before any promotion; ordered after Character/Content/Audio contracts |
-| Provider | occupied | `provider-agent` | `agent/m08-video-provider-router` | M08 hybrid image/video provider router | sync-required planning-only | synchronize before any promotion; ordered after Character/Timeline contracts |
-| QA / Security | occupied | `qa-security-agent` | `agent/cross-cutting-qa-security` | adversarial QA/security planning and audits | sync-required audit/planning | synchronize before any promotion; independent conflict-free QA work may resume afterward |
+| Lane | Agent | Branch | State |
+| --- | --- | --- | --- |
+| M03-WP7 Supervisor | `supervisor-agent` | `supervisor/m03-wp7-export-staging` | active export-staging slice |
+| M03-WP8 | `acceptance-agent` | `agent/m03-wp8-acceptance` | sync-required planning-only |
+| M04 Character | `character-agent` | `agent/m04-character-library` | sync-required planning-only |
+| M05 Content | `content-agent` | `agent/m05-content-memory` | sync-required planning-only |
+| M06 Audio | `audio-agent` | `agent/m06-audio-production` | sync-required planning-only |
+| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | sync-required planning-only |
+| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | sync-required planning-only |
+| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security` | sync-required audit/planning |
 
-## Write-claim isolation
+## Current Supervisor slice
 
-Parallel work is permitted only when authoritative `writes` scopes in `ACTIVE-WORK.yaml` do not overlap.
+PR #59 landed bounded temporary cleanup at `main@f78a855f0b20dd150af93190b25bffbe6e1a0856`. Branch `supervisor/m03-wp7-temp-cleanup` is retired for new executable work.
 
-Planning lanes use dedicated milestone directories and exact per-task checkpoint files:
-- M04 -> `docs/milestones/M04/**` + `ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md`
-- M05 -> `docs/milestones/M05/**` + `ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md`
-- M06 -> `docs/milestones/M06/**` + `ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md`
-- M07 -> `docs/milestones/M07/**` + `ai-native/parallel/checkpoints/M07-PARALLEL-LANE.md`
-- M08 -> `docs/milestones/M08/**` + `ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md`
-- QA -> `docs/qa/**` + `ai-native/parallel/checkpoints/CROSS-CUTTING-QA.md`
+Issue #60 runs on `supervisor/m03-wp7-export-staging`, created from that exact main. Migration `20260901_0016` is reserved with parent `20260901_0015` because existing `storage_objects` metadata cannot durably represent both export-source provenance and bounded expiry.
 
-A `future_executable_writes` entry is informational only. It does not reserve or authorize those paths until the Supervisor explicitly promotes the task to executable state and rechecks collisions.
+Authoritative writes are limited to:
+- `packages/python-core/src/lullabies_core/export_staging.py`
+- `packages/python-core/src/lullabies_core/persistence/export_staging.py`
+- `packages/python-core/migrations/versions/20260901_0016_export_staging.py`
+- `packages/python-core/migrations/sql/0016_export_staging_up.sql`
+- `packages/python-core/migrations/sql/0016_export_staging_down.sql`
+- `packages/python-core/tests/test_export_staging.py`
+- `packages/python-core/tests/test_migrations.py`
 
-The active Supervisor write set for this bounded slice is limited to:
-- `packages/python-core/src/lullabies_core/temporary_cleanup.py`;
-- `packages/python-core/src/lullabies_core/persistence/temporary_cleanup.py`;
-- `packages/python-core/tests/test_temporary_cleanup.py`.
+Export staging must remain private and must not widen signed delivery, share-link, or public publishing authority. Stage/reuse is bound to project, source storage identity, source SHA-256, deterministic staging object identity/key, and expiry. Conflicting reuse fails closed. No vector/index cleanup, provider spend, production credential, release, or public endpoint work is authorized in this slice.
 
-Coordination files are maintained only by the Supervisor to keep branch/slot/broadcast authority synchronized and are not shared implementation lanes.
+## Parallel safety
 
-## Current merge order
+`ACTIVE-WORK.yaml` is authoritative for write claims. Overlapping authoritative write claims block execution. `future_executable_writes` are informational only. Migration reservations must be recorded before files are created.
 
-Default merge order is dependency-driven:
+All non-Supervisor occupied lanes are currently sync-required by broadcast 7 and cannot seek promotion until synchronization is recorded.
 
-1. `supervisor/m03-wp7-temp-cleanup`
-2. next bounded M03-WP7 export-staging branch
-3. next bounded M03-WP7 vector/index cleanup branch
-4. `agent/m03-wp8-acceptance` after synchronization and WP7 completion
-5. M03 close/checkpoint reconciliation
-6. M04 Character/Entity public contract foundation
-7. M05 Content/Memory and M06 Audio when independently ready
-8. M07 Storyboard/Timeline after required upstream contracts land
-9. M08 Provider Router after relevant Character/Timeline contracts land
-10. Later milestones follow `DEPENDENCY-GRAPH.yaml`
+Planning path ownership remains:
+- M04: `docs/milestones/M04/**` and `ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md`
+- M05: `docs/milestones/M05/**` and `ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md`
+- M06: `docs/milestones/M06/**` and `ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md`
+- M07: `docs/milestones/M07/**` and `ai-native/parallel/checkpoints/M07-PARALLEL-LANE.md`
+- M08: `docs/milestones/M08/**` and `ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md`
+- QA: `docs/qa/**` and `ai-native/parallel/checkpoints/CROSS-CUTTING-QA.md`
 
-The QA/Security lane is continuous but is currently sync-required by broadcast 6 and cannot seek promotion until it records synchronization.
+## Merge order
 
-If a new dependency appears, `DEPENDENCY-GRAPH.yaml` and affected task instructions are updated before further work. Contract-owner branches promote before consumers that require those contracts.
+1. `supervisor/m03-wp7-export-staging`
+2. fresh bounded M03-WP7 vector/index cleanup branch
+3. M03-WP8 acceptance after synchronization and WP7 completion
+4. M03 close/reconciliation
+5. later milestones according to dependency/consent gates
 
-## Completion signal
+## Completion and review
 
-Every agent, including the Supervisor, uses the exact announcement when its bounded submission is ready for Supervisor review:
+Every ready bounded submission announces exactly **Work Done and Submitted**. That signal means ready for Supervisor review, not merged.
 
-> **Work Done and Submitted**
+Before promotion, the Supervisor verifies exact head/base, write ownership, migration reservation, dependency/consent state, tests, security/data implications, current-main freshness, and unresolved review findings. Required exact-head CI must be green.
 
-The signal means the bounded assigned scope is complete on the agent branch, scoped checks were run or reported unavailable, known risks are documented, and the branch/PR is frozen for Supervisor review unless fixes/synchronization are requested. It does not mean merged or production-ready.
-
-## Supervisor interrupt and review behavior
-
-When an agent submits **Work Done and Submitted**:
-
-1. Supervisor records a pause checkpoint for its own current work.
-2. Supervisor switches to review/integration mode.
-3. Supervisor verifies exact head, scope, ownership, dependency state, migration reservations, shared-file requests, current-main relation, tests, security/data implications, consent, and PR diff.
-4. Rejected work returns with precise fixes and is not merged.
-5. Approved work synchronizes with current `main` when required and obtains exact-head promotion CI.
-6. Supervisor merges with an expected-head guard where supported.
-7. Supervisor records the merge and emits the synchronization broadcast.
-8. Supervisor resumes its saved work only after coordination state is reconciled.
-
-## Mandatory post-merge broadcast
-
-After every promotion merge that active agents must observe, emit exactly:
+After a successful promotion, emit exactly:
 
 > **New changes have been merged — please merge these changes into your branch first, then resume your own work.**
 
-`SUPERVISOR-BROADCASTS.yaml` records sequence, merged PR/branch, submitted head, new `main` SHA, changed contracts/migrations/shared areas, recipients, and mandatory/advisory classification.
-
-## Agent response to merge alerts
-
-Before continuing after a mandatory broadcast, every affected agent must:
-
-1. stop at a safe checkpoint;
-2. synchronize current `main`;
-3. resolve textual and semantic conflicts;
-4. rerun the working-instruction audit;
-5. revalidate contracts, dependencies, migration state, write ownership, and consent;
-6. record `last_synced_main_sha` and `last_acknowledged_broadcast`;
-7. rerun relevant scoped checks when the merge affects its consumers;
-8. resume only after the sync is recorded.
-
-An unacknowledged mandatory broadcast makes the task `sync-required` and blocks submission/promotion.
-
-## Review queue rules
-
-Supervisor priority:
-
-1. security/data-loss/blocking fixes;
-2. contract-owner work that unblocks multiple agents;
-3. current critical path;
-4. independent small changes;
-5. future planning/documentation.
-
-Completion order never overrides dependency safety, contract compatibility, current-main synchronization, or exact-head verification.
-
-## Current Supervisor assignment
-
-PR #57 merged the approved deletion-propagation execution slice at `main@6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6`. The completed branch `supervisor/m03-wp7-deletion-execution` is retired for new executable work.
-
-The Supervisor now owns Issue #58 on `supervisor/m03-wp7-temp-cleanup`, created from that exact current main. This slice may clean only `ABORTED` or `EXPIRED` upload/quarantine state after an explicit grace cutoff. It must fail closed when canonical storage metadata exists for either the upload storage-object identity or exact physical location, must preserve project/key boundaries, must not touch `OPEN`, `UPLOADING`, or `COMPLETED` sessions, and must treat missing temporary backend state as idempotent cleanup success. Incomplete S3 multipart uploads are aborted before orphan quarantine object deletion when an UploadId exists.
-
-No migration, export staging, vector/index cleanup, provider integration, production credential change, or cost-bearing scope is authorized in this slice. Remaining WP7 scope after it lands is export staging, vector/index cleanup hooks, and final WP7 acceptance/promotion.
-
-Broadcast sequence 6 is current. The Supervisor temp-cleanup branch is synchronized to sequence 6/current main; all other occupied planning/QA lanes listed in `ACTIVE-WORK.yaml` are sync-required and cannot seek promotion until they acknowledge sequence 6.
-
-Migration `20260901_0015` is landed history and is no longer an active reservation.
-
-## Branch retirement and slot release
-
-After a branch is merged:
-- mark the landed slice and release/land any migration reservation;
-- update dependencies/contracts/checkpoints;
-- emit the merge broadcast;
-- decide whether the module slot remains occupied for a next bounded branch or becomes `open`;
-- if opened, clear `assigned_agent` before a future agent can claim it;
-- retire/delete the completed task branch when repository policy permits.
-
-Long-lived module names may remain planning concepts, but executable submissions should use bounded task branches so stale heads cannot absorb unrelated future work.
+Then update `SUPERVISOR-BROADCASTS.yaml`, `SUPERVISOR-STATE.yaml`, slot/active registries, migration state, and affected branch synchronization before the next executable slice starts.

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -2,18 +2,18 @@ version: 5
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
-  main_sha_last_reconciled: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
+  main_sha_last_promotion: f78a855f0b20dd150af93190b25bffbe6e1a0856
+  main_sha_last_reconciled: f78a855f0b20dd150af93190b25bffbe6e1a0856
   own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-temp-cleanup
+  own_branch: supervisor/m03-wp7-export-staging
   current_mode: feature-development
   completion_signal: Work Done and Submitted
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 57
-  submitted_head_sha: da0e67a9297956ab34b664a736d6739d4742996a
-  merged_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
+  pr: 59
+  submitted_head_sha: a46f2d80d4d5022e62bcbdf3294d4fc489a7fe6f
+  merged_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
   result: success
 
 new_agent_onboarding:
@@ -58,7 +58,7 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 6
+  latest_broadcast_sequence: 7
   agents_with_mandatory_sync:
     - agent/m03-wp8-acceptance
     - agent/m04-character-library

--- a/packages/python-core/migrations/sql/0016_export_staging_down.sql
+++ b/packages/python-core/migrations/sql/0016_export_staging_down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS core.export_staging_objects;

--- a/packages/python-core/migrations/sql/0016_export_staging_up.sql
+++ b/packages/python-core/migrations/sql/0016_export_staging_up.sql
@@ -1,0 +1,34 @@
+CREATE TABLE core.export_staging_objects (
+    id uuid PRIMARY KEY,
+    external_id text NOT NULL UNIQUE,
+    schema_version smallint NOT NULL DEFAULT 1,
+    project_id uuid NOT NULL,
+    source_storage_object_id uuid NOT NULL,
+    staging_storage_object_id uuid NOT NULL UNIQUE,
+    source_sha256 char(64) NOT NULL,
+    expires_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    created_by text,
+    revision integer NOT NULL DEFAULT 1,
+    CONSTRAINT fk_export_staging_project FOREIGN KEY (project_id)
+        REFERENCES core.projects(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_export_staging_source_storage FOREIGN KEY (source_storage_object_id)
+        REFERENCES core.storage_objects(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_export_staging_output_storage FOREIGN KEY (staging_storage_object_id)
+        REFERENCES core.storage_objects(id) ON DELETE RESTRICT,
+    CONSTRAINT ck_export_staging_external CHECK (external_id ~ '^EXS-[0-9]{6,20}$'),
+    CONSTRAINT ck_export_staging_distinct_storage CHECK (
+        source_storage_object_id <> staging_storage_object_id
+    ),
+    CONSTRAINT ck_export_staging_source_sha CHECK (source_sha256 ~ '^[a-f0-9]{64}$'),
+    CONSTRAINT ck_export_staging_expiry CHECK (expires_at > created_at),
+    CONSTRAINT ck_export_staging_revision CHECK (revision >= 1),
+    CONSTRAINT ck_export_staging_audit_time CHECK (updated_at >= created_at)
+);
+
+CREATE INDEX idx_export_staging_project_expiry
+    ON core.export_staging_objects (project_id, expires_at, id);
+
+CREATE INDEX idx_export_staging_source
+    ON core.export_staging_objects (source_storage_object_id, created_at, id);

--- a/packages/python-core/migrations/versions/20260901_0016_export_staging.py
+++ b/packages/python-core/migrations/versions/20260901_0016_export_staging.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "20260901_0016"
+down_revision = "20260901_0015"
+branch_labels = None
+depends_on = None
+
+_SQL_DIR = Path(__file__).resolve().parents[1] / "sql"
+
+
+def _statements(filename: str) -> list[str]:
+    text = (_SQL_DIR / filename).read_text(encoding="utf-8")
+    return [statement.strip() for statement in text.split(";\n") if statement.strip()]
+
+
+def _execute(filename: str) -> None:
+    for statement in _statements(filename):
+        op.execute(statement)
+
+
+def upgrade() -> None:
+    _execute("0016_export_staging_up.sql")
+
+
+def downgrade() -> None:
+    _execute("0016_export_staging_down.sql")

--- a/packages/python-core/src/lullabies_core/export_staging.py
+++ b/packages/python-core/src/lullabies_core/export_staging.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from .common import (
+    SCHEMA_VERSION,
+    AuditFields,
+    ProjectId,
+    SchemaVersion,
+    StorageObjectId,
+    StrictModel,
+)
+from .storage import (
+    StorageAdapter,
+    StorageIntegrityError,
+    StorageObject,
+    build_object_key,
+    sha256_bytes,
+    storage_object_from_write,
+)
+
+EXPORT_STAGING_NAMESPACE = "exports/staging"
+EXPORT_STAGING_LIFECYCLE_CLASS = "export-staging"
+
+
+class ExportStagingError(RuntimeError):
+    """Base error for bounded private export staging."""
+
+
+class ExportStagingConflictError(ExportStagingError):
+    """Requested staging identity conflicts with current source or target state."""
+
+
+def build_export_staging_key(project_id: str, storage_object_id: str) -> str:
+    return build_object_key(
+        EXPORT_STAGING_NAMESPACE,
+        storage_object_id,
+        project_id=project_id,
+    )
+
+
+class ExportStagingObject(StrictModel):
+    schema_version: SchemaVersion = SCHEMA_VERSION
+    export_staging_id: str = Field(pattern=r"^EXS-[0-9]{6,20}$")
+    project_id: ProjectId
+    source_storage_object_id: StorageObjectId
+    source_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    staging_storage_object_id: StorageObjectId
+    staging_object_key: str = Field(min_length=1, max_length=1024)
+    expires_at: AwareDatetime
+    audit: AuditFields
+
+    @model_validator(mode="after")
+    def validate_contract(self) -> ExportStagingObject:
+        if self.source_storage_object_id == self.staging_storage_object_id:
+            raise ValueError("export staging source and target storage identities must differ")
+        expected_key = build_export_staging_key(
+            self.project_id,
+            self.staging_storage_object_id,
+        )
+        if self.staging_object_key != expected_key:
+            raise ValueError("export staging object_key must equal the canonical private staging key")
+        if self.expires_at <= self.audit.created_at:
+            raise ValueError("export staging expiry must be after creation")
+        return self
+
+
+@dataclass(frozen=True)
+class PreparedExportStaging:
+    record: ExportStagingObject
+    storage_object: StorageObject
+
+
+def prepare_export_staging(
+    *,
+    source: StorageObject,
+    export_staging_id: str,
+    staging_storage_object_id: str,
+    expires_at: datetime,
+    audit: AuditFields,
+    storage: StorageAdapter,
+) -> PreparedExportStaging:
+    if source.project_id is None:
+        raise ExportStagingConflictError("export source must belong to a project")
+    if expires_at.tzinfo is None or expires_at.utcoffset() is None:
+        raise ValueError("export staging expiry must be timezone-aware")
+    if expires_at <= audit.created_at:
+        raise ValueError("export staging expiry must be after creation")
+    if source.backend != storage.backend:
+        raise ExportStagingConflictError("export source backend does not match staging adapter")
+
+    live = storage.stat(source.object_key)
+    if live.backend != source.backend or live.bucket != source.bucket:
+        raise ExportStagingConflictError("export source physical location changed")
+    if live.object_key != source.object_key or live.size_bytes != source.size_bytes:
+        raise ExportStagingConflictError("export source size or object key changed")
+    if live.sha256 is None:
+        raise StorageIntegrityError("export source lacks canonical live SHA-256 evidence")
+    if live.sha256 != source.sha256:
+        raise StorageIntegrityError("export source live SHA-256 does not match canonical metadata")
+
+    source_bytes = storage.get_bytes(source.object_key)
+    observed_digest = sha256_bytes(source_bytes)
+    if observed_digest != source.sha256 or len(source_bytes) != source.size_bytes:
+        raise StorageIntegrityError("export source bytes do not match canonical metadata")
+
+    target_key = build_export_staging_key(source.project_id, staging_storage_object_id)
+    write = storage.put_bytes(target_key, source_bytes, mime_type=source.mime_type)
+    if (
+        write.backend != source.backend
+        or write.bucket != source.bucket
+        or write.object_key != target_key
+        or write.sha256 != source.sha256
+        or write.size_bytes != source.size_bytes
+    ):
+        raise StorageIntegrityError("export staging write does not preserve source identity")
+
+    staging_storage = storage_object_from_write(
+        staging_storage_object_id,
+        write,
+        audit=audit,
+        project_id=source.project_id,
+        original_filename=source.original_filename,
+        lifecycle_class=EXPORT_STAGING_LIFECYCLE_CLASS,
+    )
+    record = ExportStagingObject(
+        export_staging_id=export_staging_id,
+        project_id=source.project_id,
+        source_storage_object_id=source.storage_object_id,
+        source_sha256=source.sha256,
+        staging_storage_object_id=staging_storage_object_id,
+        staging_object_key=target_key,
+        expires_at=expires_at,
+        audit=audit,
+    )
+    return PreparedExportStaging(record=record, storage_object=staging_storage)

--- a/packages/python-core/src/lullabies_core/export_staging.py
+++ b/packages/python-core/src/lullabies_core/export_staging.py
@@ -62,7 +62,9 @@ class ExportStagingObject(StrictModel):
             self.staging_storage_object_id,
         )
         if self.staging_object_key != expected_key:
-            raise ValueError("export staging object_key must equal the canonical private staging key")
+            raise ValueError(
+                "export staging object_key must equal the canonical private staging key"
+            )
         if self.expires_at <= self.audit.created_at:
             raise ValueError("export staging expiry must be after creation")
         return self

--- a/packages/python-core/src/lullabies_core/persistence/export_staging.py
+++ b/packages/python-core/src/lullabies_core/persistence/export_staging.py
@@ -133,7 +133,9 @@ class PostgresExportStagingRepository:
         if str(target["object_key"]) != record.staging_object_key:
             raise PersistenceConflictError("export staging target object key changed")
         if str(target["lifecycle_class"]) != EXPORT_STAGING_LIFECYCLE_CLASS:
-            raise PersistenceConflictError("export staging target is not classified as export staging")
+            raise PersistenceConflictError(
+                "export staging target is not classified as export staging"
+            )
 
     def _from_row(self, connection: Connection, row: RowMapping) -> ExportStagingObject:
         persisted_schema_version = int(row["schema_version"])

--- a/packages/python-core/src/lullabies_core/persistence/export_staging.py
+++ b/packages/python-core/src/lullabies_core/persistence/export_staging.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, cast
+from uuid import UUID, uuid4
+
+from sqlalchemy import MetaData, insert, select
+from sqlalchemy.engine import Connection, Engine, RowMapping
+from sqlalchemy.exc import IntegrityError
+
+from ..common import SCHEMA_VERSION, AuditFields, SchemaVersion
+from ..export_staging import (
+    EXPORT_STAGING_LIFECYCLE_CLASS,
+    ExportStagingObject,
+    PreparedExportStaging,
+)
+from ._db import PersistenceConflictError, PersistenceNotFoundError, PersistenceReferenceError
+from .storage_object import PostgresStorageObjectRepository
+
+ExportStagingPersistAction = Literal["created", "noop"]
+
+
+@dataclass(frozen=True)
+class ExportStagingPersistResult:
+    action: ExportStagingPersistAction
+    export_staging_id: str
+
+
+class PostgresExportStagingRepository:
+    """Durable private export-staging provenance and expiry authority."""
+
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+        metadata = MetaData()
+        metadata.reflect(bind=engine, schema="core")
+        required = {"export_staging_objects", "storage_objects", "projects"}
+        missing = [name for name in required if f"core.{name}" not in metadata.tables]
+        if missing:
+            raise PersistenceReferenceError(
+                f"export staging tables are not migrated: {', '.join(sorted(missing))}"
+            )
+        self.staging = metadata.tables["core.export_staging_objects"]
+        self.storage = metadata.tables["core.storage_objects"]
+        self.projects = metadata.tables["core.projects"]
+        self.storage_repository = PostgresStorageObjectRepository(engine)
+
+    def save_prepared(self, prepared: PreparedExportStaging) -> ExportStagingPersistResult:
+        record = prepared.record
+        storage_object = prepared.storage_object
+        if storage_object.storage_object_id != record.staging_storage_object_id:
+            raise PersistenceConflictError("prepared export staging storage identity drifted")
+        if storage_object.project_id != record.project_id:
+            raise PersistenceConflictError("prepared export staging project identity drifted")
+        if storage_object.object_key != record.staging_object_key:
+            raise PersistenceConflictError("prepared export staging object key drifted")
+        if storage_object.sha256 != record.source_sha256:
+            raise PersistenceConflictError("prepared export staging SHA-256 drifted")
+        if storage_object.lifecycle_class != EXPORT_STAGING_LIFECYCLE_CLASS:
+            raise PersistenceConflictError("prepared export staging lifecycle class drifted")
+
+        self.storage_repository.save(storage_object)
+        return self.save(record)
+
+    def save(self, record: ExportStagingObject) -> ExportStagingPersistResult:
+        try:
+            with self.engine.begin() as connection:
+                existing = self._row_by_external(connection, record.export_staging_id)
+                if existing is not None:
+                    if self._from_row(connection, existing) == record:
+                        return ExportStagingPersistResult("noop", record.export_staging_id)
+                    raise PersistenceConflictError(
+                        f"export staging {record.export_staging_id} already has different data"
+                    )
+
+                project_internal = self._project_internal(connection, record.project_id)
+                source = self._storage_row(connection, record.source_storage_object_id)
+                target = self._storage_row(connection, record.staging_storage_object_id)
+                self._verify_storage_bindings(
+                    record=record,
+                    project_internal=project_internal,
+                    source=source,
+                    target=target,
+                )
+                connection.execute(
+                    insert(self.staging).values(
+                        id=uuid4(),
+                        external_id=record.export_staging_id,
+                        schema_version=record.schema_version,
+                        project_id=project_internal,
+                        source_storage_object_id=source["id"],
+                        staging_storage_object_id=target["id"],
+                        source_sha256=record.source_sha256,
+                        expires_at=record.expires_at,
+                        created_at=record.audit.created_at,
+                        updated_at=record.audit.updated_at,
+                        created_by=record.audit.created_by,
+                        revision=record.audit.revision,
+                    )
+                )
+        except (PersistenceConflictError, PersistenceReferenceError):
+            raise
+        except IntegrityError as exc:
+            raise PersistenceConflictError(
+                f"database rejected export staging {record.export_staging_id}"
+            ) from exc
+        return ExportStagingPersistResult("created", record.export_staging_id)
+
+    def load(self, export_staging_id: str) -> ExportStagingObject:
+        with self.engine.connect() as connection:
+            row = self._row_by_external(connection, export_staging_id)
+            if row is None:
+                raise PersistenceNotFoundError(
+                    f"export staging {export_staging_id} was not found"
+                )
+            return self._from_row(connection, row)
+
+    def _verify_storage_bindings(
+        self,
+        *,
+        record: ExportStagingObject,
+        project_internal: UUID,
+        source: RowMapping,
+        target: RowMapping,
+    ) -> None:
+        if source["id"] == target["id"]:
+            raise PersistenceConflictError("export staging source and target storage rows match")
+        if source["project_id"] != project_internal or target["project_id"] != project_internal:
+            raise PersistenceConflictError("export staging storage rows cross project boundary")
+        if str(source["sha256"]) != record.source_sha256:
+            raise PersistenceConflictError("export staging source SHA-256 changed")
+        if str(target["sha256"]) != record.source_sha256:
+            raise PersistenceConflictError("export staging target SHA-256 differs from source")
+        if str(target["object_key"]) != record.staging_object_key:
+            raise PersistenceConflictError("export staging target object key changed")
+        if str(target["lifecycle_class"]) != EXPORT_STAGING_LIFECYCLE_CLASS:
+            raise PersistenceConflictError("export staging target is not classified as export staging")
+
+    def _from_row(self, connection: Connection, row: RowMapping) -> ExportStagingObject:
+        persisted_schema_version = int(row["schema_version"])
+        if persisted_schema_version != SCHEMA_VERSION:
+            raise PersistenceReferenceError(
+                "unsupported export staging schema version "
+                f"{persisted_schema_version}; expected {SCHEMA_VERSION}"
+            )
+        schema_version = cast(SchemaVersion, persisted_schema_version)
+        project_id = self._project_external(connection, cast(UUID, row["project_id"]))
+        source_id = self._storage_external(connection, cast(UUID, row["source_storage_object_id"]))
+        target_id = self._storage_external(connection, cast(UUID, row["staging_storage_object_id"]))
+        target = self._storage_row(connection, target_id)
+        return ExportStagingObject(
+            schema_version=schema_version,
+            export_staging_id=str(row["external_id"]),
+            project_id=project_id,
+            source_storage_object_id=source_id,
+            source_sha256=str(row["source_sha256"]),
+            staging_storage_object_id=target_id,
+            staging_object_key=str(target["object_key"]),
+            expires_at=row["expires_at"],
+            audit=AuditFields(
+                created_at=row["created_at"],
+                updated_at=row["updated_at"],
+                created_by=(str(row["created_by"]) if row["created_by"] is not None else None),
+                revision=int(row["revision"]),
+            ),
+        )
+
+    def _row_by_external(self, connection: Connection, external_id: str) -> RowMapping | None:
+        return connection.execute(
+            select(self.staging).where(self.staging.c.external_id == external_id)
+        ).mappings().one_or_none()
+
+    def _project_internal(self, connection: Connection, external_id: str) -> UUID:
+        value = connection.execute(
+            select(self.projects.c.id).where(self.projects.c.external_id == external_id)
+        ).scalar_one_or_none()
+        if value is None:
+            raise PersistenceReferenceError(f"missing project:{external_id}")
+        return cast(UUID, value)
+
+    def _project_external(self, connection: Connection, internal_id: UUID) -> str:
+        value = connection.execute(
+            select(self.projects.c.external_id).where(self.projects.c.id == internal_id)
+        ).scalar_one_or_none()
+        if value is None:
+            raise PersistenceReferenceError(f"missing project row:{internal_id}")
+        return str(value)
+
+    def _storage_row(self, connection: Connection, external_id: str) -> RowMapping:
+        row = connection.execute(
+            select(self.storage).where(self.storage.c.external_id == external_id)
+        ).mappings().one_or_none()
+        if row is None:
+            raise PersistenceReferenceError(f"missing storage object:{external_id}")
+        return row
+
+    def _storage_external(self, connection: Connection, internal_id: UUID) -> str:
+        value = connection.execute(
+            select(self.storage.c.external_id).where(self.storage.c.id == internal_id)
+        ).scalar_one_or_none()
+        if value is None:
+            raise PersistenceReferenceError(f"missing storage row:{internal_id}")
+        return str(value)

--- a/packages/python-core/tests/test_export_staging.py
+++ b/packages/python-core/tests/test_export_staging.py
@@ -93,7 +93,7 @@ def test_prepare_export_staging_fails_closed_when_source_bytes_drift(tmp_path: P
     filesystem = FilesystemStorageAdapter(tmp_path)
     source = source_object(filesystem)
     source_path = tmp_path / Path(*source.object_key.split("/"))
-    source_path.write_bytes(b"tampered source")
+    source_path.write_bytes(b"tampered! export source")
 
     with pytest.raises(StorageIntegrityError, match="live SHA-256"):
         prepare_export_staging(

--- a/packages/python-core/tests/test_export_staging.py
+++ b/packages/python-core/tests/test_export_staging.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from lullabies_core.common import AuditFields
+from lullabies_core.export_staging import (
+    EXPORT_STAGING_LIFECYCLE_CLASS,
+    ExportStagingConflictError,
+    prepare_export_staging,
+)
+from lullabies_core.persistence._db import PersistenceConflictError
+from lullabies_core.persistence.export_staging import PostgresExportStagingRepository
+from lullabies_core.persistence.storage_object import PostgresStorageObjectRepository
+from lullabies_core.storage import (
+    FilesystemStorageAdapter,
+    StorageIntegrityError,
+    StorageObject,
+    build_object_key,
+    storage_object_from_write,
+)
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+ALEMBIC_INI = Path(__file__).parents[1] / "alembic.ini"
+
+
+def audit(at: datetime) -> AuditFields:
+    return AuditFields(created_at=at, updated_at=at, created_by="export-staging-test")
+
+
+def source_object(
+    filesystem: FilesystemStorageAdapter,
+    *,
+    project_id: str = "PRJ-001601",
+    storage_object_id: str = "STO-001601",
+    data: bytes = b"canonical export source",
+    at: datetime | None = None,
+) -> StorageObject:
+    created_at = at or datetime(2026, 9, 5, 9, 0, tzinfo=UTC)
+    key = build_object_key("canonical/source", storage_object_id, project_id=project_id)
+    write = filesystem.put_bytes(key, data, mime_type="video/mp4")
+    return storage_object_from_write(
+        storage_object_id,
+        write,
+        audit=audit(created_at),
+        project_id=project_id,
+        original_filename="source.mp4",
+        lifecycle_class="canonical",
+    )
+
+
+def test_prepare_export_staging_copies_exact_bytes_to_private_deterministic_key(
+    tmp_path: Path,
+) -> None:
+    filesystem = FilesystemStorageAdapter(tmp_path)
+    created_at = datetime(2026, 9, 5, 9, 0, tzinfo=UTC)
+    source = source_object(filesystem, at=created_at)
+
+    prepared = prepare_export_staging(
+        source=source,
+        export_staging_id="EXS-001601",
+        staging_storage_object_id="STO-001602",
+        expires_at=created_at + timedelta(hours=4),
+        audit=audit(created_at + timedelta(minutes=1)),
+        storage=filesystem,
+    )
+
+    assert prepared.record.source_storage_object_id == source.storage_object_id
+    assert prepared.record.source_sha256 == source.sha256
+    assert prepared.record.staging_object_key == "exports/staging/PRJ-001601/STO-001602"
+    assert prepared.storage_object.lifecycle_class == EXPORT_STAGING_LIFECYCLE_CLASS
+    assert prepared.storage_object.sha256 == source.sha256
+    assert filesystem.get_bytes(prepared.record.staging_object_key) == b"canonical export source"
+
+    retried = prepare_export_staging(
+        source=source,
+        export_staging_id="EXS-001601",
+        staging_storage_object_id="STO-001602",
+        expires_at=created_at + timedelta(hours=4),
+        audit=audit(created_at + timedelta(minutes=1)),
+        storage=filesystem,
+    )
+    assert retried == prepared
+
+
+def test_prepare_export_staging_fails_closed_when_source_bytes_drift(tmp_path: Path) -> None:
+    filesystem = FilesystemStorageAdapter(tmp_path)
+    source = source_object(filesystem)
+    source_path = tmp_path / Path(*source.object_key.split("/"))
+    source_path.write_bytes(b"tampered source")
+
+    with pytest.raises(StorageIntegrityError, match="live SHA-256"):
+        prepare_export_staging(
+            source=source,
+            export_staging_id="EXS-001603",
+            staging_storage_object_id="STO-001603",
+            expires_at=datetime(2026, 9, 5, 14, 0, tzinfo=UTC),
+            audit=audit(datetime(2026, 9, 5, 10, 0, tzinfo=UTC)),
+            storage=filesystem,
+        )
+
+
+def test_prepare_export_staging_rejects_projectless_source(tmp_path: Path) -> None:
+    filesystem = FilesystemStorageAdapter(tmp_path)
+    source = source_object(filesystem).model_copy(update={"project_id": None})
+
+    with pytest.raises(ExportStagingConflictError, match="belong to a project"):
+        prepare_export_staging(
+            source=source,
+            export_staging_id="EXS-001604",
+            staging_storage_object_id="STO-001604",
+            expires_at=datetime(2026, 9, 5, 14, 0, tzinfo=UTC),
+            audit=audit(datetime(2026, 9, 5, 10, 0, tzinfo=UTC)),
+            storage=filesystem,
+        )
+
+
+def _alembic_config() -> Config:
+    return Config(str(ALEMBIC_INI))
+
+
+def _insert_project(engine: object, external_id: str) -> None:
+    with engine.begin() as connection:  # type: ignore[attr-defined]
+        connection.execute(
+            text(
+                """
+                INSERT INTO core.projects (
+                    id, external_id, title, status, audience, "cast", content_format,
+                    language, target_duration_seconds, output, creative, provider_policy,
+                    created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :external_id, :title, 'draft',
+                    '{}'::jsonb, '{}'::jsonb, 'song', 'en', 120,
+                    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, now(), now()
+                )
+                """
+            ),
+            {"external_id": external_id, "title": f"Export fixture {external_id}"},
+        )
+
+
+@pytest.mark.postgres
+@pytest.mark.skipif(DATABASE_URL is None, reason="DATABASE_URL is not configured")
+def test_postgres_export_staging_persists_exact_provenance_and_reuse(tmp_path: Path) -> None:
+    assert DATABASE_URL is not None
+    config = _alembic_config()
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+    engine = create_engine(DATABASE_URL)
+
+    try:
+        project_id = "PRJ-001611"
+        created_at = datetime(2026, 9, 5, 9, 0, tzinfo=UTC)
+        _insert_project(engine, project_id)
+        filesystem = FilesystemStorageAdapter(tmp_path)
+        source = source_object(
+            filesystem,
+            project_id=project_id,
+            storage_object_id="STO-001611",
+            at=created_at,
+        )
+        PostgresStorageObjectRepository(engine).save(source)
+
+        prepared = prepare_export_staging(
+            source=source,
+            export_staging_id="EXS-001611",
+            staging_storage_object_id="STO-001612",
+            expires_at=created_at + timedelta(hours=6),
+            audit=audit(created_at + timedelta(minutes=1)),
+            storage=filesystem,
+        )
+        repository = PostgresExportStagingRepository(engine)
+        created = repository.save_prepared(prepared)
+        assert created.action == "created"
+        assert repository.load("EXS-001611") == prepared.record
+
+        repeated = repository.save_prepared(prepared)
+        assert repeated.action == "noop"
+
+        conflicting = prepared.record.model_copy(
+            update={"expires_at": prepared.record.expires_at + timedelta(hours=1)}
+        )
+        with pytest.raises(PersistenceConflictError, match="different data"):
+            repository.save(conflicting)
+    finally:
+        command.downgrade(config, "base")
+        engine.dispose()

--- a/packages/python-core/tests/test_migrations.py
+++ b/packages/python-core/tests/test_migrations.py
@@ -42,6 +42,7 @@ EXPECTED_CORE_TABLES = {
     "asset_delivery_policies",
     "asset_lifecycle_states",
     "asset_lifecycle_events",
+    "export_staging_objects",
     "storage_objects",
     "upload_sessions",
     "upload_parts",
@@ -94,6 +95,7 @@ M03_WP5_TABLES = {"derivative_records"}
 M03_WP6_SHARE_TABLES = {"delivery_share_links"}
 M03_WP6_POLICY_TABLES = {"asset_delivery_policies"}
 M03_WP7_LIFECYCLE_TABLES = {"asset_lifecycle_states", "asset_lifecycle_events"}
+M03_WP7_EXPORT_TABLES = {"export_staging_objects"}
 
 
 def alembic_config() -> Config:
@@ -287,6 +289,24 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
             "occurred_at",
             "revision",
         }.issubset(lifecycle_event_columns)
+        export_staging_columns = {
+            column["name"]
+            for column in db_inspector.get_columns("export_staging_objects", schema="core")
+        }
+        assert {
+            "external_id",
+            "project_id",
+            "source_storage_object_id",
+            "staging_storage_object_id",
+            "source_sha256",
+            "expires_at",
+            "created_at",
+            "updated_at",
+            "revision",
+        }.issubset(export_staging_columns)
+        assert "url" not in export_staging_columns
+        assert "token" not in export_staging_columns
+        assert "share_link_id" not in export_staging_columns
         approval_request_columns = {
             column["name"]
             for column in db_inspector.get_columns("approval_requests", schema="core")
@@ -320,7 +340,7 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         with engine.connect() as connection:
             result = connection.execute(text("SELECT version_num FROM alembic_version"))
             revision = result.scalar_one()
-        assert revision == "20260901_0015"
+        assert revision == "20260901_0016"
 
         project_id = uuid4()
         with engine.begin() as connection:
@@ -441,9 +461,14 @@ def test_postgresql_migration_chain_is_reversible_and_deterministic() -> None:
         command.upgrade(config, "head")
         assert set(inspect(engine).get_table_names(schema="core")) == EXPECTED_CORE_TABLES
 
+        command.downgrade(config, "20260901_0015")
+        m15_tables = set(inspect(engine).get_table_names(schema="core"))
+        pre_export_tables = EXPECTED_CORE_TABLES - M03_WP7_EXPORT_TABLES
+        assert m15_tables == pre_export_tables
+
         command.downgrade(config, "20260901_0014")
         m14_tables = set(inspect(engine).get_table_names(schema="core"))
-        pre_wp7_lifecycle_tables = EXPECTED_CORE_TABLES - M03_WP7_LIFECYCLE_TABLES
+        pre_wp7_lifecycle_tables = pre_export_tables - M03_WP7_LIFECYCLE_TABLES
         assert m14_tables == pre_wp7_lifecycle_tables
 
         command.downgrade(config, "20260901_0013")


### PR DESCRIPTION
Implements Issue #60 as the next bounded M03-WP7 slice after temporary cleanup.

Safety contract:
- export staging uses a deterministic private `exports/staging/<project>/<storage-id>` namespace;
- source project, storage identity, live location, size and canonical SHA-256 are verified before staging;
- staged bytes must preserve exact source SHA-256/size;
- durable `export_staging_objects` records bind source storage row, staging storage row, project, immutable source SHA-256 and explicit expiry;
- exact retry is idempotent; conflicting reuse fails closed;
- staging storage is classified `export-staging` for later bounded cleanup;
- schema contains no URL, token or share-link authority and does not widen delivery/public access;
- migration `20260901_0016` is reserved against parent `20260901_0015`, with reversible migration-chain coverage;
- no vector/index cleanup, provider spend, production credentials, public endpoint or unrelated milestone work is included.

Supervisor coordination is synchronized to broadcast sequence 7/current main; all other occupied planning/QA lanes remain sync-required.

Issue: #60

Work Done and Submitted