### PR TITLE
chore(supervisor): reconcile broadcast 10 and activate WP8 acceptance

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -1,40 +1,41 @@
-version: 5
+version: 6
 supervisor:
   role: supervisor
   assigned_agent: supervisor-agent
   main_branch: main
   review_and_merge_authority: true
-  own_task_id: M03-WP7-CLOSEOUT
-  own_branch: supervisor/m03-wp7-closeout
+  own_task_id: M03-WP8-REVIEW
+  own_branch: supervisor/m03-wp8-review
 
 active:
-  - task_id: M03-WP7-CLOSEOUT
-    title: M03-WP7 closeout and WP8 handoff
-    role: supervisor-module
+  - task_id: M03-WP8-REVIEW
+    title: M03-WP8 acceptance review and promotion authority
+    role: supervisor-review
     assigned_agent: supervisor-agent
-    branch: supervisor/m03-wp7-closeout
-    base_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
-    module: asset_lifecycle
-    status: active-wp7-closeout
+    branch: supervisor/m03-wp8-review
+    base_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
+    module: m03_acceptance_review
+    status: active-review-only
     writes:
-      - ai-native/parallel/checkpoints/M03-WP7-CLOSEOUT.md
+      - ai-native/parallel/checkpoints/M03-WP8-REVIEW.md
     shared_requests: []
     depends_on:
-      - M03-WP7
+      - M03-WP7-CLOSEOUT
     migration_reservation: null
-    consent_scope: M03-governance-closeout
+    consent_scope: M03-review-and-promotion
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
-    last_acknowledged_broadcast: 9
+    last_synced_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
+    last_acknowledged_broadcast: 10
     required_broadcast: null
 
   - task_id: M03-WP8
-    title: M03 end-to-end acceptance
+    title: M03 end-to-end source acceptance
     role: module
     assigned_agent: acceptance-agent
-    branch: agent/m03-wp8-acceptance
+    branch: agent/m03-wp8-acceptance-v2
+    base_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
     module: m03_acceptance
-    status: sync-required-planning-only-waiting-on-wp7-closeout
+    status: active-acceptance
     writes:
       - docs/milestones/M03/WP8-ACCEPTANCE-MATRIX.md
       - ai-native/parallel/checkpoints/M03-WP8.md
@@ -42,11 +43,11 @@ active:
     depends_on:
       - M03-WP7-CLOSEOUT
     migration_reservation: null
-    consent_scope: M03
+    consent_scope: M03-source-acceptance-only
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
-    last_acknowledged_broadcast: 4
-    required_broadcast: 9
+    last_synced_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
+    last_acknowledged_broadcast: 10
+    required_broadcast: null
 
   - task_id: M04-PARALLEL-LANE
     title: Character and Entity Library planning/contracts
@@ -66,7 +67,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 9
+    required_broadcast: 10
 
   - task_id: M05-PARALLEL-LANE
     title: Content Intelligence and Memory planning/contracts
@@ -86,7 +87,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 9
+    required_broadcast: 10
 
   - task_id: M06-PARALLEL-LANE
     title: Hybrid Audio Production planning/contracts
@@ -106,7 +107,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 9
+    required_broadcast: 10
 
   - task_id: M07-PARALLEL-LANE
     title: Storyboard and Timeline planning/contracts
@@ -128,7 +129,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 9
+    required_broadcast: 10
 
   - task_id: M08-PARALLEL-LANE
     title: Hybrid Image/Video Provider Router planning/contracts
@@ -149,7 +150,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 9
+    required_broadcast: 10
 
   - task_id: CROSS-CUTTING-QA
     title: Cross-cutting adversarial QA and security
