### PR TITLE
M03: reconcile WP8 completion and external governance hold

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -1,52 +1,31 @@
-version: 6
+version: 7
 supervisor:
   role: supervisor
   assigned_agent: supervisor-agent
   main_branch: main
   review_and_merge_authority: true
-  own_task_id: M03-WP8-REVIEW
-  own_branch: supervisor/m03-wp8-review
+  own_task_id: M03-GOV-HOLD
+  own_branch: supervisor/m03-wp8-closeout
 
 active:
-  - task_id: M03-WP8-REVIEW
-    title: M03-WP8 acceptance review and promotion authority
-    role: supervisor-review
+  - task_id: M03-GOV-HOLD
+    title: M03 post-WP8 governance hold
+    role: supervisor-governance
     assigned_agent: supervisor-agent
-    branch: supervisor/m03-wp8-review
-    base_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
-    module: m03_acceptance_review
-    status: active-review-only
+    branch: supervisor/m03-wp8-closeout
+    base_sha: c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3
+    module: m03_governance_hold
+    status: active-governance-hold
     writes:
-      - ai-native/parallel/checkpoints/M03-WP8-REVIEW.md
+      - ai-native/parallel/checkpoints/M03-GOV-HOLD.md
     shared_requests: []
     depends_on:
-      - M03-WP7-CLOSEOUT
+      - M03-WP8
     migration_reservation: null
-    consent_scope: M03-review-and-promotion
+    consent_scope: M03-governance-closeout-only
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
-    last_acknowledged_broadcast: 10
-    required_broadcast: null
-
-  - task_id: M03-WP8
-    title: M03 end-to-end source acceptance
-    role: module
-    assigned_agent: acceptance-agent
-    branch: agent/m03-wp8-acceptance-v2
-    base_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
-    module: m03_acceptance
-    status: active-acceptance
-    writes:
-      - docs/milestones/M03/WP8-ACCEPTANCE-MATRIX.md
-      - ai-native/parallel/checkpoints/M03-WP8.md
-    shared_requests: []
-    depends_on:
-      - M03-WP7-CLOSEOUT
-    migration_reservation: null
-    consent_scope: M03-source-acceptance-only
-    completion_signal: Work Done and Submitted
-    last_synced_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
-    last_acknowledged_broadcast: 10
+    last_synced_main_sha: c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3
+    last_acknowledged_broadcast: 11
     required_broadcast: null
 
   - task_id: M04-PARALLEL-LANE
@@ -61,13 +40,13 @@ active:
       - ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md
     shared_requests: []
     depends_on:
-      - M03-WP8
+      - M03-GOV-HOLD
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 10
+    required_broadcast: 11
 
   - task_id: M05-PARALLEL-LANE
     title: Content Intelligence and Memory planning/contracts
@@ -87,7 +66,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 10
+    required_broadcast: 11
 
   - task_id: M06-PARALLEL-LANE
     title: Hybrid Audio Production planning/contracts
@@ -101,13 +80,13 @@ active:
       - ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md
     shared_requests: []
     depends_on:
-      - M03-WP8
+      - M03-GOV-HOLD
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 10
+    required_broadcast: 11
 
   - task_id: M07-PARALLEL-LANE
     title: Storyboard and Timeline planning/contracts
@@ -129,7 +108,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 10
+    required_broadcast: 11
 
   - task_id: M08-PARALLEL-LANE
     title: Hybrid Image/Video Provider Router planning/contracts
@@ -150,7 +129,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 10
+    required_broadcast: 11
 
   - task_id: CROSS-CUTTING-QA
     title: Cross-cutting adversarial QA and security
@@ -170,7 +149,7 @@ active:
     completion_signal: Work Done and Submitted
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
     last_acknowledged_broadcast: 4
