### PR TITLE
GOV: broadcast M04 planning promotion constraints

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -1,4 +1,4 @@
-version: 9
+version: 10
 supervisor:
   role: supervisor
   assigned_agent: supervisor-agent
@@ -13,7 +13,7 @@ active:
     role: supervisor-governance
     assigned_agent: supervisor-agent
     branch: supervisor/m03-governance-hold-current
-    base_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    base_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
     module: m03_governance_hold
     status: active-governance-hold
     writes:
@@ -24,15 +24,15 @@ active:
     migration_reservation: null
     consent_scope: M03-governance-closeout-only
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
-    last_acknowledged_broadcast: 12
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_broadcast: 13
     required_broadcast: null
 
   - task_id: M04-PARALLEL-LANE
     title: Character and Entity Library planning/contracts
     role: planning-contract
     assigned_agent: character-agent
-    branch: agent/m04-character-library
+    branch: agent/m04-character-library-current
     module: characters_entities
     status: planning-only
     writes:
@@ -44,8 +44,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
-    last_acknowledged_broadcast: 12
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_broadcast: 13
     required_broadcast: null
 
   - task_id: M05-PARALLEL-LANE
@@ -64,8 +64,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
-    last_acknowledged_broadcast: 12
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_broadcast: 13
     required_broadcast: null
 
   - task_id: M06-PARALLEL-LANE
@@ -84,8 +84,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
-    last_acknowledged_broadcast: 12
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_broadcast: 13
     required_broadcast: null
 
   - task_id: M07-PARALLEL-LANE
@@ -106,8 +106,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
-    last_acknowledged_broadcast: 12
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_broadcast: 13
     required_broadcast: null
 
   - task_id: M08-PARALLEL-LANE
@@ -127,8 +127,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
-    last_acknowledged_broadcast: 12
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_broadcast: 13
     required_broadcast: null
 
   - task_id: CROSS-CUTTING-QA
@@ -147,8 +147,8 @@ active:
     migration_reservation: null
     consent_scope: audit-planning; executable test changes require applicable scope
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
-    last_acknowledged_broadcast: 12
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_broadcast: 13
     required_broadcast: null
 
 rules:

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "source_branch_required": "main",
   "assignment_authority": "supervisor",
   "no_slot_response": "Go Home Come Back Next Time",
