### PR TITLE
M03-WP7: close implementation and hand off WP8 acceptance

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -4,33 +4,29 @@ supervisor:
   assigned_agent: supervisor-agent
   main_branch: main
   review_and_merge_authority: true
-  own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-vector-index-cleanup
+  own_task_id: M03-WP7-CLOSEOUT
+  own_branch: supervisor/m03-wp7-closeout
 
 active:
-  - task_id: M03-WP7
-    title: Retention/archive/delete/export/vector cleanup primitives
+  - task_id: M03-WP7-CLOSEOUT
+    title: M03-WP7 closeout and WP8 handoff
     role: supervisor-module
     assigned_agent: supervisor-agent
-    branch: supervisor/m03-wp7-vector-index-cleanup
-    base_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
+    branch: supervisor/m03-wp7-closeout
+    base_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
     module: asset_lifecycle
-    status: active-vector-index-cleanup
+    status: active-wp7-closeout
     writes:
-      - packages/python-core/src/lullabies_core/index_cleanup.py
-      - packages/python-core/tests/test_index_cleanup.py
+      - ai-native/parallel/checkpoints/M03-WP7-CLOSEOUT.md
     shared_requests: []
     depends_on:
-      - M03-WP6
+      - M03-WP7
     migration_reservation: null
-    consent_scope: M03
+    consent_scope: M03-governance-closeout
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
-    last_acknowledged_broadcast: 8
+    last_synced_main_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
+    last_acknowledged_broadcast: 9
     required_broadcast: null
-    remaining_scope:
-      - vector/index cleanup hooks
-      - final WP7 acceptance and promotion
 
   - task_id: M03-WP8
     title: M03 end-to-end acceptance
@@ -38,19 +34,19 @@ active:
     assigned_agent: acceptance-agent
     branch: agent/m03-wp8-acceptance
     module: m03_acceptance
-    status: sync-required-planning-only-waiting-on-wp7
+    status: sync-required-planning-only-waiting-on-wp7-closeout
     writes:
       - docs/milestones/M03/WP8-ACCEPTANCE-MATRIX.md
       - ai-native/parallel/checkpoints/M03-WP8.md
     shared_requests: []
     depends_on:
-      - M03-WP7
+      - M03-WP7-CLOSEOUT
     migration_reservation: null
     consent_scope: M03
     completion_signal: Work Done and Submitted
     last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
     last_acknowledged_broadcast: 4
-    required_broadcast: 8
+    required_broadcast: 9
 
   - task_id: M04-PARALLEL-LANE
     title: Character and Entity Library planning/contracts
@@ -70,7 +66,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 8
+    required_broadcast: 9
 
   - task_id: M05-PARALLEL-LANE
     title: Content Intelligence and Memory planning/contracts
@@ -90,7 +86,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 8
+    required_broadcast: 9
 
   - task_id: M06-PARALLEL-LANE
     title: Hybrid Audio Production planning/contracts
@@ -110,7 +106,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 8
+    required_broadcast: 9
 
   - task_id: M07-PARALLEL-LANE
     title: Storyboard and Timeline planning/contracts
@@ -132,7 +128,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 8
+    required_broadcast: 9
 
   - task_id: M08-PARALLEL-LANE
     title: Hybrid Image/Video Provider Router planning/contracts
@@ -153,7 +149,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 8
+    required_broadcast: 9
 
   - task_id: CROSS-CUTTING-QA
     title: Cross-cutting adversarial QA and security
@@ -173,13 +169,12 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 8
+    required_broadcast: 9
 
 rules:
   - Supervisor owns updates to this registry and all merge decisions.