@@ -169,7 +170,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 9
+    required_broadcast: 10
 
 rules:
   - Supervisor owns updates to this registry and all merge decisions.

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -12,8 +12,8 @@
     "completed_submission_branch_must_be_retired_or_replaced": true
   },
   "slots": [
-    {"slot_id":"SUPERVISOR-M03-WP7","module":"asset_lifecycle","branch":"supervisor/m03-wp7-closeout","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-wp7-closeout"},
-    {"slot_id":"M03-WP8","module":"m03_acceptance","branch":"agent/m03-wp8-acceptance","status":"occupied","assigned_agent":"acceptance-agent","accepts_new_agent":true,"start_status":"planning-only-waiting-on-wp7-closeout"},
+    {"slot_id":"SUPERVISOR-M03-WP8-REVIEW","module":"m03_acceptance_review","branch":"supervisor/m03-wp8-review","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-review-only"},
+    {"slot_id":"M03-WP8","module":"m03_acceptance","branch":"agent/m03-wp8-acceptance-v2","status":"occupied","assigned_agent":"acceptance-agent","accepts_new_agent":true,"start_status":"active-acceptance"},
     {"slot_id":"M04-CHARACTER","module":"characters_entities","branch":"agent/m04-character-library","status":"occupied","assigned_agent":"character-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
-version: 4
-latest_sequence: 9
+version: 5
+latest_sequence: 10
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -49,24 +49,30 @@ broadcasts:
     schema_migration_changes:
       - 20260901_0016
   - sequence: 9
-    trigger: supervisor-merge
     merged_pr: 63
     merged_branch: supervisor/m03-wp7-vector-index-cleanup
     submitted_head_sha: 359b6173d062b48128b1722e8f6340262b5fee5e
     merged_main_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-wp7-vector-index-cleanup-sync
+    schema_migration_changes: []
+  - sequence: 10
+    trigger: supervisor-merge
+    merged_pr: 65
+    merged_branch: supervisor/m03-wp7-closeout
+    submitted_head_sha: 615ac1d287f2773a09d15ac74a390dcb0ccb4d47
+    merged_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-wp7-closeout-wp8-handoff-sync
     changed_areas:
-      - provider-neutral deterministic vector and search cleanup hooks
-      - deletion-result fingerprint and final-revision idempotency binding
-      - exact terminal receipt-set validation
-      - Supervisor WP7 closeout and WP8 handoff requirement
-    contract_changes:
-      - index cleanup internal primitive
+      - WP7 implementation closeout checkpoint
+      - migrations 20260901_0015 and 20260901_0016 confirmed landed
+      - M03-WP8 source acceptance unblocked
+      - Supervisor review authority separated from acceptance-agent writes
+    contract_changes: []
     schema_migration_changes: []
     recipients:
-      - supervisor/m03-wp7-closeout
-      - agent/m03-wp8-acceptance
+      - supervisor/m03-wp8-review
+      - agent/m03-wp8-acceptance-v2
       - agent/m04-character-library
       - agent/m05-content-memory
       - agent/m06-audio-production
@@ -76,44 +82,44 @@ broadcasts:
     mandatory: true
 
 recipient_states:
-  supervisor/m03-wp7-closeout:
+  supervisor/m03-wp8-review:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 9
-    last_synced_main_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
-  agent/m03-wp8-acceptance:
-    state: sync-required
-    required_sequence: 9
-    last_acknowledged_sequence: 4
-    last_synced_main_sha: ddaf0547e1804945c6a585220f499b8efa614e5a
+    last_acknowledged_sequence: 10
+    last_synced_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
+  agent/m03-wp8-acceptance-v2:
+    state: synchronized
+    required_sequence: null
+    last_acknowledged_sequence: 10
+    last_synced_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
   agent/m04-character-library:
     state: sync-required
-    required_sequence: 9
+    required_sequence: 10
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m05-content-memory:
     state: sync-required
-    required_sequence: 9
+    required_sequence: 10
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m06-audio-production:
     state: sync-required
-    required_sequence: 9
+    required_sequence: 10
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m07-storyboard-timeline:
     state: sync-required
-    required_sequence: 9
+    required_sequence: 10
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m08-video-provider-router:
     state: sync-required
-    required_sequence: 9
+    required_sequence: 10
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/cross-cutting-qa-security:
     state: sync-required
-    required_sequence: 9
+    required_sequence: 10
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
 

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -2,16 +2,16 @@
 
 ## Authority
 
-The Supervisor owns assignment, coordination-state mutation, review order, and promotion to `main`. New executable slices start from current `main`; completed branches are retired before the next bounded slice.
+The Supervisor owns assignment, coordination-state mutation, review order, and promotion to `main`. New executable slices start from current `main`; completed or superseded branches are retired before the next bounded slice.
 
-New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after Supervisor assignment. All defined slots are currently occupied, so an additional arrival receives exactly **Go Home Come Back Next Time**.
+New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after Supervisor assignment. All defined slots are occupied, so an additional arrival receives exactly **Go Home Come Back Next Time**.
 
 ## Current branch matrix
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03-WP7 Closeout | `supervisor-agent` | `supervisor/m03-wp7-closeout` | governance-only closeout/handoff |
-| M03-WP8 | `acceptance-agent` | `agent/m03-wp8-acceptance` | sync-required planning-only until closeout lands |
+| M03-WP8 Review | `supervisor-agent` | `supervisor/m03-wp8-review` | active review/promotion authority only |
+| M03-WP8 Acceptance | `acceptance-agent` | `agent/m03-wp8-acceptance-v2` | active source acceptance |
 | M04 Character | `character-agent` | `agent/m04-character-library` | sync-required planning-only |
 | M05 Content | `content-agent` | `agent/m05-content-memory` | sync-required planning-only |
 | M06 Audio | `audio-agent` | `agent/m06-audio-production` | sync-required planning-only |
@@ -19,28 +19,40 @@ New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after S
 | M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | sync-required planning-only |
 | QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security` | sync-required audit/planning |
 
-## WP7 closeout
+The earlier `agent/m03-wp8-acceptance` branch is retired for executable work after a partial pre-reconciliation slot edit. It is not promotion authority and will not be force-reset. `agent/m03-wp8-acceptance-v2` is the clean current-main acceptance branch.
 
-PR #63 landed deterministic provider-neutral vector/index cleanup hooks at `main@4a898d0465382c62ae911a4d7f4581b4fdd2d60c`. The bounded WP7 implementation sequence now includes lifecycle state/retention, deletion planning/execution, temporary cleanup, private export staging, and vector/index cleanup hooks. Migrations `20260901_0015` and `20260901_0016` are landed; no active migration reservation remains.
+## M03 transition state
 
-Issue #64 on `supervisor/m03-wp7-closeout` records mandatory broadcast 9 and the handoff checkpoint only. No product/API/schema/provider change is authorized.
+PR #65 closed WP7 at `main@38b182f4ea886b48c4249aacf362fb58546bd3f5`. Broadcast 10 records that merge and unblocks bounded WP8 source acceptance. Migrations `20260901_0015` and `20260901_0016` remain landed; there is no active M03 migration reservation.
 
-After this closeout lands, `agent/m03-wp8-acceptance` may synchronize to the resulting current main and move from planning-only to bounded executable acceptance. Source acceptance may run, but final M03 governance/promotion remains blocked by Issue #36 until live GitHub main protection/ruleset evidence exists.
+WP8 may create only the canonical acceptance matrix/checkpoint and genuinely missing acceptance tests if the evidence audit proves a gap. Existing focused evidence already covers multipart restart/resume and lost-ack recovery, cross-project delivery denial and signer mismatch, malicious/MIME-spoof quarantine rejection, provenance/hash integrity, archive/restore, deletion propagation, temporary cleanup, export staging, and vector/index cleanup hooks.
+
+No product/API/schema/provider expansion, external provider credential, production bucket, or cost-bearing action is authorized by WP8.
+
+## External governance boundary
+
+Issue #36 remains open because live GitHub repository ruleset read-back does not prove protected `main`. WP8 source acceptance may be merged when its exact-head source checks are green, but that merge must not claim final M03 protected-main governance completion while Issue #36 is unresolved.
 
 ## Parallel safety
 
-`ACTIVE-WORK.yaml` is authoritative for write claims. Overlapping authoritative write claims block execution. All non-Supervisor lanes are sync-required by broadcast 9 and cannot seek promotion until synchronization is recorded.
+`ACTIVE-WORK.yaml` is authoritative for active write claims. The acceptance agent owns only:
+
+- `docs/milestones/M03/WP8-ACCEPTANCE-MATRIX.md`
+- `ai-native/parallel/checkpoints/M03-WP8.md`
+
+The Supervisor review lane owns only `ai-native/parallel/checkpoints/M03-WP8-REVIEW.md`. Other lanes remain disjoint and sync-required by broadcast 10.
 
 ## Merge order
 
-1. `supervisor/m03-wp7-closeout`
-2. synchronized `agent/m03-wp8-acceptance`
-3. M03 close/reconciliation only after acceptance and external governance gate evaluation
-4. later milestones according to dependency/consent gates
+1. `supervisor/m03-wp8-review` coordination reconciliation
+2. fast-forward `agent/m03-wp8-acceptance-v2` to the resulting current main
+3. `agent/m03-wp8-acceptance-v2` source acceptance submission
+4. Supervisor exact-head review and merge when all required source checks are green
+5. final M03 governance close only after Issue #36 live protection evidence is satisfied
 
 ## Completion and review
 
-Every ready bounded submission announces exactly **Work Done and Submitted**. Before promotion, the Supervisor verifies exact head/base, write ownership, migration state, dependency/consent state, tests, security/data implications, current-main freshness, and unresolved review findings. Required exact-head CI must be green.
+Every ready bounded submission announces exactly **Work Done and Submitted**. Before promotion, the Supervisor verifies exact head/base, current-main freshness, write ownership, migration state, consent/dependencies, tests, security/data implications, and unresolved review findings. Required exact-head CI must be green.
 
 After a successful promotion, emit exactly:
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -1,19 +1,19 @@
-version: 5
+version: 6
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
-  main_sha_last_reconciled: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
-  own_task_id: M03-WP7-CLOSEOUT
-  own_branch: supervisor/m03-wp7-closeout
-  current_mode: governance-closeout
+  main_sha_last_promotion: 38b182f4ea886b48c4249aacf362fb58546bd3f5
+  main_sha_last_reconciled: 38b182f4ea886b48c4249aacf362fb58546bd3f5
+  own_task_id: M03-WP8-REVIEW
+  own_branch: supervisor/m03-wp8-review
+  current_mode: acceptance-review
   completion_signal: Work Done and Submitted
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 63
-  submitted_head_sha: 359b6173d062b48128b1722e8f6340262b5fee5e
-  merged_main_sha: 4a898d0465382c62ae911a4d7f4581b4fdd2d60c
+  pr: 65
+  submitted_head_sha: 615ac1d287f2773a09d15ac74a390dcb0ccb4d47
+  merged_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
   result: success
 
 new_agent_onboarding:
@@ -32,12 +32,15 @@ pause_checkpoint:
   next_action: null
   reason: null
 
-review_queue: []
+review_queue:
+  - task_id: M03-WP8
+    branch: agent/m03-wp8-acceptance-v2
+    state: awaiting-submission
+    exact_head_sha: null
 
 synchronization:
-  latest_broadcast_sequence: 9
+  latest_broadcast_sequence: 10
   agents_with_mandatory_sync:
-    - agent/m03-wp8-acceptance
     - agent/m04-character-library
     - agent/m05-content-memory
     - agent/m06-audio-production
@@ -45,6 +48,11 @@ synchronization:
     - agent/m08-video-provider-router
     - agent/cross-cutting-qa-security
   policy: branches-with-unacknowledged-mandatory-broadcast-cannot-seek-promotion
+
+external_gates:
+  m03_main_protection_issue: 36
+  status: not-verified
+  effect: source acceptance may complete; final M03 governance/promotion may not claim protected-main completion
 
 rules:
   - The Supervisor reviews and merges incoming module PRs; module agents do not merge themselves.


### PR DESCRIPTION
Governance-only reconciliation after merged WP7 closeout PR #65 / `main@38b182f4ea886b48c4249aacf362fb58546bd3f5`.

This PR:
- records mandatory post-merge broadcast sequence 10 for PR #65;
- retires the partially edited `agent/m03-wp8-acceptance` branch without force-resetting it;
- assigns clean current-main branch `agent/m03-wp8-acceptance-v2` to bounded M03-WP8 source acceptance;
- separates Supervisor review/promotion authority onto `supervisor/m03-wp8-review`;
- limits acceptance writes to the canonical WP8 matrix/checkpoint and review writes to a separate review checkpoint;
- preserves all later milestone/QA lanes as sync-required and collision-free;
- records Issue #36 as the unresolved external protected-main governance gate;
- makes no product/API/schema/provider/credential/cost-bearing change.

After this PR lands, acceptance-v2 will fast-forward to resulting main and Issue #66 source acceptance can execute.

Work Done and Submitted