-    required_broadcast: 10
+    required_broadcast: 11
 
 rules:
   - Supervisor owns updates to this registry and all merge decisions.

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -12,8 +12,7 @@
     "completed_submission_branch_must_be_retired_or_replaced": true
   },
   "slots": [
-    {"slot_id":"SUPERVISOR-M03-WP8-REVIEW","module":"m03_acceptance_review","branch":"supervisor/m03-wp8-review","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-review-only"},
-    {"slot_id":"M03-WP8","module":"m03_acceptance","branch":"agent/m03-wp8-acceptance-v2","status":"occupied","assigned_agent":"acceptance-agent","accepts_new_agent":true,"start_status":"active-acceptance"},
+    {"slot_id":"SUPERVISOR-M03-GOV-HOLD","module":"m03_governance_hold","branch":"supervisor/m03-wp8-closeout","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-governance-hold"},
     {"slot_id":"M04-CHARACTER","module":"characters_entities","branch":"agent/m04-character-library","status":"occupied","assigned_agent":"character-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
-version: 5
-latest_sequence: 10
+version: 6
+latest_sequence: 11
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -56,23 +56,29 @@ broadcasts:
     classification: mandatory-wp7-vector-index-cleanup-sync
     schema_migration_changes: []
   - sequence: 10
-    trigger: supervisor-merge
     merged_pr: 65
     merged_branch: supervisor/m03-wp7-closeout
     submitted_head_sha: 615ac1d287f2773a09d15ac74a390dcb0ccb4d47
     merged_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
-    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
     classification: mandatory-wp7-closeout-wp8-handoff-sync
+    schema_migration_changes: []
+  - sequence: 11
+    trigger: supervisor-merge
+    merged_pr: 68
+    merged_branch: agent/m03-wp8-acceptance-v2
+    submitted_head_sha: 66d81de4a4c0aea16186dae43d3a1922cd8d2123
+    merged_main_sha: c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-wp8-source-acceptance-closeout-sync
     changed_areas:
-      - WP7 implementation closeout checkpoint
-      - migrations 20260901_0015 and 20260901_0016 confirmed landed
-      - M03-WP8 source acceptance unblocked
-      - Supervisor review authority separated from acceptance-agent writes
+      - M03-WP8 acceptance matrix and checkpoint landed
+      - exact-head Repository Governance, Core Domain Contracts and Durable Control Plane passed
+      - M03 source acceptance complete
+      - final protected-main governance remains blocked by Issue 36
     contract_changes: []
     schema_migration_changes: []
     recipients:
-      - supervisor/m03-wp8-review
-      - agent/m03-wp8-acceptance-v2
+      - supervisor/m03-wp8-closeout
       - agent/m04-character-library
       - agent/m05-content-memory
       - agent/m06-audio-production
@@ -82,44 +88,39 @@ broadcasts:
     mandatory: true
 
 recipient_states:
-  supervisor/m03-wp8-review:
+  supervisor/m03-wp8-closeout:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 10
-    last_synced_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
-  agent/m03-wp8-acceptance-v2:
-    state: synchronized
-    required_sequence: null
-    last_acknowledged_sequence: 10
-    last_synced_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
+    last_acknowledged_sequence: 11
+    last_synced_main_sha: c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3
   agent/m04-character-library:
     state: sync-required
-    required_sequence: 10
+    required_sequence: 11
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m05-content-memory:
     state: sync-required
-    required_sequence: 10
+    required_sequence: 11
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m06-audio-production:
     state: sync-required
-    required_sequence: 10
+    required_sequence: 11
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m07-storyboard-timeline:
     state: sync-required
-    required_sequence: 10
+    required_sequence: 11
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/m08-video-provider-router:
     state: sync-required
-    required_sequence: 10
+    required_sequence: 11
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
   agent/cross-cutting-qa-security:
     state: sync-required
-    required_sequence: 10
+    required_sequence: 11
     last_acknowledged_sequence: 4
     last_synced_main_sha: d4cd69c53af832a75285650453ba480744afbd04
 

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -10,8 +10,7 @@ New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after S
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03-WP8 Review | `supervisor-agent` | `supervisor/m03-wp8-review` | active review/promotion authority only |
-| M03-WP8 Acceptance | `acceptance-agent` | `agent/m03-wp8-acceptance-v2` | active source acceptance |
+| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-wp8-closeout` | active governance-only hold |
 | M04 Character | `character-agent` | `agent/m04-character-library` | sync-required planning-only |
 | M05 Content | `content-agent` | `agent/m05-content-memory` | sync-required planning-only |
 | M06 Audio | `audio-agent` | `agent/m06-audio-production` | sync-required planning-only |
@@ -19,36 +18,36 @@ New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after S
 | M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | sync-required planning-only |
 | QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security` | sync-required audit/planning |
 
-The earlier `agent/m03-wp8-acceptance` branch is retired for executable work after a partial pre-reconciliation slot edit. It is not promotion authority and will not be force-reset. `agent/m03-wp8-acceptance-v2` is the clean current-main acceptance branch.
+The completed `agent/m03-wp8-acceptance-v2` and `supervisor/m03-wp8-review` branches are retired from active execution authority. The earlier `agent/m03-wp8-acceptance` branch also remains retired and is not promotion authority.
 
-## M03 transition state
+## M03 source completion
 
-PR #65 closed WP7 at `main@38b182f4ea886b48c4249aacf362fb58546bd3f5`. Broadcast 10 records that merge and unblocks bounded WP8 source acceptance. Migrations `20260901_0015` and `20260901_0016` remain landed; there is no active M03 migration reservation.
+PR #68 landed the canonical WP8 acceptance matrix/checkpoint at `main@c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3`. Its exact head `66d81de4a4c0aea16186dae43d3a1922cd8d2123` passed Repository Governance, Core Domain Contracts, and Durable Control Plane before merge.
 
-WP8 may create only the canonical acceptance matrix/checkpoint and genuinely missing acceptance tests if the evidence audit proves a gap. Existing focused evidence already covers multipart restart/resume and lost-ack recovery, cross-project delivery denial and signer mismatch, malicious/MIME-spoof quarantine rejection, provenance/hash integrity, archive/restore, deletion propagation, temporary cleanup, export staging, and vector/index cleanup hooks.
+Broadcast 11 records that successful promotion. WP7 implementation and WP8 source acceptance are complete. Migrations `20260901_0015` and `20260901_0016` remain landed; there is no active M03 migration reservation.
 
-No product/API/schema/provider expansion, external provider credential, production bucket, or cost-bearing action is authorized by WP8.
+No further WP7/WP8 product/API/schema/provider implementation is authorized by this closeout.
 
 ## External governance boundary
 
-Issue #36 remains open because live GitHub repository ruleset read-back does not prove protected `main`. WP8 source acceptance may be merged when its exact-head source checks are green, but that merge must not claim final M03 protected-main governance completion while Issue #36 is unresolved.
+Issue #36 is now the only M03 blocker. Live GitHub repository ruleset read-back still returns `[]`, so protected-main enforcement is not verified.
+
+The current connector exposes ruleset read-only access and no administration/environment write action. Therefore the Supervisor must not claim, simulate, or bypass live protection. An administrator must apply and verify the retained protection policy from an admin-capable context, after which Issue #36 can be re-evaluated against repository-native read-back evidence.
 
 ## Parallel safety
 
-`ACTIVE-WORK.yaml` is authoritative for active write claims. The acceptance agent owns only:
+`ACTIVE-WORK.yaml` is authoritative for active write claims. The M03 governance-hold lane owns only:
 
-- `docs/milestones/M03/WP8-ACCEPTANCE-MATRIX.md`
-- `ai-native/parallel/checkpoints/M03-WP8.md`
+- `ai-native/parallel/checkpoints/M03-GOV-HOLD.md`
 
-The Supervisor review lane owns only `ai-native/parallel/checkpoints/M03-WP8-REVIEW.md`. Other lanes remain disjoint and sync-required by broadcast 10.
+All later milestone and QA lanes remain disjoint, sync-required by broadcast 11, and planning-only until their dependency/consent gates are explicitly satisfied.
 
-## Merge order
+## Merge / hold order
 
-1. `supervisor/m03-wp8-review` coordination reconciliation
-2. fast-forward `agent/m03-wp8-acceptance-v2` to the resulting current main
-3. `agent/m03-wp8-acceptance-v2` source acceptance submission
-4. Supervisor exact-head review and merge when all required source checks are green
-5. final M03 governance close only after Issue #36 live protection evidence is satisfied
+1. merge `supervisor/m03-wp8-closeout` only after exact-head Repository Governance, Core Domain Contracts and Durable Control Plane are green;
+2. keep Issue #36 open while live ruleset/protection read-back is absent;
+3. do not start new M03 source implementation while the external governance hold is active;
+4. later milestone execution requires fresh scope/dependency synchronization and may not treat unresolved M03 governance as completed.
 
 ## Completion and review
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -1,19 +1,19 @@
-version: 6
+version: 7
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 38b182f4ea886b48c4249aacf362fb58546bd3f5
-  main_sha_last_reconciled: 38b182f4ea886b48c4249aacf362fb58546bd3f5
-  own_task_id: M03-WP8-REVIEW
-  own_branch: supervisor/m03-wp8-review
-  current_mode: acceptance-review
+  main_sha_last_promotion: c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3
+  main_sha_last_reconciled: c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3
+  own_task_id: M03-GOV-HOLD
+  own_branch: supervisor/m03-wp8-closeout
+  current_mode: external-governance-hold
   completion_signal: Work Done and Submitted
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 65
-  submitted_head_sha: 615ac1d287f2773a09d15ac74a390dcb0ccb4d47
-  merged_main_sha: 38b182f4ea886b48c4249aacf362fb58546bd3f5
+  pr: 68
+  submitted_head_sha: 66d81de4a4c0aea16186dae43d3a1922cd8d2123
+  merged_main_sha: c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3
   result: success
 
 new_agent_onboarding:
@@ -24,22 +24,18 @@ new_agent_onboarding:
   no_slot_response: Go Home Come Back Next Time
 
 pause_checkpoint:
-  active: false
-  branch: null
+  active: true
+  branch: supervisor/m03-wp8-closeout
   head_sha: null
-  task_id: null
-  subtask: null
-  next_action: null
-  reason: null
+  task_id: M03-GOV-HOLD
+  subtask: wait-for-live-protected-main-evidence
+  next_action: verify Issue 36 live ruleset/protection read-back from an admin-capable context
+  reason: M03 source acceptance is complete; final governance truth state depends on external GitHub administration
 
-review_queue:
-  - task_id: M03-WP8
-    branch: agent/m03-wp8-acceptance-v2
-    state: awaiting-submission
-    exact_head_sha: null
+review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 10
+  latest_broadcast_sequence: 11
   agents_with_mandatory_sync:
     - agent/m04-character-library
     - agent/m05-content-memory
@@ -52,7 +48,8 @@ synchronization:
 external_gates:
   m03_main_protection_issue: 36
   status: not-verified
-  effect: source acceptance may complete; final M03 governance/promotion may not claim protected-main completion
+  live_ruleset_readback: []
+  effect: M03 source acceptance complete; final protected-main governance/promotion remains blocked
 
 rules:
   - The Supervisor reviews and merges incoming module PRs; module agents do not merge themselves.

--- a/ai-native/parallel/checkpoints/M03-GOV-HOLD.md
+++ b/ai-native/parallel/checkpoints/M03-GOV-HOLD.md
@@ -1,0 +1,39 @@
+# M03 Governance Hold Checkpoint
+
+## Status
+
+M03 source implementation and WP8 source acceptance are complete through PR #68.
+
+Current accepted source main:
+
+`c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3`
+
+WP8 accepted head:
+
+`66d81de4a4c0aea16186dae43d3a1922cd8d2123`
+
+Exact-head certification before PR #68 merge:
+
+- Repository Governance — PASS
+- Core Domain Contracts — PASS
+- Durable Control Plane — PASS
+
+## Active blocker
+
+Issue #36 remains open. Live GitHub ruleset read-back returns `[]`; protected-main enforcement is therefore not verified.
+
+The connected GitHub App in the current execution context exposes ruleset read access only and no administration/environment write action. Do not fabricate or bypass this gate.
+
+## Allowed next action
+
+From an administrator-capable context:
+
+1. apply the retained main-protection policy;
+2. verify effective live GitHub settings and required checks;
+3. record repository-native evidence on Issue #36;
+4. re-read live ruleset/protection state;
+5. close Issue #36 only when the retained verifier and live read-back prove enforcement.
+
+No new WP7/WP8 product, API, schema, provider, credential, migration, or paid-service work is authorized by this hold.
+
+Work Done and Submitted


### PR DESCRIPTION
Governance-only post-merge closeout for Issue #69 after WP8 source-acceptance PR #68 merged to `main@c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3`.

This PR:
- records mandatory broadcast sequence 11 for PR #68;
- retires completed WP8 acceptance/review branches from active execution authority;
- moves the Supervisor to `supervisor/m03-wp8-closeout` with a single governance-hold checkpoint write;
- preserves M04–M08 and QA as collision-free sync-required planning/audit lanes;
- records M03 source acceptance as complete;
- records Issue #36 as the sole remaining M03 blocker because live ruleset read-back is still `[]`;
- creates no migration and makes no product/API/schema/provider/credential/cost-bearing change.

Final protected-main governance must not be claimed until Issue #36 is satisfied from an admin-capable context.

Work Done and Submitted