-  - Completed/merged task branches are retired or replaced before a next bounded executable slice begins.
-  - Before claiming a new task, compare its write set with every active entry.
-  - Overlapping active write claims block parallel execution unless Supervisor splits/reassigns ownership.
-  - Every resume revalidates current main, dependencies, working instructions, broadcasts, slots, migration state, write ownership, and consent.
+  - Completed/merged executable branches are retired or replaced before the next bounded executable slice.
+  - Overlapping active write claims block parallel execution.
+  - Every resume revalidates current main, dependencies, broadcasts, slots, migration state, write ownership, and consent.
   - Every ready submission announces exactly Work Done and Submitted.
   - A mandatory unacknowledged Supervisor broadcast puts the task into sync-required state and blocks promotion.

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -12,8 +12,8 @@
     "completed_submission_branch_must_be_retired_or_replaced": true
   },
   "slots": [
-    {"slot_id":"SUPERVISOR-M03-WP7","module":"asset_lifecycle","branch":"supervisor/m03-wp7-vector-index-cleanup","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-vector-index-cleanup"},
-    {"slot_id":"M03-WP8","module":"m03_acceptance","branch":"agent/m03-wp8-acceptance","status":"occupied","assigned_agent":"acceptance-agent","accepts_new_agent":true,"start_status":"planning-only-waiting-on-wp7"},
+    {"slot_id":"SUPERVISOR-M03-WP7","module":"asset_lifecycle","branch":"supervisor/m03-wp7-closeout","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-wp7-closeout"},
+    {"slot_id":"M03-WP8","module":"m03_acceptance","branch":"agent/m03-wp8-acceptance","status":"occupied","assigned_agent":"acceptance-agent","accepts_new_agent":true,"start_status":"planning-only-waiting-on-wp7-closeout"},
     {"slot_id":"M04-CHARACTER","module":"characters_entities","branch":"agent/m04-character-library","status":"occupied","assigned_agent":"character-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
 version: 4
-latest_sequence: 8
+latest_sequence: 9
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -38,30 +38,34 @@ broadcasts:
   - sequence: 7
     merged_pr: 59
     merged_branch: supervisor/m03-wp7-temp-cleanup
-    submitted_head_sha: a46f2d80d4d5022e62bcbdf3294d4fc489a7fe6f
     merged_main_sha: f78a855f0b20dd150af93190b25bffbe6e1a0856
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-wp7-temp-cleanup-sync
   - sequence: 8
-    trigger: supervisor-merge
     merged_pr: 61
     merged_branch: supervisor/m03-wp7-export-staging
     submitted_head_sha: 2c0d4ab48e128af68f92c923567631c72ef1c20b
     merged_main_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-wp7-export-staging-sync
-    changed_areas:
-      - deterministic private export staging namespace and source integrity checks
-      - durable export staging provenance and expiry authority
-      - migration 20260901_0016
-      - reversible migration chain coverage
-      - Supervisor branch and migration ownership reconciliation
-    contract_changes:
-      - export staging internal primitive
     schema_migration_changes:
       - 20260901_0016
+  - sequence: 9
+    trigger: supervisor-merge
+    merged_pr: 63
+    merged_branch: supervisor/m03-wp7-vector-index-cleanup
+    submitted_head_sha: 359b6173d062b48128b1722e8f6340262b5fee5e
+    merged_main_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-wp7-vector-index-cleanup-sync
+    changed_areas:
+      - provider-neutral deterministic vector and search cleanup hooks
+      - deletion-result fingerprint and final-revision idempotency binding
+      - exact terminal receipt-set validation
+      - Supervisor WP7 closeout and WP8 handoff requirement
+    contract_changes:
+      - index cleanup internal primitive
+    schema_migration_changes: []
     recipients:
-      - supervisor/m03-wp7-vector-index-cleanup
+      - supervisor/m03-wp7-closeout
       - agent/m03-wp8-acceptance
       - agent/m04-character-library
       - agent/m05-content-memory
@@ -72,44 +76,44 @@ broadcasts:
     mandatory: true
 
 recipient_states:
-  supervisor/m03-wp7-vector-index-cleanup:
+  supervisor/m03-wp7-closeout:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 8
-    last_synced_main_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
+    last_acknowledged_sequence: 9
+    last_synced_main_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
   agent/m03-wp8-acceptance:
     state: sync-required
-    required_sequence: 8
+    required_sequence: 9
     last_acknowledged_sequence: 4
     last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
   agent/m04-character-library:
     state: sync-required
-    required_sequence: 8
+    required_sequence: 9
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m05-content-memory:
     state: sync-required
-    required_sequence: 8
+    required_sequence: 9
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m06-audio-production:
     state: sync-required
-    required_sequence: 8
+    required_sequence: 9
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m07-storyboard-timeline:
     state: sync-required
-    required_sequence: 8
+    required_sequence: 9
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m08-video-provider-router:
     state: sync-required
-    required_sequence: 8
+    required_sequence: 9
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/cross-cutting-qa-security:
     state: sync-required
-    required_sequence: 8
+    required_sequence: 9
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
 

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -2,7 +2,7 @@
 
 ## Authority
 
-The Supervisor owns assignment, coordination-state mutation, review order, and promotion to `main`. New executable slices start from current `main`; completed executable branches are retired before the next bounded slice.
+The Supervisor owns assignment, coordination-state mutation, review order, and promotion to `main`. New executable slices start from current `main`; completed branches are retired before the next bounded slice.
 
 New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after Supervisor assignment. All defined slots are currently occupied, so an additional arrival receives exactly **Go Home Come Back Next Time**.
 
@@ -10,8 +10,8 @@ New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after S
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03-WP7 Supervisor | `supervisor-agent` | `supervisor/m03-wp7-vector-index-cleanup` | active bounded vector/index cleanup hooks |
-| M03-WP8 | `acceptance-agent` | `agent/m03-wp8-acceptance` | sync-required planning-only |
+| M03-WP7 Closeout | `supervisor-agent` | `supervisor/m03-wp7-closeout` | governance-only closeout/handoff |
+| M03-WP8 | `acceptance-agent` | `agent/m03-wp8-acceptance` | sync-required planning-only until closeout lands |
 | M04 Character | `character-agent` | `agent/m04-character-library` | sync-required planning-only |
 | M05 Content | `content-agent` | `agent/m05-content-memory` | sync-required planning-only |
 | M06 Audio | `audio-agent` | `agent/m06-audio-production` | sync-required planning-only |
@@ -19,37 +19,29 @@ New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after S
 | M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | sync-required planning-only |
 | QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security` | sync-required audit/planning |
 
-## Current Supervisor slice
+## WP7 closeout
 
-PR #61 landed bounded private export staging at `main@98e6808ec4034b93a4f1b417563f27866c6e91de`. Migration `20260901_0016` is landed history and the export-staging branch is retired for new executable work.
+PR #63 landed deterministic provider-neutral vector/index cleanup hooks at `main@4a898d0465382c62ae911a4d7f4581b4fdd2d60c`. The bounded WP7 implementation sequence now includes lifecycle state/retention, deletion planning/execution, temporary cleanup, private export staging, and vector/index cleanup hooks. Migrations `20260901_0015` and `20260901_0016` are landed; no active migration reservation remains.
 
-Issue #62 runs on `supervisor/m03-wp7-vector-index-cleanup`, created from that exact main. This slice adds deterministic vector/index cleanup-hook contracts only. Hooks must be explicit, project-scoped, idempotent, auditable, and fail closed on asset/project/revision identity mismatch. No direct external vector/database credentials, provider spend, broad index mutation, hidden side effects, public delivery authority, or unrelated milestone work is authorized.
+Issue #64 on `supervisor/m03-wp7-closeout` records mandatory broadcast 9 and the handoff checkpoint only. No product/API/schema/provider change is authorized.
 
-Authoritative implementation writes are limited to:
-- `packages/python-core/src/lullabies_core/index_cleanup.py`
-- `packages/python-core/tests/test_index_cleanup.py`
-
-No migration is reserved for this slice. If durable execution state proves necessary, implementation stops and the Supervisor must first reserve a new migration revision.
+After this closeout lands, `agent/m03-wp8-acceptance` may synchronize to the resulting current main and move from planning-only to bounded executable acceptance. Source acceptance may run, but final M03 governance/promotion remains blocked by Issue #36 until live GitHub main protection/ruleset evidence exists.
 
 ## Parallel safety
 
-`ACTIVE-WORK.yaml` is authoritative for write claims. Overlapping authoritative write claims block execution. All non-Supervisor occupied lanes are sync-required by broadcast 8 and cannot seek promotion until synchronization is recorded.
+`ACTIVE-WORK.yaml` is authoritative for write claims. Overlapping authoritative write claims block execution. All non-Supervisor lanes are sync-required by broadcast 9 and cannot seek promotion until synchronization is recorded.
 
 ## Merge order
 
-1. `supervisor/m03-wp7-vector-index-cleanup`
-2. M03-WP8 acceptance after synchronization and WP7 completion
-3. M03 close/reconciliation
+1. `supervisor/m03-wp7-closeout`
+2. synchronized `agent/m03-wp8-acceptance`
+3. M03 close/reconciliation only after acceptance and external governance gate evaluation
 4. later milestones according to dependency/consent gates
 
 ## Completion and review
 
-Every ready bounded submission announces exactly **Work Done and Submitted**. That signal means ready for Supervisor review, not merged.
-
-Before promotion, the Supervisor verifies exact head/base, write ownership, migration state, dependency/consent state, tests, security/data implications, current-main freshness, and unresolved review findings. Required exact-head CI must be green.
+Every ready bounded submission announces exactly **Work Done and Submitted**. Before promotion, the Supervisor verifies exact head/base, write ownership, migration state, dependency/consent state, tests, security/data implications, current-main freshness, and unresolved review findings. Required exact-head CI must be green.
 
 After a successful promotion, emit exactly:
 
 > **New changes have been merged — please merge these changes into your branch first, then resume your own work.**
-
-Then reconcile broadcasts, state, slots, active work, migration state, and affected branch synchronization before the next executable slice starts.

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -2,18 +2,18 @@ version: 5
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 98e6808ec4034b93a4f1b417563f27866c6e91de
-  main_sha_last_reconciled: 98e6808ec4034b93a4f1b417563f27866c6e91de
-  own_task_id: M03-WP7
-  own_branch: supervisor/m03-wp7-vector-index-cleanup
-  current_mode: feature-development
+  main_sha_last_promotion: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
+  main_sha_last_reconciled: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
+  own_task_id: M03-WP7-CLOSEOUT
+  own_branch: supervisor/m03-wp7-closeout
+  current_mode: governance-closeout
   completion_signal: Work Done and Submitted
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 61
-  submitted_head_sha: 2c0d4ab48e128af68f92c923567631c72ef1c20b
-  merged_main_sha: 98e6808ec4034b93a4f1b417563f27866c6e91de
+  pr: 63
+  submitted_head_sha: 359b6173d062b48128b1722e8f6340262b5fee5e
+  merged_main_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
   result: success
 
 new_agent_onboarding:
@@ -35,7 +35,7 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 8
+  latest_broadcast_sequence: 9
   agents_with_mandatory_sync:
     - agent/m03-wp8-acceptance
     - agent/m04-character-library
@@ -48,7 +48,7 @@ synchronization:
 
 rules:
   - The Supervisor reviews and merges incoming module PRs; module agents do not merge themselves.
-  - Supervisor implementation occurs on its own bounded module branch, never directly on main.
+  - Supervisor implementation occurs on its own bounded branch, never directly on main.
   - Completed submission branches are retired or replaced before the next bounded slice.
   - New agents begin from main and may not self-assign.
   - If no eligible open slot exists, respond exactly Go Home Come Back Next Time and assign no work.

--- a/ai-native/parallel/checkpoints/M03-WP7-CLOSEOUT.md
+++ b/ai-native/parallel/checkpoints/M03-WP7-CLOSEOUT.md
@@ -1,0 +1,34 @@
+# M03-WP7 Closeout and WP8 Handoff
+
+## Authority
+
+- Current protected source baseline for this closeout: `main@4a898d0465382c62ae911a4d7f4581b4fdd2d60c`.
+- This checkpoint is governance/evidence only. It introduces no product, API, schema, provider, credential, or cost-bearing behavior.
+
+## Landed WP7 implementation evidence
+
+- PR #51 — durable asset lifecycle state/retention authority; migration `20260901_0015` landed.
+- PR #57 — approved deletion propagation execution with live-plan/revision/storage-integrity guards.
+- PR #59 — bounded terminal temporary upload/quarantine cleanup.
+- PR #61 — deterministic private export staging with durable provenance/expiry; migration `20260901_0016` landed.
+- PR #63 — deterministic provider-neutral vector/search cleanup hooks bound to completed deletion evidence.
+
+Both WP7 migrations `20260901_0015` and `20260901_0016` are landed history. No active migration reservation remains.
+
+## Parallel handoff state
+
+- Mandatory post-PR #63 broadcast sequence: `9`.
+- Supervisor closeout branch is synchronized to current main and broadcast 9.
+- `agent/m03-wp8-acceptance` was audited after PR #63 and had `ahead_by=0`; therefore it contains no unique commits that would be lost by a later safe fast-forward to the post-closeout main.
+- WP8 remains sync-required/planning-only until this closeout merges and its resulting post-merge broadcast is acknowledged.
+- Other occupied planning/QA lanes remain sync-required and cannot seek promotion on stale heads.
+
+## Remaining external governance boundary
+
+Issue #36 remains open. Live GitHub ruleset read-back still returns `[]`, so source-side green governance checks are not evidence that `main` protection is actually enforced. WP8 source acceptance may proceed after synchronization, but final M03 governance/promotion must not be claimed complete until Issue #36 has live administrator configuration/read-back evidence.
+
+## Exit statement
+
+The bounded M03-WP7 source implementation is complete and ready to hand off to M03-WP8 source acceptance after this governance closeout lands.
+
+Work Done and Submitted


### PR DESCRIPTION
Governance-only closeout for Issue #64 after the bounded M03-WP7 implementation sequence landed through PR #63.

This PR:
- records mandatory post-PR #63 broadcast sequence 9;
- retires the vector/index implementation branch from executable authority and moves the Supervisor slot to the closeout branch;
- records migrations `20260901_0015` and `20260901_0016` as landed with no active reservation;
- records the WP7 closeout checkpoint and the safe WP8 handoff boundary;
- keeps `agent/m03-wp8-acceptance` sync-required/planning-only until this closeout merges;
- preserves every other occupied planning/QA lane as sync-required;
- makes no product, API, schema, provider, credential, or cost-bearing change.

WP8 source acceptance may proceed after synchronization. Final M03 governance/promotion remains blocked by Issue #36 because live repository ruleset read-back still returns `[]`.

Issue: #64

Work Done and Submitted