### PR TITLE
M04: harden planning against adversarial trust boundaries

### DIFF
--- a/ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md
+++ b/ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md
@@ -1,0 +1,55 @@
+# M04 Parallel Lane Checkpoint
+
+## Authority
+
+- Issue: #77 — M04 planning hardening — adversarial constraints and executable hold
+- Lane: `M04-PARALLEL-LANE`
+- Branch: `agent/m04-character-library`
+- Planning baseline: `main@5c7d3bab84992a8681c64ffe4911637568ad608b`
+- Broadcast state: sequence 12 synchronized
+- Consent scope: planning-only-until-new-scope-approved
+- Executable M04 authority: **not granted**
+- Migration reservation: none
+- Product/API/schema/provider/test implementation: not authorized by this checkpoint
+
+## Planning work completed
+
+- Reconciled `docs/milestones/M04/PLAN.md` with the cross-cutting adversarial QA plan introduced by PR #74 and broadcast 12.
+- Made live M03 protected-main governance (Issue #36) and explicit M04 executable consent explicit entry gates.
+- Preserved downstream M05/M07/M08 dependency ordering.
+- Added planning obligations for canonical tenant/project authorization, lock conflict rejection, append/version immutability, rights/consent/provenance continuity, imported/reference-pack trust boundaries, provider-output distrust hooks and no synthetic production/security success.
+- Recorded that deterministic fake/manual reference assets may prove source contracts only and cannot substitute for real-provider/production evidence when a later gate requires it.
+- Created this previously missing M04 planning checkpoint.
+
+## Current evidence classification
+
+- M04 executable surface: `DEFERRED_MODULE` — not authorized yet.
+- M03 protected-main governance: `EXTERNAL_NOT_VERIFIED` — Issue #36 remains open.
+- Cross-cutting QA obligations: planning-integrated.
+- M04 schema/migrations: not reserved/not implemented.
+- Paid/provider/production evidence: not required and not produced by this planning slice.
+
+## Mandatory executable entry recheck
+
+Before any M04 implementation branch or migration reservation is created, the Supervisor must verify all of the following against then-current main:
+
+1. Issue #36 is closed from live repository-native protection evidence at the required truth level.
+2. Explicit M04 executable consent exists; generic conversational continuation is insufficient.
+3. M04 branch/write ownership is freshly assigned with no collision.
+4. Current migration head is audited and any required revision is reserved before schema writes.
+5. Broadcast/dependency state is synchronized.
+6. The exact proposed executable surface is re-evaluated against `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` and receives only targeted missing adversarial evidence.
+7. No production credential, paid provider call or public side effect is introduced unless separately authorized.
+
+## Downstream hold
+
+- M05 cannot treat this planning checkpoint as completed executable M04.
+- M07 remains dependent on executable M04/M05/M06 completion.
+- M08 remains dependent on executable M04/M07 completion.
+- Branch synchronization or green planning CI does not satisfy those dependencies.
+
+## Next authorized action
+
+Submit this planning-only two-file change for ordinary exact-head repository governance/source regression CI. If merged, close Issue #77 as planning complete and keep M04 executable work on hold until the mandatory entry criteria above are satisfied.
+
+Work Done and Submitted

--- a/docs/milestones/M04/PLAN.md
+++ b/docs/milestones/M04/PLAN.md
@@ -1,18 +1,41 @@
 # M04 — Character and Entity Library
 
+## Planning authority and current state
+
+This document is the planning contract for M04 only. It does **not** authorize executable M04 product/API/schema/provider work.
+
+Current planning baseline: `main@5c7d3bab84992a8681c64ffe4911637568ad608b` after cross-cutting QA PR #74 and mandatory broadcast 12 / PR #76.
+
+Executable M04 work remains blocked until all entry criteria below are satisfied, including live M03 protected-main governance in Issue #36 and explicit M04 executable consent. Generic conversational continuation is not that consent.
+
 ## Objective
 
 Implement reusable, versioned, rights-aware characters/entities with lock modes, reference packs and provider-neutral identity continuity.
 
 ## Entry criteria
 
-- P0 complete.
-- M01–M03 accepted.
-- Explicit M04 consent.
+All are required before executable M04 work begins:
+
+- P0 complete;
+- M01–M03 accepted at their required truth level;
+- Issue #36 live protected-main governance verified and closed, because M04 depends on `M03-GOV-HOLD`;
+- explicit M04 executable consent recorded through Supervisor authority;
+- current-main/broadcast/write-ownership/migration state revalidated immediately before implementation;
+- cross-cutting adversarial QA obligations applicable to the proposed executable surface mapped to targeted acceptance evidence.
+
+Current state: planning may continue, but executable entry criteria are **not satisfied** while Issue #36 remains `EXTERNAL_NOT_VERIFIED` and explicit M04 executable consent is absent.
 
 ## Dependencies
 
 `M03 -> M04`
+
+Downstream dependency impact:
+
+- M05 remains dependent on M04;
+- M07 remains dependent on M04/M05/M06;
+- M08 remains dependent on M04/M07.
+
+Planning synchronization must never be interpreted as downstream execution authority.
 
 ## Work packages
 
@@ -28,7 +51,8 @@ Implement reusable, versioned, rights-aware characters/entities with lock modes,
 - human/non-human categories;
 - body/face/hair/eyes/palette/wardrobe/accessories;
 - personality/movement/voice metadata;
-- create new version instead of silent mutation.
+- create new version instead of silent mutation;
+- immutable historical version semantics for already-pinned projects.
 
 ### M04-WP3 — Lock engine
 - global hard lock;
@@ -37,7 +61,8 @@ Implement reusable, versioned, rights-aware characters/entities with lock modes,
 - scene lock;
 - one-off/unlocked;
 - forbidden mutations;
-- lock conflict validation.
+- lock conflict validation;
+- fail-closed rejection when a requested mutation conflicts with an effective stronger lock.
 
 ### M04-WP4 — Reference-pack asset model
 - front/side/back/full body;
@@ -45,35 +70,62 @@ Implement reusable, versioned, rights-aware characters/entities with lock modes,
 - poses;
 - wardrobe variants;
 - canonical approved image references;
-- version pinning.
+- exact version pinning;
+- canonical tenant/project authorization for referenced asset IDs;
+- provenance/consent state retained for imported references.
 
-Generation of images can initially use fake/manual assets until M08 real provider routing; M04 owns reference-pack structure/approval.
+Generation of images can initially use deterministic fake/manual assets until M08 real provider routing; M04 owns reference-pack structure/approval. Fake/manual assets may prove source contracts but must never be relabeled as real-provider or production evidence.
 
 ### M04-WP5 — Voice/entity association
 - voice profile/version mapping;
 - language/pronunciation references;
-- no raw provider credential/reference as canonical identity.
+- no raw provider credential/reference as canonical identity;
+- rights/consent state remains attached to the exact reusable voice/entity version.
 
 ### M04-WP6 — Identity QA interface
 - deterministic/fixture identity checks;
-- later multimodal provider implementation plugs into same QA contract;
-- hard locked-attribute failures.
+- later multimodal provider implementation plugs into the same QA contract;
+- hard locked-attribute failures;
+- provider/model output remains untrusted and cannot silently redefine canonical identity, locks, tenant authority or rights state.
 
 ### M04-WP7 — Project reuse/import/export
 - select existing character/entity;
 - pin exact version/look;
 - duplicate/fork version intentionally;
 - export manifest/reference pack;
-- rights validation.
+- rights validation;
+- import/export cannot bypass canonical ownership, tenant or consent checks;
+- imported metadata/instructions remain low-trust evidence and cannot mint lock, policy or privileged authority.
 
 ### M04-WP8 — API/acceptance
 - list/search/select/version/lock APIs;
 - cross-project reuse fixture;
 - mutation rejection;
 - tenant isolation;
-- reference lineage.
+- reference lineage;
+- rights/provenance enforcement;
+- canonical authorization of externally supplied entity/version/look/reference IDs.
+
+## Cross-cutting adversarial acceptance obligations
+
+Broadcast 12 and `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` are mandatory planning inputs. When M04 later requests executable promotion, QA must re-evaluate the exact proposed surface and add only targeted evidence for newly reachable authority paths.
+
+At minimum M04 acceptance must prove:
+
+1. **Cross-tenant isolation** — foreign tenant entity/version/look/reference IDs are inaccessible even when supplied by imports, model/provider output or remembered state.
+2. **Canonical authorization** — returned/imported IDs are canonical-looked-up and tenant/project-authorized before use; model/provider prose cannot mint authority.
+3. **Lock integrity** — hard/project/look/scene lock conflicts fail closed; a lower-trust request cannot bypass an effective stronger lock.
+4. **Append/version immutability** — new looks/versions never silently mutate exact versions already pinned by prior projects.
+5. **Rights and provenance continuity** — likeness, voice and reference reuse retain exact ownership/consent/provenance state across versioning, reuse, import and export.
+6. **Reference-pack trust boundary** — foreign asset IDs, malformed manifests and low-trust embedded instructions cannot redefine canonical identity, policy, lock or security state.
+7. **Provider-output distrust hook** — later provider-returned IDs/URLs/metadata remain untrusted until schema validation, canonical lookup and policy checks occur.
+8. **No synthetic security success** — deterministic fixtures/fakes may prove source contracts, but absent admin/provider/production evidence remains `NOT_VERIFIED` where a later gate requires it.
+
+No duplicate umbrella tests should be added for M03 properties already proven by the M03-WP8 acceptance matrix unless M04 introduces a genuinely new authority/trust path.
 
 ## Expected modules/files
+
+Planned future executable surface only:
 
 - entity domain/repositories/services;
 - asset/reference pack services;
@@ -81,40 +133,61 @@ Generation of images can initially use fake/manual assets until M08 real provide
 - entity API routes;
 - tests/fixtures.
 
+Actual executable file ownership and migration reservations must be assigned fresh by the Supervisor after entry criteria pass.
+
 ## Data/migration impact
 
-Adds entity/version/look/lock/reference relationships and indexes/search fields.
+Expected future implementation adds entity/version/look/lock/reference relationships and indexes/search fields.
+
+This planning slice creates **no migration reservation and no schema change**. Future migration IDs must be reserved only after executable M04 authority is granted and the then-current migration head is re-audited.
 
 ## API/UI impact
 
-API sufficient for future Character Library UI. No polished web library required yet.
+Future API should be sufficient for a Character Library UI. No polished web library is required for initial M04 source acceptance.
+
+This planning slice changes no API or UI.
 
 ## Security/cost/rights impact
 
-- tenant isolation;
-- likeness/voice/right records;
-- no paid generation required to accept milestone;
-- imported references require provenance/consent state.
+Future M04 must preserve:
 
-## Test/acceptance
+- tenant and project authority isolation;
+- exact likeness/voice/reference ownership, consent and provenance records;
+- secret/reference separation — raw provider credentials never become canonical identity or ordinary prompt/memory data;
+- no paid generation requirement for milestone source acceptance unless a later explicit gate requires real-provider evidence;
+- fail-closed imported-reference validation;
+- provider/model/retrieval outputs as untrusted evidence rather than authority.
 
-- same locked character reused in multiple projects by exact version;
-- forbidden mutation rejected;
-- new look/version does not alter previous projects;
-- reference pack assets lineage valid;
-- cross-tenant entity inaccessible.
+## Test/acceptance plan
+
+Targeted future acceptance evidence includes:
+
+- same locked character reused in multiple authorized projects by exact version;
+- forbidden lock mutation rejected;
+- new look/version does not alter previous pinned projects;
+- reference-pack asset lineage and content identity remain valid;
+- cross-tenant entity/version/look/reference inaccessible;
+- foreign reference asset ID rejected before reuse;
+- import/export manifest cannot bypass ownership/rights/consent;
+- low-trust imported/generated instructions cannot mutate policy, lock or privileged authority;
+- rights/provenance remain attached across fork/version/export/import;
+- newly introduced trust paths receive only the minimum adversarial tests required by the cross-cutting QA map.
 
 ## Rollout/rollback
 
-Append/version-based. Rollback code/migrations without rewriting historical entity versions.
+Planned implementation is append/version-based. Rollback must not rewrite historical entity versions or invalidate previously pinned lineage. Migration rollback details must be designed against the actual future schema before executable promotion.
 
 ## Exit criteria
 
-One recurring character can be versioned, locked, reference-packed and reused across multiple projects with stable provider-neutral identity and rights lineage.
+M04 can exit only when one recurring character/entity can be versioned, locked, reference-packed and reused across multiple authorized projects with stable provider-neutral identity, exact lineage, rights/consent continuity and adversarial authority/tenant protections proven by targeted evidence.
+
+Planning completion is **not** milestone completion.
 
 ## Non-goals
 
 - actual provider image/video generation;
 - advanced web Character Library design;
 - biometric identity matching claims;
-- celebrity/voice cloning without later policy implementation.
+- celebrity/voice cloning without later policy implementation;
+- production credentials or paid provider calls during this planning slice;
+- using generic `continue`, branch synchronization, mocks or green planning CI as executable M04 consent.


### PR DESCRIPTION
Implements Issue #77 as a planning-only M04 Character/Entity Library reconciliation on current `main@5c7d3bab84992a8681c64ffe4911637568ad608b`.

Scope is intentionally bounded to two planning files:
- hardens `docs/milestones/M04/PLAN.md` with broadcast-12 / cross-cutting adversarial QA constraints;
- creates the previously missing `ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md`.

The planning contract now makes these future executable gates explicit: Issue #36 live protected-main governance, explicit M04 executable consent, fresh write/migration/broadcast revalidation, canonical tenant/project authorization, lock integrity, append/version immutability, rights/consent/provenance continuity, reference-pack trust boundaries, provider-output distrust hooks, and no synthetic production/security success.

No product/API/schema/migration/provider/test implementation, paid call, credential, production data, publish action or executable M04 authorization is included. M05/M07/M08 remain dependency-gated.

Work Done and Submitted