### PR TITLE
M03-WP7: add deterministic vector and index cleanup hooks

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -5,41 +5,30 @@ supervisor:
   main_branch: main
   review_and_merge_authority: true
   own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-export-staging
+  own_branch: supervisor/m03-wp7-vector-index-cleanup
 
 active:
   - task_id: M03-WP7
-    title: Retention/archive/delete/export primitives
+    title: Retention/archive/delete/export/vector cleanup primitives
     role: supervisor-module
     assigned_agent: supervisor-agent
-    branch: supervisor/m03-wp7-export-staging
-    base_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
-    previous_submission:
-      pr: 59
-      head_sha: a46f2d80d4d5022e62bcbdf3294d4fc489a7fe6f
-      merged_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
-      scope: bounded temporary upload and quarantine cleanup
+    branch: supervisor/m03-wp7-vector-index-cleanup
+    base_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
     module: asset_lifecycle
-    status: active-export-staging
+    status: active-vector-index-cleanup
     writes:
-      - packages/python-core/src/lullabies_core/export_staging.py
-      - packages/python-core/src/lullabies_core/persistence/export_staging.py
-      - packages/python-core/migrations/versions/20260901_0016_export_staging.py
-      - packages/python-core/migrations/sql/0016_export_staging_up.sql
-      - packages/python-core/migrations/sql/0016_export_staging_down.sql
-      - packages/python-core/tests/test_export_staging.py
-      - packages/python-core/tests/test_migrations.py
+      - packages/python-core/src/lullabies_core/index_cleanup.py
+      - packages/python-core/tests/test_index_cleanup.py
     shared_requests: []
     depends_on:
       - M03-WP6
-    migration_reservation: 20260901_0016
+    migration_reservation: null
     consent_scope: M03
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
-    last_acknowledged_broadcast: 7
+    last_synced_main_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
+    last_acknowledged_broadcast: 8
     required_broadcast: null
     remaining_scope:
-      - export staging
       - vector/index cleanup hooks
       - final WP7 acceptance and promotion
 
@@ -48,16 +37,11 @@ active:
     role: module
     assigned_agent: acceptance-agent
     branch: agent/m03-wp8-acceptance
-    base_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     module: m03_acceptance
     status: sync-required-planning-only-waiting-on-wp7
     writes:
       - docs/milestones/M03/WP8-ACCEPTANCE-MATRIX.md
       - ai-native/parallel/checkpoints/M03-WP8.md
