### PR TITLE
GOV: broadcast cross-cutting adversarial QA constraints

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -1,4 +1,4 @@
-version: 8
+version: 9
 supervisor:
   role: supervisor
   assigned_agent: supervisor-agent
@@ -13,7 +13,7 @@ active:
     role: supervisor-governance
     assigned_agent: supervisor-agent
     branch: supervisor/m03-governance-hold-current
-    base_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
+    base_sha: 6eab0440ef32280c16e41b41851deb3f11937495
     module: m03_governance_hold
     status: active-governance-hold
     writes:
@@ -24,8 +24,8 @@ active:
     migration_reservation: null
     consent_scope: M03-governance-closeout-only
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
-    last_acknowledged_broadcast: 11
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_broadcast: 12
     required_broadcast: null
 
   - task_id: M04-PARALLEL-LANE
@@ -44,8 +44,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
-    last_acknowledged_broadcast: 11
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_broadcast: 12
     required_broadcast: null
 
   - task_id: M05-PARALLEL-LANE
@@ -64,8 +64,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
-    last_acknowledged_broadcast: 11
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_broadcast: 12
     required_broadcast: null
 
   - task_id: M06-PARALLEL-LANE
@@ -84,8 +84,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
-    last_acknowledged_broadcast: 11
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_broadcast: 12
     required_broadcast: null
 
   - task_id: M07-PARALLEL-LANE
@@ -106,8 +106,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
-    last_acknowledged_broadcast: 11
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_broadcast: 12
     required_broadcast: null
 
   - task_id: M08-PARALLEL-LANE
@@ -127,15 +127,15 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
-    last_acknowledged_broadcast: 11
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_broadcast: 12
     required_broadcast: null
 
   - task_id: CROSS-CUTTING-QA
     title: Cross-cutting adversarial QA and security
     role: qa
     assigned_agent: qa-security-agent
-    branch: agent/cross-cutting-qa-security
+    branch: agent/cross-cutting-qa-security-current
     module: media_qa
     status: active-audit-planning
     writes:
@@ -147,8 +147,8 @@ active:
     migration_reservation: null
     consent_scope: audit-planning; executable test changes require applicable scope
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
-    last_acknowledged_broadcast: 11
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_broadcast: 12
     required_broadcast: null
 
 rules:

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "source_branch_required": "main",
   "assignment_authority": "supervisor",
   "no_slot_response": "Go Home Come Back Next Time",
@@ -18,6 +18,6 @@
     {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M07-TIMELINE","module":"timeline_storyboard","branch":"agent/m07-storyboard-timeline","status":"occupied","assigned_agent":"timeline-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M08-PROVIDER","module":"providers","branch":"agent/m08-video-provider-router","status":"occupied","assigned_agent":"provider-agent","accepts_new_agent":true,"start_status":"planning-only"},
-    {"slot_id":"CROSS-CUTTING-QA","module":"media_qa","branch":"agent/cross-cutting-qa-security","status":"occupied","assigned_agent":"qa-security-agent","accepts_new_agent":true,"start_status":"active-audit-planning"}
+    {"slot_id":"CROSS-CUTTING-QA","module":"media_qa","branch":"agent/cross-cutting-qa-security-current","status":"occupied","assigned_agent":"qa-security-agent","accepts_new_agent":true,"start_status":"active-audit-planning"}
   ]
 }

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
-version: 7
-latest_sequence: 11
+version: 8
+latest_sequence: 12
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -86,43 +86,68 @@ broadcasts:
       - agent/m08-video-provider-router
       - agent/cross-cutting-qa-security
     mandatory: true
+  - sequence: 12
+    trigger: qa-planning-promotion
+    merged_pr: 74
+    merged_branch: agent/cross-cutting-qa-security
+    submitted_head_sha: 6ce2de1bf01ae9562ee2b370ca53760bd05f9ebd
+    merged_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-cross-cutting-adversarial-qa-sync
+    changed_areas:
+      - cross-cutting adversarial QA audit plan
+      - M04-M08 future security acceptance hooks
+      - generic continuation remains non-privileged authorization
+      - M03 protected-main governance remains blocked by Issue 36
+    contract_changes:
+      - future module acceptance must re-evaluate newly reachable authority/trust boundaries
+    schema_migration_changes: []
+    recipients:
+      - supervisor/m03-governance-hold-current
+      - agent/m04-character-library
+      - agent/m05-content-memory
+      - agent/m06-audio-production
+      - agent/m07-storyboard-timeline
+      - agent/m08-video-provider-router
+      - agent/cross-cutting-qa-security-current
+    mandatory: true
 
 recipient_states:
-  supervisor/m03-wp8-closeout:
+  supervisor/m03-governance-hold-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 11
-    last_synced_main_sha: c61955f56ef5c9c7f3e6ff717e12dac5364d8fc3
+    last_acknowledged_sequence: 12
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
   agent/m04-character-library:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 11
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
+    last_acknowledged_sequence: 12
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
   agent/m05-content-memory:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 11
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
+    last_acknowledged_sequence: 12
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
   agent/m06-audio-production:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 11
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
+    last_acknowledged_sequence: 12
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
   agent/m07-storyboard-timeline:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 11
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
+    last_acknowledged_sequence: 12
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
   agent/m08-video-provider-router:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 11
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
-  agent/cross-cutting-qa-security:
+    last_acknowledged_sequence: 12
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+  agent/cross-cutting-qa-security-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 11
-    last_synced_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
+    last_acknowledged_sequence: 12
+    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
 
 rules:
   - Supervisor increments latest_sequence after every successful promotion merge to main that active agents must observe.

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -10,50 +10,53 @@ New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after S
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold |
-| M04 Character | `character-agent` | `agent/m04-character-library` | broadcast-11 synchronized; planning-only; dependency-gated |
-| M05 Content | `content-agent` | `agent/m05-content-memory` | broadcast-11 synchronized; planning-only; dependency-gated |
-| M06 Audio | `audio-agent` | `agent/m06-audio-production` | broadcast-11 synchronized; planning-only; dependency-gated |
-| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | broadcast-11 synchronized; planning-only; dependency-gated |
-| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast-11 synchronized; planning-only; dependency-gated |
-| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security` | broadcast-11 synchronized; audit/planning only |
+| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 12 synchronized |
+| M04 Character | `character-agent` | `agent/m04-character-library` | broadcast 12 synchronized; planning-only; dependency-gated |
+| M05 Content | `content-agent` | `agent/m05-content-memory` | broadcast 12 synchronized; planning-only; dependency-gated |
+| M06 Audio | `audio-agent` | `agent/m06-audio-production` | broadcast 12 synchronized; planning-only; dependency-gated |
+| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | broadcast 12 synchronized; planning-only; dependency-gated |
+| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 12 synchronized; planning-only; dependency-gated |
+| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 12 synchronized; audit/planning only |
 
-The completed `agent/m03-wp8-acceptance-v2`, `supervisor/m03-wp8-review`, and `supervisor/m03-wp8-closeout` branches are retired from active execution authority. The earlier `agent/m03-wp8-acceptance` branch also remains retired and is not promotion authority.
+Completed QA submission branch `agent/cross-cutting-qa-security` is retired from active authority after PR #74. `agent/cross-cutting-qa-security-current` is the fresh current-main audit/planning branch. Earlier completed M03/WP8 submission/review/closeout branches remain retired.
 
-## M03 source completion
+## M03 source completion and external hold
 
-PR #68 landed the canonical WP8 acceptance matrix/checkpoint. PR #70 then reconciled post-WP8 governance state and merged to `main@0d79b73e112c8145244f01abcaa7b2489ac03560`. Both promotions passed exact-head Repository Governance, Core Domain Contracts, and Durable Control Plane before merge.
+M03 implementation, WP8 source acceptance, and source-side closeout are complete. Issue #36 remains the final M03 protected-main governance blocker because live GitHub enforcement is not verified. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
 
-Broadcast 11 records WP8 source acceptance. WP7 implementation and WP8 source acceptance/closeout are complete. Migrations `20260901_0015` and `20260901_0016` remain landed; there is no active M03 migration reservation.
+Migrations `20260901_0015` and `20260901_0016` remain landed; there is no active M03 migration reservation.
 
-No further WP7/WP8 product/API/schema/provider implementation is authorized by this closeout.
+## Cross-cutting QA promotion
 
-## Broadcast 11 synchronization
+PR #74 landed `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` and the QA checkpoint at `main@6eab0440ef32280c16e41b41851deb3f11937495` after exact-head Repository Governance, Core Domain Contracts and Durable Control Plane passed.
 
-Before Issue #71 reconciliation, M04, M05, M06, M07, M08, and cross-cutting QA were each exactly 0 commits ahead and 11 commits behind current main. Each branch was non-force fast-forwarded to `main@0d79b73e112c8145244f01abcaa7b2489ac03560`; no unique work was discarded.
+The plan reuses current M03 focused evidence and assigns future adversarial obligations only where later modules introduce new trust or authority surfaces. It covers authority isolation, tenant validation, memory poisoning, provider-output distrust, secret handling, budget/retry ceilings, rights/provenance and multimodal instruction isolation.
 
-This synchronization clears only the stale mandatory broadcast receipt. It does **not** expand consent or satisfy dependency gates.
+Broadcast 12 records this cross-cutting acceptance guidance because future M04-M08 work must observe it. The broadcast is an acceptance/planning constraint, not feature-execution authority.
 
-## External governance boundary
+## Dependency and consent boundary
 
-Issue #36 is the remaining M03 blocker. Live GitHub branch read-back shows `main` is not protected and repository rulesets remain empty. Protected-main enforcement is therefore not verified.
+- M04 and M06 remain dependent on `M03-GOV-HOLD`.
+- M05 remains dependent on M04.
+- M07 remains dependent on M04/M05/M06.
+- M08 remains dependent on M04/M07.
+- Cross-cutting QA has no module dependency but remains audit/planning only unless an applicable executable scope authorizes tests.
+- `docs/milestones/M04/PLAN.md` requires M01-M03 accepted plus explicit M04 consent before executable M04 work.
+- The repository threat model explicitly states generic `continue` is not privileged development, publish or security authorization.
 
-The current connector exposes ruleset/protection read evidence but no administration/environment write action. The Supervisor must not claim, simulate, or bypass live protection. An administrator must apply and verify the retained protection policy from an admin-capable context, after which Issue #36 can be re-evaluated against repository-native read-back evidence.
+Therefore no later module may treat branch synchronization or conversational continuation as satisfying its executable entry criteria.
 
 ## Parallel safety
 
-`ACTIVE-WORK.yaml` is authoritative for active write claims. The M03 governance-hold lane owns only:
-
-- `ai-native/parallel/checkpoints/M03-GOV-HOLD.md`
-
-Later milestone lanes are now synchronized but remain planning-only under their existing consent/dependency contracts. In particular, M04 and M06 depend on `M03-GOV-HOLD`; M05 depends on M04; M07 depends on M04/M05/M06; M08 depends on M04/M07. Cross-cutting QA remains audit/planning only unless an applicable executable scope is granted.
+`ACTIVE-WORK.yaml` is authoritative for active write claims. Later planning lanes remain disjoint and may update only their claimed planning/checkpoint surfaces. QA owns `docs/qa/**` and its checkpoint plus shared-request access to security docs; executable product/test changes require separate applicable scope.
 
 ## Hold order
 
-1. keep Issue #36 open while live protected-main evidence is absent;
-2. do not start new M03 product implementation while the external governance hold is active;
-3. do not treat broadcast synchronization as feature-execution authority;
-4. later milestone execution requires its dependency chain plus explicit executable scope/consent to be satisfied.
+1. maintain Issue #36 as `EXTERNAL_NOT_VERIFIED` while protected-main evidence is absent;
+2. preserve broadcast 12 adversarial obligations in future milestone acceptance;
+3. do not start M04/M06 executable work until M03 acceptance/governance dependency and explicit executable consent are satisfied;
+4. do not promote downstream M05/M07/M08 past their dependency chain;
+5. do not create synthetic provider/admin/production evidence from mocks or source CI.
 
 ## Completion and review
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -1,9 +1,9 @@
-version: 8
+version: 9
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 0d79b73e112c8145244f01abcaa7b2489ac03560
-  main_sha_last_reconciled: 0d79b73e112c8145244f01abcaa7b2489ac03560
+  main_sha_last_promotion: 6eab0440ef32280c16e41b41851deb3f11937495
+  main_sha_last_reconciled: 6eab0440ef32280c16e41b41851deb3f11937495
   own_task_id: M03-GOV-HOLD
   own_branch: supervisor/m03-governance-hold-current
   current_mode: external-governance-hold
@@ -11,9 +11,9 @@ supervisor:
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 70
-  submitted_head_sha: 532bfba093e3a18d1c1d6280c329b5747c9eef32
-  merged_main_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
+  pr: 74
+  submitted_head_sha: 6ce2de1bf01ae9562ee2b370ca53760bd05f9ebd
+  merged_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
   result: success
 
 new_agent_onboarding:
@@ -26,7 +26,7 @@ new_agent_onboarding:
 pause_checkpoint:
   active: true
   branch: supervisor/m03-governance-hold-current
-  head_sha: 0d79b73e112c8145244f01abcaa7b2489ac03560
+  head_sha: 6eab0440ef32280c16e41b41851deb3f11937495
   task_id: M03-GOV-HOLD
   subtask: wait-for-live-protected-main-evidence
   next_action: verify Issue 36 live ruleset/protection read-back from an admin-capable context
@@ -35,7 +35,7 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 11
+  latest_broadcast_sequence: 12
   agents_with_mandatory_sync: []
   policy: branches-with-unacknowledged-mandatory-broadcast-cannot-seek-promotion
 


### PR DESCRIPTION
Implements Issue #75 as governance-only coordination after QA PR #74 merged to `main@6eab0440ef32280c16e41b41851deb3f11937495`.

This PR:
- records mandatory broadcast sequence 12 for the cross-cutting adversarial QA plan;
- records M04–M08 and Supervisor hold as synchronized to the triggering main;
- retires completed `agent/cross-cutting-qa-security` from active authority and replaces it with fresh `agent/cross-cutting-qa-security-current`;
- preserves all planning-only/audit-only consent scopes and dependency gates;
- keeps Issue #36 as the external M03 protected-main blocker;
- explicitly carries future adversarial obligations without granting feature execution.

No product/API/schema/provider/test implementation, migration, credential, paid call, publish action, security-setting mutation or feature-execution unlock.

Work Done and Submitted