@@ -13,7 +13,7 @@
   },
   "slots": [
     {"slot_id":"SUPERVISOR-M03-GOV-HOLD","module":"m03_governance_hold","branch":"supervisor/m03-governance-hold-current","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-governance-hold"},
-    {"slot_id":"M04-CHARACTER","module":"characters_entities","branch":"agent/m04-character-library","status":"occupied","assigned_agent":"character-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"M04-CHARACTER","module":"characters_entities","branch":"agent/m04-character-library-current","status":"occupied","assigned_agent":"character-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M07-TIMELINE","module":"timeline_storyboard","branch":"agent/m07-storyboard-timeline","status":"occupied","assigned_agent":"timeline-agent","accepts_new_agent":true,"start_status":"planning-only"},

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
-version: 8
-latest_sequence: 12
+version: 9
+latest_sequence: 13
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -111,43 +111,70 @@ broadcasts:
       - agent/m08-video-provider-router
       - agent/cross-cutting-qa-security-current
     mandatory: true
+  - sequence: 13
+    trigger: m04-planning-promotion
+    merged_pr: 78
+    merged_branch: agent/m04-character-library
+    submitted_head_sha: 8525499dcaf6889c252de89369ff312cde0464f7
+    merged_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-m04-planning-hardening-sync
+    changed_areas:
+      - M04 planning contract hardened with cross-cutting adversarial obligations
+      - missing M04 planning checkpoint created
+      - Issue 36 protected-main governance remains an executable M04 dependency
+      - explicit M04 executable consent remains required
+      - downstream M05/M07/M08 dependencies remain holds, not completion signals
+    contract_changes:
+      - M04 future executable promotion must revalidate tenant authority, lock integrity, version immutability, rights/provenance and reference-pack trust boundaries
+      - planning synchronization does not grant executable M04 or downstream authority
+    schema_migration_changes: []
+    recipients:
+      - supervisor/m03-governance-hold-current
+      - agent/m04-character-library-current
+      - agent/m05-content-memory
+      - agent/m06-audio-production
+      - agent/m07-storyboard-timeline
+      - agent/m08-video-provider-router
+      - agent/cross-cutting-qa-security-current
+    mandatory: true
 
 recipient_states:
   supervisor/m03-governance-hold-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 12
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
-  agent/m04-character-library:
+    last_acknowledged_sequence: 13
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+  agent/m04-character-library-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 12
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_sequence: 13
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
   agent/m05-content-memory:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 12
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_sequence: 13
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
   agent/m06-audio-production:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 12
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_sequence: 13
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
   agent/m07-storyboard-timeline:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 12
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_sequence: 13
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
   agent/m08-video-provider-router:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 12
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_sequence: 13
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
   agent/cross-cutting-qa-security-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 12
-    last_synced_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+    last_acknowledged_sequence: 13
+    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
 
 rules:
   - Supervisor increments latest_sequence after every successful promotion merge to main that active agents must observe.

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -6,61 +6,80 @@ The Supervisor owns assignment, coordination-state mutation, review order, and p
 
 New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after Supervisor assignment. All defined slots are occupied, so an additional arrival receives exactly **Go Home Come Back Next Time**.
 
+Planning synchronization, a green planning PR, or conversational continuation does not grant privileged/executable development authority.
+
 ## Current branch matrix
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 12 synchronized |
-| M04 Character | `character-agent` | `agent/m04-character-library` | broadcast 12 synchronized; planning-only; dependency-gated |
-| M05 Content | `content-agent` | `agent/m05-content-memory` | broadcast 12 synchronized; planning-only; dependency-gated |
-| M06 Audio | `audio-agent` | `agent/m06-audio-production` | broadcast 12 synchronized; planning-only; dependency-gated |
-| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | broadcast 12 synchronized; planning-only; dependency-gated |
-| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 12 synchronized; planning-only; dependency-gated |
-| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 12 synchronized; audit/planning only |
+| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 13 synchronized |
+| M04 Character | `character-agent` | `agent/m04-character-library-current` | broadcast 13 synchronized; planning hardened; executable hold |
+| M05 Content | `content-agent` | `agent/m05-content-memory` | broadcast 13 synchronized; planning-only; dependent on executable M04 |
+| M06 Audio | `audio-agent` | `agent/m06-audio-production` | broadcast 13 synchronized; planning-only; M03 governance dependency retained |
+| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | broadcast 13 synchronized; planning-only; dependent on M04/M05/M06 |
+| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 13 synchronized; planning-only; dependent on M04/M07 |
+| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 13 synchronized; audit/planning only |
 
-Completed QA submission branch `agent/cross-cutting-qa-security` is retired from active authority after PR #74. `agent/cross-cutting-qa-security-current` is the fresh current-main audit/planning branch. Earlier completed M03/WP8 submission/review/closeout branches remain retired.
+Completed `agent/m04-character-library` is retired after squash-merge PR #78 and is not force-reset or reusable as promotion authority. `agent/m04-character-library-current` is the fresh current-main planning branch. Earlier completed QA and M03/WP8 submission/review/closeout branches remain retired.
 
 ## M03 source completion and external hold
 
-M03 implementation, WP8 source acceptance, and source-side closeout are complete. Issue #36 remains the final M03 protected-main governance blocker because live GitHub enforcement is not verified. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
+M03 implementation, WP8 source acceptance, and source-side closeout are complete. Issue #36 remains the final M03 protected-main governance blocker because live GitHub enforcement is not verified.
 
-Migrations `20260901_0015` and `20260901_0016` remain landed; there is no active M03 migration reservation.
+Migrations `20260901_0015` and `20260901_0016` remain landed; there is no active M03 or M04 migration reservation. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
 
 ## Cross-cutting QA promotion
 
-PR #74 landed `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` and the QA checkpoint at `main@6eab0440ef32280c16e41b41851deb3f11937495` after exact-head Repository Governance, Core Domain Contracts and Durable Control Plane passed.
+PR #74 landed `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` at `main@6eab0440ef32280c16e41b41851deb3f11937495`. Broadcast 12 made its authority/tenant/secret/memory/provider/budget/rights/multimodal adversarial obligations mandatory inputs for future milestone acceptance.
 
-The plan reuses current M03 focused evidence and assigns future adversarial obligations only where later modules introduce new trust or authority surfaces. It covers authority isolation, tenant validation, memory poisoning, provider-output distrust, secret handling, budget/retry ceilings, rights/provenance and multimodal instruction isolation.
+The QA plan is an audit/planning constraint. It does not grant feature execution, provider spend, production credentials, publication or security-setting authority.
 
-Broadcast 12 records this cross-cutting acceptance guidance because future M04-M08 work must observe it. The broadcast is an acceptance/planning constraint, not feature-execution authority.
+## M04 planning promotion
+
+PR #78 `M04: harden planning against adversarial trust boundaries` passed exact-head Repository Governance, Core Domain Contracts and Durable Control Plane and merged to `main@5367ffe5401292744cbe29d8f1a16c36591fae27`.
+
+That promotion:
+
+- hardened the M04 planning contract with canonical tenant/project authorization, lock integrity, append/version immutability, rights/consent/provenance continuity, reference-pack trust boundaries and provider-output distrust hooks;
+- created the previously missing `ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md`;
+- explicitly retained Issue #36 live protected-main governance and explicit M04 executable consent as mandatory entry gates;
+- created no product/API/schema/provider implementation and no migration reservation;
+- did not complete executable M04 and therefore did not satisfy downstream M05/M07/M08 executable dependencies.
+
+Broadcast 13 records this planning promotion for every affected active lane.
 
 ## Dependency and consent boundary
 
-- M04 and M06 remain dependent on `M03-GOV-HOLD`.
-- M05 remains dependent on M04.
-- M07 remains dependent on M04/M05/M06.
-- M08 remains dependent on M04/M07.
-- Cross-cutting QA has no module dependency but remains audit/planning only unless an applicable executable scope authorizes tests.
-- `docs/milestones/M04/PLAN.md` requires M01-M03 accepted plus explicit M04 consent before executable M04 work.
-- The repository threat model explicitly states generic `continue` is not privileged development, publish or security authorization.
-
-Therefore no later module may treat branch synchronization or conversational continuation as satisfying its executable entry criteria.
+- M04 executable work remains dependent on `M03-GOV-HOLD` and explicit M04 executable consent.
+- M05 executable work remains dependent on executable M04 completion; M04 planning completion is insufficient.
+- M06 executable work retains its M03 governance dependency and requires applicable executable consent.
+- M07 executable work remains dependent on executable M04/M05/M06 completion.
+- M08 executable work remains dependent on executable M04/M07 completion.
+- Cross-cutting QA has no module dependency but remains audit/planning only unless an applicable executable scope authorizes targeted tests.
+- Generic `continue`, branch synchronization, green planning CI, mocks, or a planning checkpoint cannot satisfy a privileged development/publish/security gate.
 
 ## Parallel safety
 
-`ACTIVE-WORK.yaml` is authoritative for active write claims. Later planning lanes remain disjoint and may update only their claimed planning/checkpoint surfaces. QA owns `docs/qa/**` and its checkpoint plus shared-request access to security docs; executable product/test changes require separate applicable scope.
+`ACTIVE-WORK.yaml` is authoritative for active write claims. Planning lanes may update only their claimed milestone-plan/checkpoint surfaces. QA owns its documented QA/checkpoint surfaces plus explicitly requested security documentation access. Executable product/test/schema/provider writes require fresh applicable authority and collision-free ownership.
+
+Future migration IDs are reserved only after executable authority exists and the then-current migration head has been re-audited.
 
 ## Hold order
 
-1. maintain Issue #36 as `EXTERNAL_NOT_VERIFIED` while protected-main evidence is absent;
-2. preserve broadcast 12 adversarial obligations in future milestone acceptance;
-3. do not start M04/M06 executable work until M03 acceptance/governance dependency and explicit executable consent are satisfied;
-4. do not promote downstream M05/M07/M08 past their dependency chain;
-5. do not create synthetic provider/admin/production evidence from mocks or source CI.
+1. keep Issue #36 `EXTERNAL_NOT_VERIFIED` until live protected-main evidence exists;
+2. preserve broadcast 12 adversarial obligations and broadcast 13 M04 planning constraints in future milestone acceptance;
+3. do not start executable M04 until Issue #36 and explicit M04 executable consent both clear;
+4. do not treat M04 planning completion as satisfying M05/M07/M08 executable dependencies;
+5. do not promote M06 executable work while its M03 governance/consent gates remain unresolved;
+6. do not create synthetic provider/admin/production success from source CI, mocks or deterministic fakes.
+
+## Next safe planning work
+
+While executable gates remain closed, a later planning lane may be audited and hardened only within its existing planning consent scope. Any such planning slice must identify a real documentation/checkpoint gap, preserve all dependency/consent holds, avoid implementation/schema/provider work, and pass ordinary exact-head repository/source regression CI before merge.
 
 ## Completion and review
 
-Every ready bounded submission announces exactly **Work Done and Submitted**. Before promotion, the Supervisor verifies exact head/base, current-main freshness, write ownership, migration state, consent/dependencies, tests, security/data implications, and unresolved review findings. Required exact-head CI must be green.
+Every ready bounded submission announces exactly **Work Done and Submitted**. Before promotion, the Supervisor verifies exact head/base, current-main freshness, write ownership, migration state, consent/dependencies, tests, security/data implications and unresolved review findings. Required exact-head CI must be green.
 
 After a successful promotion that active agents must observe, emit exactly:
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -1,9 +1,9 @@
-version: 9
+version: 10
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 6eab0440ef32280c16e41b41851deb3f11937495
-  main_sha_last_reconciled: 6eab0440ef32280c16e41b41851deb3f11937495
+  main_sha_last_promotion: 5367ffe5401292744cbe29d8f1a16c36591fae27
+  main_sha_last_reconciled: 5367ffe5401292744cbe29d8f1a16c36591fae27
   own_task_id: M03-GOV-HOLD
   own_branch: supervisor/m03-governance-hold-current
   current_mode: external-governance-hold
@@ -11,9 +11,9 @@ supervisor:
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 74
-  submitted_head_sha: 6ce2de1bf01ae9562ee2b370ca53760bd05f9ebd
-  merged_main_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+  pr: 78
+  submitted_head_sha: 8525499dcaf6889c252de89369ff312cde0464f7
+  merged_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
   result: success
 
 new_agent_onboarding:
@@ -26,7 +26,7 @@ new_agent_onboarding:
 pause_checkpoint:
   active: true
   branch: supervisor/m03-governance-hold-current
-  head_sha: 6eab0440ef32280c16e41b41851deb3f11937495
+  head_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
   task_id: M03-GOV-HOLD
   subtask: wait-for-live-protected-main-evidence
   next_action: verify Issue 36 live ruleset/protection read-back from an admin-capable context
@@ -35,7 +35,7 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 12
+  latest_broadcast_sequence: 13
   agents_with_mandatory_sync: []
   policy: branches-with-unacknowledged-mandatory-broadcast-cannot-seek-promotion
 
@@ -45,11 +45,28 @@ external_gates:
   live_ruleset_readback: []
   effect: M03 source acceptance complete; final protected-main governance/promotion remains blocked
 
+planning_state:
+  m04:
+    status: planning-hardened-only
+    promotion_pr: 78
+    active_branch: agent/m04-character-library-current
+    executable_authority: false
+    executable_gates:
+      - Issue 36 live protected-main governance
+      - explicit M04 executable consent
+      - fresh write ownership and migration reservation if required
+  downstream:
+    m05: dependency-gated-planning-only
+    m06: dependency-gated-planning-only
+    m07: dependency-gated-planning-only
+    m08: dependency-gated-planning-only
+
 rules:
   - The Supervisor reviews and merges incoming module PRs; module agents do not merge themselves.
   - Supervisor implementation occurs on its own bounded branch, never directly on main.
-  - Completed submission branches are retired or replaced before the next bounded slice.
+  - Completed submission branches are retired or replaced before the next bounded executable slice.
   - New agents begin from main and may not self-assign.
   - If no eligible open slot exists, respond exactly Go Home Come Back Next Time and assign no work.
-  - Every successful promotion merge produces a broadcast before feature implementation resumes.
+  - Every successful promotion merge produces a broadcast before affected planning or feature work resumes.
   - Main SHA, slot state, migration state, write ownership, and broadcast state are reconciled after every promotion.
+  - Planning promotion or branch synchronization does not grant executable milestone authority.


### PR DESCRIPTION
Implements Issue #79 as governance-only coordination after M04 planning PR #78 merged to `main@5367ffe5401292744cbe29d8f1a16c36591fae27`.

This PR changes exactly the five canonical Supervisor coordination files and:
- records mandatory broadcast sequence 13 for the M04 planning promotion;
- retires completed `agent/m04-character-library` from active authority and binds fresh `agent/m04-character-library-current`;
- records all active planning/audit lanes synchronized to the triggering main;
- preserves Issue #36 live protected-main governance and explicit M04 consent as executable M04 gates;
- preserves M05/M07/M08 downstream dependency holds and M06 governance/consent hold;
- records that planning synchronization/green planning CI/generic continuation do not grant executable authority.

No milestone product/API/schema/provider/test implementation, migration, credential, paid call, production data, publish action, security-setting mutation or executable milestone unlock.

Work Done and Submitted