-    future_executable_writes:
-      - packages/python-core/tests/**
-      - apps/api/tests/**
-      - apps/worker/tests/**
     shared_requests: []
     depends_on:
       - M03-WP7
@@ -66,14 +50,13 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     last_acknowledged_broadcast: 4
-    required_broadcast: 7
+    required_broadcast: 8
 
   - task_id: M04-PARALLEL-LANE
     title: Character and Entity Library planning/contracts
     role: planning-contract
     assigned_agent: character-agent
     branch: agent/m04-character-library
-    base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: characters_entities
     status: sync-required-planning-only
     writes:
@@ -87,14 +70,13 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 7
+    required_broadcast: 8
 
   - task_id: M05-PARALLEL-LANE
     title: Content Intelligence and Memory planning/contracts
     role: planning-contract
     assigned_agent: content-agent
     branch: agent/m05-content-memory
-    base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: content_memory
     status: sync-required-planning-only
     writes:
@@ -108,14 +90,13 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 7
+    required_broadcast: 8
 
   - task_id: M06-PARALLEL-LANE
     title: Hybrid Audio Production planning/contracts
     role: planning-contract
     assigned_agent: audio-agent
     branch: agent/m06-audio-production
-    base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: audio
     status: sync-required-planning-only
     writes:
@@ -129,14 +110,13 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 7
+    required_broadcast: 8
 
   - task_id: M07-PARALLEL-LANE
     title: Storyboard and Timeline planning/contracts
     role: planning-contract
     assigned_agent: timeline-agent
     branch: agent/m07-storyboard-timeline
-    base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: timeline_storyboard
     status: sync-required-planning-only
     writes:
@@ -152,14 +132,13 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 7
+    required_broadcast: 8
 
   - task_id: M08-PARALLEL-LANE
     title: Hybrid Image/Video Provider Router planning/contracts
     role: planning-contract
     assigned_agent: provider-agent
     branch: agent/m08-video-provider-router
-    base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: providers
     status: sync-required-planning-only
     writes:
@@ -174,14 +153,13 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 7
+    required_broadcast: 8
 
   - task_id: CROSS-CUTTING-QA
     title: Cross-cutting adversarial QA and security
     role: qa
     assigned_agent: qa-security-agent
     branch: agent/cross-cutting-qa-security
-    base_sha: 486c294f7be53aad49ee362465968e766a80899a
     module: media_qa
     status: sync-required-active-audit-planning
     writes:
@@ -195,16 +173,13 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 7
+    required_broadcast: 8
 
 rules:
   - Supervisor owns updates to this registry and all merge decisions.
   - Completed/merged task branches are retired or replaced before a next bounded executable slice begins.
   - Before claiming a new task, compare its write set with every active entry.
   - Overlapping active write claims block parallel execution unless Supervisor splits/reassigns ownership.
-  - future_executable_writes are non-authoritative until the task is explicitly promoted to executable status.
-  - Planning lanes use dedicated milestone directories and one exact per-task checkpoint file; broad shared checkpoint globs are forbidden.
-  - Every resume must revalidate branch head, base/current main, dependencies, working instructions, broadcasts, slots, and consent.
-  - Every ready submission must announce exactly Work Done and Submitted.
+  - Every resume revalidates current main, dependencies, working instructions, broadcasts, slots, migration state, write ownership, and consent.
+  - Every ready submission announces exactly Work Done and Submitted.
   - A mandatory unacknowledged Supervisor broadcast puts the task into sync-required state and blocks promotion.
-  - Future milestone branches may exist before executable readiness but must remain planning/contract-only until entry and consent gates allow implementation.

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -12,77 +12,13 @@
     "completed_submission_branch_must_be_retired_or_replaced": true
   },
   "slots": [
-    {
-      "slot_id": "SUPERVISOR-M03-WP7",
-      "module": "asset_lifecycle",
-      "branch": "supervisor/m03-wp7-export-staging",
-      "status": "occupied",
-      "assigned_agent": "supervisor-agent",
-      "accepts_new_agent": false,
-      "start_status": "active-export-staging"
-    },
-    {
-      "slot_id": "M03-WP8",
-      "module": "m03_acceptance",
-      "branch": "agent/m03-wp8-acceptance",
-      "status": "occupied",
-      "assigned_agent": "acceptance-agent",
-      "accepts_new_agent": true,
-      "start_status": "planning-only-waiting-on-wp7"
-    },
-    {
-      "slot_id": "M04-CHARACTER",
-      "module": "characters_entities",
-      "branch": "agent/m04-character-library",
-      "status": "occupied",
-      "assigned_agent": "character-agent",
-      "accepts_new_agent": true,
-      "start_status": "planning-only"
-    },
-    {
-      "slot_id": "M05-CONTENT",
-      "module": "content_memory",
-      "branch": "agent/m05-content-memory",
-      "status": "occupied",
-      "assigned_agent": "content-agent",
-      "accepts_new_agent": true,
-      "start_status": "planning-only"
-    },
-    {
-      "slot_id": "M06-AUDIO",
-      "module": "audio",
-      "branch": "agent/m06-audio-production",
-      "status": "occupied",
-      "assigned_agent": "audio-agent",
-      "accepts_new_agent": true,
-      "start_status": "planning-only"
-    },
-    {
-      "slot_id": "M07-TIMELINE",
-      "module": "timeline_storyboard",
-      "branch": "agent/m07-storyboard-timeline",
-      "status": "occupied",
-      "assigned_agent": "timeline-agent",
-      "accepts_new_agent": true,
-      "start_status": "planning-only"
-    },
-    {
-      "slot_id": "M08-PROVIDER",
-      "module": "providers",
-      "branch": "agent/m08-video-provider-router",
-      "status": "occupied",
-      "assigned_agent": "provider-agent",
-      "accepts_new_agent": true,
-      "start_status": "planning-only"
-    },
-    {
-      "slot_id": "CROSS-CUTTING-QA",
-      "module": "media_qa",
-      "branch": "agent/cross-cutting-qa-security",
-      "status": "occupied",
-      "assigned_agent": "qa-security-agent",
-      "accepts_new_agent": true,
-      "start_status": "active-audit-planning"
-    }
+    {"slot_id":"SUPERVISOR-M03-WP7","module":"asset_lifecycle","branch":"supervisor/m03-wp7-vector-index-cleanup","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-vector-index-cleanup"},
+    {"slot_id":"M03-WP8","module":"m03_acceptance","branch":"agent/m03-wp8-acceptance","status":"occupied","assigned_agent":"acceptance-agent","accepts_new_agent":true,"start_status":"planning-only-waiting-on-wp7"},
+    {"slot_id":"M04-CHARACTER","module":"characters_entities","branch":"agent/m04-character-library","status":"occupied","assigned_agent":"character-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"M07-TIMELINE","module":"timeline_storyboard","branch":"agent/m07-storyboard-timeline","status":"occupied","assigned_agent":"timeline-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"M08-PROVIDER","module":"providers","branch":"agent/m08-video-provider-router","status":"occupied","assigned_agent":"provider-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"CROSS-CUTTING-QA","module":"media_qa","branch":"agent/cross-cutting-qa-security","status":"occupied","assigned_agent":"qa-security-agent","accepts_new_agent":true,"start_status":"active-audit-planning"}
   ]
 }

--- a/ai-native/parallel/MIGRATION-REGISTRY.yaml
+++ b/ai-native/parallel/MIGRATION-REGISTRY.yaml
@@ -7,13 +7,7 @@ policy:
   migration_dependency_must_match_landed_or_declared_parent: true
   merge_alert_requires_migration_revalidation: true
 
-reservations:
-  - revision: 20260901_0016
-    task_id: M03-WP7
-    branch: supervisor/m03-wp7-export-staging
-    parent_revision: 20260901_0015
-    purpose: durable export staging object provenance and expiry authority
-    status: reserved
+reservations: []
 
 landed:
   - revision: 20260901_0015
@@ -26,14 +20,22 @@ landed:
     submitted_head_sha: 745cc22e5680e164aa875631190c30b1c50aba76
     landed_main_sha: 8ed99a094cb443b789929d71c468464e2e0bb72a
     status: landed
+  - revision: 20260901_0016
+    task_id: M03-WP7
+    branch: supervisor/m03-wp7-export-staging
+    continuation_branch: supervisor/m03-wp7-vector-index-cleanup
+    parent_revision: 20260901_0015
+    purpose: durable export staging object provenance and expiry authority
+    merged_pr: 61
+    submitted_head_sha: 2c0d4ab48e128af68f92c923567631c72ef1c20b
+    landed_main_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
+    status: landed
 
 next_allocation:
   rule: supervisor-assigns-next-unique-revision-after-current-main-and-active-reservations-are-reconciled
-  current_landed_head: 20260901_0015
+  current_landed_head: 20260901_0016
 
 notes:
   - Never infer the next revision only from the current branch; inspect current main plus active reservations.
-  - Parallel migrations may require an explicit dependency/merge ordering even when their SQL domains are independent.
-  - If a branch synchronizes after another migration lands, Supervisor decides whether to renumber/re-parent before promotion.
-  - Every mandatory post-merge alert forces migration-owning agents to revalidate parent revision and reservation before resuming.
-  - Landed revisions are history, not active reservations, and do not block allocation of the next unique revision.
+  - Landed revisions are history, not active reservations.
+  - The current vector/index cleanup slice has no migration reservation.

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,199 +1,67 @@
 version: 4
-latest_sequence: 7
+latest_sequence: 8
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
   - sequence: 1
-    trigger: supervisor-merge
     merged_pr: 49
     merged_branch: supervisor/multi-agent-workflow-v2
-    submitted_head_sha: 3f2d486d51e64666e3eb40673061c7257f707405
     merged_main_sha: 8ccf33d07974bba80f9b7dedfd4b51419f0618a8
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-working-instruction-sync
-    changed_areas:
-      - README working instructions
-      - Supervisor/parallel coordination protocol and state
-      - active work and dependency registries
-      - migration reservation ownership metadata
-      - shared-file and contract coordination authority
-    contract_changes: []
-    schema_migration_changes: []
-    recipients:
-      - supervisor/m03-wp7-retention
-      - agent/m03-wp8-acceptance
-      - agent/m04-character-library
-      - agent/m05-content-memory
-      - agent/m06-audio-production
-      - agent/m07-storyboard-timeline
-      - agent/m08-video-provider-router
-      - agent/cross-cutting-qa-security
-    mandatory: true
-
   - sequence: 2
-    trigger: supervisor-merge
     merged_pr: 50
     merged_branch: supervisor/new-agent-onboarding
-    submitted_head_sha: 3dfd7c88d35c224cdfd60a70023105a9a446c2bc
     merged_main_sha: 75a8fb19a797dfcc329f1c229d4b0688be9789c9
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-new-agent-onboarding-sync
-    changed_areas:
-      - new agent must start from main
-      - Supervisor module slot assignment authority
-      - AGENT-SLOTS.json occupancy registry
-      - exact Go Home Come Back Next Time no-slot behavior
-      - Repository Governance parallel-state validator
-      - README working instructions
-    contract_changes: []
-    schema_migration_changes: []
-    recipients:
-      - supervisor/m03-wp7-retention
-      - agent/m03-wp8-acceptance
-      - agent/m04-character-library
-      - agent/m05-content-memory
-      - agent/m06-audio-production
-      - agent/m07-storyboard-timeline
-      - agent/m08-video-provider-router
-      - agent/cross-cutting-qa-security
-    mandatory: true
-
   - sequence: 3
-    trigger: supervisor-merge
     merged_pr: 51
     merged_branch: supervisor/m03-wp7-retention
-    submitted_head_sha: 745cc22e5680e164aa875631190c30b1c50aba76
     merged_main_sha: 8ed99a094cb443b789929d71c468464e2e0bb72a
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-asset-lifecycle-contract-sync
-    changed_areas:
-      - M03-WP7 durable asset lifecycle state authority
-      - migration 20260901_0015
-      - lifecycle persistence and public exports
-      - archive/restore and deletion scheduling contract
-      - migration-chain tests
-      - Supervisor WP7 continuation branch retirement/replacement
-      - parallel write-scope reconciliation
-    contract_changes:
-      - AssetLifecycleState
-      - AssetLifecycleSnapshot
-      - AssetLifecycleEvent
-      - PostgresAssetLifecycleRepository
     schema_migration_changes:
       - 20260901_0015
-    recipients:
-      - supervisor/m03-wp7-retention-continuation
-      - agent/m03-wp8-acceptance
-      - agent/m04-character-library
-      - agent/m05-content-memory
-      - agent/m06-audio-production
-      - agent/m07-storyboard-timeline
-      - agent/m08-video-provider-router
-      - agent/cross-cutting-qa-security
-    mandatory: true
-
   - sequence: 4
-    trigger: supervisor-merge
     merged_pr: 52
     merged_branch: supervisor/parallel-governance-hardening
-    submitted_head_sha: 31454da596ee590e443452cba98139bf80384029
     merged_main_sha: a8e987ce8e0697fdff5bf891e82daec2b28dd096
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-parallel-governance-hardening-sync
-    changed_areas:
-      - fail-closed active write-claim collision validation
-      - exact occupied slot to active task branch/agent/module validation
-      - stale broadcast acknowledgement validation
-      - Supervisor open-slot count validation
-      - active and landed migration consistency validation
-      - synthetic governance validator self-tests
-    contract_changes: []
-    schema_migration_changes: []
-    recipients:
-      - supervisor/m03-wp7-retention-continuation
-      - agent/m03-wp8-acceptance
-      - agent/m04-character-library
-      - agent/m05-content-memory
-      - agent/m06-audio-production
-      - agent/m07-storyboard-timeline
-      - agent/m08-video-provider-router
-      - agent/cross-cutting-qa-security
-    mandatory: true
-
   - sequence: 5
-    trigger: supervisor-merge
     merged_pr: 55
     merged_branch: supervisor/m03-wp7-retention-continuation
-    submitted_head_sha: 843f431ec85b798957e4c5cbb1cad06798b28a4d
     merged_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-supervisor-reconciliation-sync
-    changed_areas:
-      - Supervisor state reconciliation after PR 54
-      - WP7 remaining-scope authority
-      - WP8 planning dependency state
-    contract_changes: []
-    schema_migration_changes: []
-    recipients:
-      - supervisor/m03-wp7-deletion-execution
-      - agent/m03-wp8-acceptance
-      - agent/m04-character-library
-      - agent/m05-content-memory
-      - agent/m06-audio-production
-      - agent/m07-storyboard-timeline
-      - agent/m08-video-provider-router
-      - agent/cross-cutting-qa-security
-    mandatory: true
-
   - sequence: 6
-    trigger: supervisor-merge
     merged_pr: 57
     merged_branch: supervisor/m03-wp7-deletion-execution
-    submitted_head_sha: da0e67a9297956ab34b664a736d6739d4742996a
     merged_main_sha: 6e892e3417788d2fc9a1ea0a91cfc5d44ce47be6
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-wp7-deletion-execution-sync
-    changed_areas:
-      - approved deletion propagation execution
-      - fail-closed live-plan and lifecycle revision binding
-      - storage integrity verification before purge
-      - idempotent partial-retry semantics
-      - share-link revocation and derivative cancellation propagation
-      - Supervisor branch/slot/plan reconciliation
-    contract_changes:
-      - deletion execution internal primitive
-    schema_migration_changes: []
-    recipients:
-      - supervisor/m03-wp7-temp-cleanup
-      - agent/m03-wp8-acceptance
-      - agent/m04-character-library
-      - agent/m05-content-memory
-      - agent/m06-audio-production
-      - agent/m07-storyboard-timeline
-      - agent/m08-video-provider-router
-      - agent/cross-cutting-qa-security
-    mandatory: true
-
   - sequence: 7
-    trigger: supervisor-merge
     merged_pr: 59
     merged_branch: supervisor/m03-wp7-temp-cleanup
     submitted_head_sha: a46f2d80d4d5022e62bcbdf3294d4fc489a7fe6f
     merged_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
     alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-wp7-temp-cleanup-sync
+  - sequence: 8
+    trigger: supervisor-merge
+    merged_pr: 61
+    merged_branch: supervisor/m03-wp7-export-staging
+    submitted_head_sha: 2c0d4ab48e128af68f92c923567631c72ef1c20b
+    merged_main_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-wp7-export-staging-sync
     changed_areas:
-      - bounded abandoned upload and quarantine cleanup
-      - explicit terminal grace-window enforcement
-      - canonical storage identity and location collision guard
-      - idempotent filesystem cleanup
-      - S3 multipart abort-before-delete behavior
-      - Supervisor branch and ownership reconciliation
+      - deterministic private export staging namespace and source integrity checks
+      - durable export staging provenance and expiry authority
+      - migration 20260901_0016
+      - reversible migration chain coverage
+      - Supervisor branch and migration ownership reconciliation
     contract_changes:
-      - temporary cleanup internal primitive
-    schema_migration_changes: []
+      - export staging internal primitive
+    schema_migration_changes:
+      - 20260901_0016
     recipients:
-      - supervisor/m03-wp7-export-staging
+      - supervisor/m03-wp7-vector-index-cleanup
       - agent/m03-wp8-acceptance
       - agent/m04-character-library
       - agent/m05-content-memory
@@ -204,50 +72,47 @@ broadcasts:
     mandatory: true
 
 recipient_states:
-  supervisor/m03-wp7-export-staging:
+  supervisor/m03-wp7-vector-index-cleanup:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 7
-    last_synced_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
+    last_acknowledged_sequence: 8
+    last_synced_main_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
   agent/m03-wp8-acceptance:
     state: sync-required
-    required_sequence: 7
+    required_sequence: 8
     last_acknowledged_sequence: 4
     last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
   agent/m04-character-library:
     state: sync-required
-    required_sequence: 7
+    required_sequence: 8
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m05-content-memory:
     state: sync-required
-    required_sequence: 7
+    required_sequence: 8
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m06-audio-production:
     state: sync-required
-    required_sequence: 7
+    required_sequence: 8
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m07-storyboard-timeline:
     state: sync-required
-    required_sequence: 7
+    required_sequence: 8
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m08-video-provider-router:
     state: sync-required
-    required_sequence: 7
+    required_sequence: 8
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/cross-cutting-qa-security:
     state: sync-required
-    required_sequence: 7
+    required_sequence: 8
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
 
 rules:
   - Supervisor increments latest_sequence after every successful promotion merge to main that active agents must observe.
-  - Each broadcast records merged branch/PR, new main SHA, affected contracts/migrations/shared files, recipients, and mandatory/advisory sync classification.
-  - Mandatory recipients become sync-required until they acknowledge the sequence and record the synchronized main SHA.
-  - An agent must inspect this registry on every start/resume and before announcing Work Done and Submitted.
-  - If a recipient branch was created from the broadcast main SHA or later and is unaffected, Supervisor may mark acknowledgement satisfied without a redundant merge.
+  - Mandatory recipients become sync-required until synchronization is recorded.

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -2,7 +2,7 @@
 
 ## Authority
 
-The Supervisor owns assignment, coordination-state mutation, review order, and promotion to `main`. New executable slices always start from current `main`; completed executable branches are retired before the next bounded slice.
+The Supervisor owns assignment, coordination-state mutation, review order, and promotion to `main`. New executable slices start from current `main`; completed executable branches are retired before the next bounded slice.
 
 New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after Supervisor assignment. All defined slots are currently occupied, so an additional arrival receives exactly **Go Home Come Back Next Time**.
 
@@ -10,7 +10,7 @@ New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after S
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03-WP7 Supervisor | `supervisor-agent` | `supervisor/m03-wp7-export-staging` | active export-staging slice |
+| M03-WP7 Supervisor | `supervisor-agent` | `supervisor/m03-wp7-vector-index-cleanup` | active bounded vector/index cleanup hooks |
 | M03-WP8 | `acceptance-agent` | `agent/m03-wp8-acceptance` | sync-required planning-only |
 | M04 Character | `character-agent` | `agent/m04-character-library` | sync-required planning-only |
 | M05 Content | `content-agent` | `agent/m05-content-memory` | sync-required planning-only |
@@ -21,51 +21,35 @@ New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after S
 
 ## Current Supervisor slice
 
-PR #59 landed bounded temporary cleanup at `main@f78a855f0b20dd150af93190b25bffbe6e1a0856`. Branch `supervisor/m03-wp7-temp-cleanup` is retired for new executable work.
+PR #61 landed bounded private export staging at `main@98e6808ec4034b93a4f1b417563f27866c6e91de`. Migration `20260901_0016` is landed history and the export-staging branch is retired for new executable work.
 
-Issue #60 runs on `supervisor/m03-wp7-export-staging`, created from that exact main. Migration `20260901_0016` is reserved with parent `20260901_0015` because existing `storage_objects` metadata cannot durably represent both export-source provenance and bounded expiry.
+Issue #62 runs on `supervisor/m03-wp7-vector-index-cleanup`, created from that exact main. This slice adds deterministic vector/index cleanup-hook contracts only. Hooks must be explicit, project-scoped, idempotent, auditable, and fail closed on asset/project/revision identity mismatch. No direct external vector/database credentials, provider spend, broad index mutation, hidden side effects, public delivery authority, or unrelated milestone work is authorized.
 
-Authoritative writes are limited to:
-- `packages/python-core/src/lullabies_core/export_staging.py`
-- `packages/python-core/src/lullabies_core/persistence/export_staging.py`
-- `packages/python-core/migrations/versions/20260901_0016_export_staging.py`
-- `packages/python-core/migrations/sql/0016_export_staging_up.sql`
-- `packages/python-core/migrations/sql/0016_export_staging_down.sql`
-- `packages/python-core/tests/test_export_staging.py`
-- `packages/python-core/tests/test_migrations.py`
+Authoritative implementation writes are limited to:
+- `packages/python-core/src/lullabies_core/index_cleanup.py`
+- `packages/python-core/tests/test_index_cleanup.py`
 
-Export staging must remain private and must not widen signed delivery, share-link, or public publishing authority. Stage/reuse is bound to project, source storage identity, source SHA-256, deterministic staging object identity/key, and expiry. Conflicting reuse fails closed. No vector/index cleanup, provider spend, production credential, release, or public endpoint work is authorized in this slice.
+No migration is reserved for this slice. If durable execution state proves necessary, implementation stops and the Supervisor must first reserve a new migration revision.
 
 ## Parallel safety
 
-`ACTIVE-WORK.yaml` is authoritative for write claims. Overlapping authoritative write claims block execution. `future_executable_writes` are informational only. Migration reservations must be recorded before files are created.
-
-All non-Supervisor occupied lanes are currently sync-required by broadcast 7 and cannot seek promotion until synchronization is recorded.
-
-Planning path ownership remains:
-- M04: `docs/milestones/M04/**` and `ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md`
-- M05: `docs/milestones/M05/**` and `ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md`
-- M06: `docs/milestones/M06/**` and `ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md`
-- M07: `docs/milestones/M07/**` and `ai-native/parallel/checkpoints/M07-PARALLEL-LANE.md`
-- M08: `docs/milestones/M08/**` and `ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md`
-- QA: `docs/qa/**` and `ai-native/parallel/checkpoints/CROSS-CUTTING-QA.md`
+`ACTIVE-WORK.yaml` is authoritative for write claims. Overlapping authoritative write claims block execution. All non-Supervisor occupied lanes are sync-required by broadcast 8 and cannot seek promotion until synchronization is recorded.
 
 ## Merge order
 
-1. `supervisor/m03-wp7-export-staging`
-2. fresh bounded M03-WP7 vector/index cleanup branch
-3. M03-WP8 acceptance after synchronization and WP7 completion
-4. M03 close/reconciliation
-5. later milestones according to dependency/consent gates
+1. `supervisor/m03-wp7-vector-index-cleanup`
+2. M03-WP8 acceptance after synchronization and WP7 completion
+3. M03 close/reconciliation
+4. later milestones according to dependency/consent gates
 
 ## Completion and review
 
 Every ready bounded submission announces exactly **Work Done and Submitted**. That signal means ready for Supervisor review, not merged.
 
-Before promotion, the Supervisor verifies exact head/base, write ownership, migration reservation, dependency/consent state, tests, security/data implications, current-main freshness, and unresolved review findings. Required exact-head CI must be green.
+Before promotion, the Supervisor verifies exact head/base, write ownership, migration state, dependency/consent state, tests, security/data implications, current-main freshness, and unresolved review findings. Required exact-head CI must be green.
 
 After a successful promotion, emit exactly:
 
 > **New changes have been merged — please merge these changes into your branch first, then resume your own work.**
 
-Then update `SUPERVISOR-BROADCASTS.yaml`, `SUPERVISOR-STATE.yaml`, slot/active registries, migration state, and affected branch synchronization before the next executable slice starts.
+Then reconcile broadcasts, state, slots, active work, migration state, and affected branch synchronization before the next executable slice starts.

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -2,18 +2,18 @@ version: 5
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: f78a855f0b20dd150af93190b25bffbe6e1a0856
-  main_sha_last_reconciled: f78a855f0b20dd150af93190b25bffbe6e1a0856
+  main_sha_last_promotion: 98e6808ec4034b93a4f1b417563f27866c6e91de
+  main_sha_last_reconciled: 98e6808ec4034b93a4f1b417563f27866c6e91de
   own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-export-staging
+  own_branch: supervisor/m03-wp7-vector-index-cleanup
   current_mode: feature-development
   completion_signal: Work Done and Submitted
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 59
-  submitted_head_sha: a46f2d80d4d5022e62bcbdf3294d4fc489a7fe6f
-  merged_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
+  pr: 61
+  submitted_head_sha: 2c0d4ab48e128af68f92c923567631c72ef1c20b
+  merged_main_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
   result: success
 
 new_agent_onboarding:
@@ -22,29 +22,6 @@ new_agent_onboarding:
   assignment_authority: supervisor
   current_open_slots: 0
   no_slot_response: Go Home Come Back Next Time
-  actions:
-    - new-agent-starts-from-main
-    - supervisor-loads-slot-registry-and-supervisor-plan
-    - assign-first-valid-open-slot-or-reject
-    - update-slot-and-plan-before-agent-work
-    - agent-checks-out-assigned-branch-only-after-assignment
-  rejection_behavior:
-    stop_agent_immediately: true
-    branch_assignment: false
-    work_permitted: false
-
-interrupt_policy:
-  enabled: true
-  trigger: agent-submission-ready
-  required_signal: Work Done and Submitted
-  actions:
-    - checkpoint-supervisor-work
-    - review-submission
-    - reject-with-fixes-or-promote
-    - exact-head-ci-before-executable-merge
-    - merge-to-main
-    - emit-sync-broadcast
-    - restore-supervisor-checkpoint
 
 pause_checkpoint:
   active: false
@@ -58,7 +35,7 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 7
+  latest_broadcast_sequence: 8
   agents_with_mandatory_sync:
     - agent/m03-wp8-acceptance
     - agent/m04-character-library
@@ -71,12 +48,9 @@ synchronization:
 
 rules:
   - The Supervisor reviews and merges incoming module PRs; module agents do not merge themselves.
-  - Supervisor implementation occurs on its own bounded module branch, never by mixing feature work directly into main.
-  - A completed submission branch is retired or replaced before the Supervisor starts the next bounded slice.
-  - A new agent always begins onboarding from main and may not self-assign a module or branch.
-  - Supervisor assigns only a slot whose AGENT-SLOTS.json status is open and accepts_new_agent is true.
-  - If no eligible open slot exists, Supervisor replies exactly Go Home Come Back Next Time and the agent starts no work.
-  - A submission signal means ready for review, not merged or production-ready.
-  - Supervisor records pause state before interrupting its own feature work.
-  - Every successful promotion merge produces a broadcast record before Supervisor resumes feature implementation.
-  - Main SHA, queue state, slot state, migration state, write ownership, and broadcast state are reconciled after every promotion event.
+  - Supervisor implementation occurs on its own bounded module branch, never directly on main.
+  - Completed submission branches are retired or replaced before the next bounded slice.
+  - New agents begin from main and may not self-assign.
+  - If no eligible open slot exists, respond exactly Go Home Come Back Next Time and assign no work.
+  - Every successful promotion merge produces a broadcast before feature implementation resumes.
+  - Main SHA, slot state, migration state, write ownership, and broadcast state are reconciled after every promotion.

--- a/packages/python-core/src/lullabies_core/index_cleanup.py
+++ b/packages/python-core/src/lullabies_core/index_cleanup.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import StrEnum
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from .common import AssetId, ProjectId, StrictModel
+from .deletion_execution import DeletionPropagationExecutionResult
+
+
+class IndexCleanupPlanningError(RuntimeError):
+    """Vector/index cleanup work cannot be represented safely."""
+
+
+class IndexCleanupReceiptError(RuntimeError):
+    """Cleanup receipts do not prove the exact approved cleanup set."""
+
+
+class IndexCleanupTargetKind(StrEnum):
+    VECTOR_RECORD = "vector-record"
+    SEARCH_DOCUMENT = "search-document"
+
+
+class IndexCleanupTarget(StrictModel):
+    """Provider-neutral identity of one vector/index record that should be removed."""
+
+    kind: IndexCleanupTargetKind
+    namespace: str = Field(min_length=1, max_length=200)
+    record_key: str = Field(min_length=1, max_length=512)
+
+    @model_validator(mode="after")
+    def validate_identity(self) -> IndexCleanupTarget:
+        for name, value in (("namespace", self.namespace), ("record_key", self.record_key)):
+            if value != value.strip():
+                raise ValueError(f"index cleanup {name} must not contain surrounding whitespace")
+            if any(ord(character) < 32 for character in value):
+                raise ValueError(f"index cleanup {name} must not contain control characters")
+        return self
+
+    def identity(self) -> tuple[str, str, str]:
+        return (self.kind.value, self.namespace, self.record_key)
+
+
+class IndexCleanupHook(StrictModel):
+    """One deterministic, idempotent cleanup instruction for a future executor."""
+
+    target: IndexCleanupTarget
+    idempotency_key: str = Field(pattern=r"^index-cleanup:[a-f0-9]{64}$")
+
+
+class AssetIndexCleanupPlan(StrictModel):
+    """Auditable provider-neutral cleanup hooks bound to completed hard deletion."""
+
+    asset_id: AssetId
+    project_id: ProjectId
+    deletion_plan_fingerprint: str = Field(pattern=r"^[a-f0-9]{64}$")
+    deletion_final_revision: int = Field(ge=2)
+    planned_at: AwareDatetime
+    hooks: list[IndexCleanupHook] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_hooks(self) -> AssetIndexCleanupPlan:
+        identities = [hook.target.identity() for hook in self.hooks]
+        if identities != sorted(identities):
+            raise ValueError("index cleanup hooks must be ordered by canonical target identity")
+        if len(identities) != len(set(identities)):
+            raise ValueError("index cleanup hooks must not repeat a canonical target")
+        for hook in self.hooks:
+            expected = index_cleanup_idempotency_key(
+                project_id=self.project_id,
+                asset_id=self.asset_id,
+                deletion_plan_fingerprint=self.deletion_plan_fingerprint,
+                deletion_final_revision=self.deletion_final_revision,
+                target=hook.target,
+            )
+            if hook.idempotency_key != expected:
+                raise ValueError("index cleanup idempotency key does not match plan binding")
+        return self
+
+    def fingerprint(self) -> str:
+        payload = self.model_dump(mode="json", exclude={"planned_at"})
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+class IndexCleanupReceiptStatus(StrEnum):
+    DELETED = "deleted"
+    ALREADY_ABSENT = "already-absent"
+
+
+class IndexCleanupReceipt(StrictModel):
+    idempotency_key: str = Field(pattern=r"^index-cleanup:[a-f0-9]{64}$")
+    status: IndexCleanupReceiptStatus
+
+
+class IndexCleanupCompletion(StrictModel):
+    plan_fingerprint: str = Field(pattern=r"^[a-f0-9]{64}$")
+    receipts: list[IndexCleanupReceipt]
+
+
+def index_cleanup_idempotency_key(
+    *,
+    project_id: str,
+    asset_id: str,
+    deletion_plan_fingerprint: str,
+    deletion_final_revision: int,
+    target: IndexCleanupTarget,
+) -> str:
+    payload = {
+        "asset_id": asset_id,
+        "deletion_final_revision": deletion_final_revision,
+        "deletion_plan_fingerprint": deletion_plan_fingerprint,
+        "kind": target.kind.value,
+        "namespace": target.namespace,
+        "project_id": project_id,
+        "record_key": target.record_key,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return f"index-cleanup:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()}"
+
+
+def build_index_cleanup_plan(
+    deletion: DeletionPropagationExecutionResult,
+    *,
+    targets: list[IndexCleanupTarget],
+    planned_at: AwareDatetime,
+) -> AssetIndexCleanupPlan:
+    """Create explicit cleanup hooks after hard-delete propagation has succeeded.
+
+    This function causes no provider mutation. The deletion result is the authority for
+    project, asset, approved-plan fingerprint, and final lifecycle revision. A future
+    executor can use each deterministic idempotency key and report either ``deleted`` or
+    ``already-absent`` without widening this core contract to provider credentials.
+    """
+
+    identities = [target.identity() for target in targets]
+    if len(identities) != len(set(identities)):
+        raise IndexCleanupPlanningError("duplicate vector/index cleanup target")
+
+    ordered = sorted(targets, key=lambda target: target.identity())
+    hooks = [
+        IndexCleanupHook(
+            target=target,
+            idempotency_key=index_cleanup_idempotency_key(
+                project_id=deletion.project_id,
+                asset_id=deletion.asset_id,
+                deletion_plan_fingerprint=deletion.plan_fingerprint,
+                deletion_final_revision=deletion.final_revision,
+                target=target,
+            ),
+        )
+        for target in ordered
+    ]
+    return AssetIndexCleanupPlan(
+        asset_id=deletion.asset_id,
+        project_id=deletion.project_id,
+        deletion_plan_fingerprint=deletion.plan_fingerprint,
+        deletion_final_revision=deletion.final_revision,
+        planned_at=planned_at,
+        hooks=hooks,
+    )
+
+
+def validate_index_cleanup_receipts(
+    plan: AssetIndexCleanupPlan,
+    receipts: list[IndexCleanupReceipt],
+) -> IndexCleanupCompletion:
+    """Accept only an exact, duplicate-free terminal receipt set for the approved hooks."""
+
+    expected = [hook.idempotency_key for hook in plan.hooks]
+    observed = [receipt.idempotency_key for receipt in receipts]
+    if len(observed) != len(set(observed)):
+        raise IndexCleanupReceiptError("index cleanup receipts repeat an idempotency key")
+    if set(observed) != set(expected):
+        missing = sorted(set(expected) - set(observed))
+        unexpected = sorted(set(observed) - set(expected))
+        raise IndexCleanupReceiptError(
+            f"index cleanup receipt set mismatch; missing={missing}; unexpected={unexpected}"
+        )
+    ordered = sorted(receipts, key=lambda receipt: receipt.idempotency_key)
+    return IndexCleanupCompletion(plan_fingerprint=plan.fingerprint(), receipts=ordered)

--- a/packages/python-core/tests/test_index_cleanup.py
+++ b/packages/python-core/tests/test_index_cleanup.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from lullabies_core.deletion_execution import DeletionPropagationExecutionResult
+from lullabies_core.index_cleanup import (
+    AssetIndexCleanupPlan,
+    IndexCleanupHook,
+    IndexCleanupPlanningError,
+    IndexCleanupReceipt,
+    IndexCleanupReceiptError,
+    IndexCleanupReceiptStatus,
+    IndexCleanupTarget,
+    IndexCleanupTargetKind,
+    build_index_cleanup_plan,
+    validate_index_cleanup_receipts,
+)
+
+
+def deletion_result(
+    *,
+    fingerprint: str = "a" * 64,
+    final_revision: int = 5,
+) -> DeletionPropagationExecutionResult:
+    return DeletionPropagationExecutionResult(
+        asset_id="AST-001701",
+        project_id="PRJ-001701",
+        plan_fingerprint=fingerprint,
+        deleted_storage_object_ids=("STO-001701",),
+        already_absent_storage_object_ids=(),
+        revoked_share_link_ids=(),
+        already_inactive_share_link_ids=(),
+        cancelled_derivative_record_ids=(),
+        already_terminal_derivative_record_ids=(),
+        final_revision=final_revision,
+    )
+
+
+def vector_target() -> IndexCleanupTarget:
+    return IndexCleanupTarget(
+        kind=IndexCleanupTargetKind.VECTOR_RECORD,
+        namespace="asset-embeddings-v1",
+        record_key="AST-001701:embedding",
+    )
+
+
+def search_target() -> IndexCleanupTarget:
+    return IndexCleanupTarget(
+        kind=IndexCleanupTargetKind.SEARCH_DOCUMENT,
+        namespace="asset-search-v1",
+        record_key="AST-001701",
+    )
+
+
+def test_build_index_cleanup_plan_is_ordered_stable_and_provider_neutral() -> None:
+    planned_at = datetime(2026, 9, 5, 12, 0, tzinfo=UTC)
+    deletion = deletion_result()
+
+    plan = build_index_cleanup_plan(
+        deletion,
+        targets=[vector_target(), search_target()],
+        planned_at=planned_at,
+    )
+
+    assert plan.asset_id == deletion.asset_id
+    assert plan.project_id == deletion.project_id
+    assert plan.deletion_plan_fingerprint == deletion.plan_fingerprint
+    assert plan.deletion_final_revision == deletion.final_revision
+    assert [hook.target.identity() for hook in plan.hooks] == sorted(
+        [vector_target().identity(), search_target().identity()]
+    )
+    assert all(hook.idempotency_key.startswith("index-cleanup:") for hook in plan.hooks)
+
+    later = build_index_cleanup_plan(
+        deletion,
+        targets=[search_target(), vector_target()],
+        planned_at=planned_at + timedelta(minutes=10),
+    )
+    assert [hook.idempotency_key for hook in later.hooks] == [
+        hook.idempotency_key for hook in plan.hooks
+    ]
+    assert later.fingerprint() == plan.fingerprint()
+
+
+def test_deletion_binding_changes_cleanup_idempotency_keys() -> None:
+    planned_at = datetime(2026, 9, 5, 12, 0, tzinfo=UTC)
+    first = build_index_cleanup_plan(
+        deletion_result(fingerprint="a" * 64, final_revision=5),
+        targets=[vector_target()],
+        planned_at=planned_at,
+    )
+    changed_fingerprint = build_index_cleanup_plan(
+        deletion_result(fingerprint="b" * 64, final_revision=5),
+        targets=[vector_target()],
+        planned_at=planned_at,
+    )
+    changed_revision = build_index_cleanup_plan(
+        deletion_result(fingerprint="a" * 64, final_revision=6),
+        targets=[vector_target()],
+        planned_at=planned_at,
+    )
+
+    assert first.hooks[0].idempotency_key != changed_fingerprint.hooks[0].idempotency_key
+    assert first.hooks[0].idempotency_key != changed_revision.hooks[0].idempotency_key
+
+
+def test_duplicate_cleanup_targets_fail_closed() -> None:
+    with pytest.raises(IndexCleanupPlanningError, match="duplicate"):
+        build_index_cleanup_plan(
+            deletion_result(),
+            targets=[vector_target(), vector_target()],
+            planned_at=datetime(2026, 9, 5, 12, 0, tzinfo=UTC),
+        )
+
+
+def test_target_identity_rejects_ambiguous_whitespace_and_controls() -> None:
+    with pytest.raises(ValidationError, match="surrounding whitespace"):
+        IndexCleanupTarget(
+            kind=IndexCleanupTargetKind.VECTOR_RECORD,
+            namespace=" asset-embeddings-v1",
+            record_key="AST-001701",
+        )
+    with pytest.raises(ValidationError, match="control characters"):
+        IndexCleanupTarget(
+            kind=IndexCleanupTargetKind.SEARCH_DOCUMENT,
+            namespace="asset-search-v1",
+            record_key="AST-001701\nother",
+        )
+
+
+def test_plan_rejects_tampered_idempotency_key() -> None:
+    plan = build_index_cleanup_plan(
+        deletion_result(),
+        targets=[vector_target()],
+        planned_at=datetime(2026, 9, 5, 12, 0, tzinfo=UTC),
+    )
+    tampered = IndexCleanupHook(
+        target=plan.hooks[0].target,
+        idempotency_key=f"index-cleanup:{'f' * 64}",
+    )
+
+    with pytest.raises(ValidationError, match="does not match plan binding"):
+        AssetIndexCleanupPlan(
+            asset_id=plan.asset_id,
+            project_id=plan.project_id,
+            deletion_plan_fingerprint=plan.deletion_plan_fingerprint,
+            deletion_final_revision=plan.deletion_final_revision,
+            planned_at=plan.planned_at,
+            hooks=[tampered],
+        )
+
+
+def test_receipts_must_prove_exact_terminal_hook_set() -> None:
+    plan = build_index_cleanup_plan(
+        deletion_result(),
+        targets=[vector_target(), search_target()],
+        planned_at=datetime(2026, 9, 5, 12, 0, tzinfo=UTC),
+    )
+    receipts = [
+        IndexCleanupReceipt(
+            idempotency_key=plan.hooks[1].idempotency_key,
+            status=IndexCleanupReceiptStatus.ALREADY_ABSENT,
+        ),
+        IndexCleanupReceipt(
+            idempotency_key=plan.hooks[0].idempotency_key,
+            status=IndexCleanupReceiptStatus.DELETED,
+        ),
+    ]
+
+    completion = validate_index_cleanup_receipts(plan, receipts)
+    assert completion.plan_fingerprint == plan.fingerprint()
+    assert [receipt.idempotency_key for receipt in completion.receipts] == sorted(
+        hook.idempotency_key for hook in plan.hooks
+    )
+
+    with pytest.raises(IndexCleanupReceiptError, match="mismatch"):
+        validate_index_cleanup_receipts(plan, receipts[:1])
+
+    with pytest.raises(IndexCleanupReceiptError, match="repeat"):
+        validate_index_cleanup_receipts(plan, [receipts[0], receipts[0]])
+
+    unexpected = IndexCleanupReceipt(
+        idempotency_key=f"index-cleanup:{'0' * 64}",
+        status=IndexCleanupReceiptStatus.DELETED,
+    )
+    with pytest.raises(IndexCleanupReceiptError, match="unexpected"):
+        validate_index_cleanup_receipts(plan, [receipts[0], unexpected])
+
+
+def test_planned_at_must_be_timezone_aware() -> None:
+    with pytest.raises(ValidationError):
+        build_index_cleanup_plan(
+            deletion_result(),
+            targets=[vector_target()],
+            planned_at=datetime(2026, 9, 5, 12, 0),
+        )


### PR DESCRIPTION
Implements Issue #62 as the final bounded M03-WP7 lifecycle primitive before WP8 acceptance.

Safety contract:
- cleanup hooks are provider-neutral plans, not hidden external mutations;
- hooks are created only from a successful deletion-propagation execution result;
- asset/project identity, approved deletion-plan fingerprint, and final lifecycle revision are bound into every deterministic idempotency key;
- vector/search targets are explicit logical namespace + record identities and are canonicalized/sorted;
- duplicate targets fail closed;
- cleanup receipts must prove the exact approved hook set and may report only terminal `deleted` or `already-absent` states;
- changing deletion fingerprint or final revision changes the idempotency authority;
- no external vector/search credentials, provider spend, broad index mutation, schema migration, public endpoint, or unrelated milestone scope is included.

Post-PR #61 reconciliation records migration `20260901_0016` as landed, emits mandatory broadcast sequence 8, retires the export-staging branch for executable work, and moves the Supervisor slot/write ownership to this bounded branch.

Issue: #62

Work Done and Submitted