### PR TITLE
M05: harden memory planning against poisoning and authority escalation

### DIFF
--- a/ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md
+++ b/ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md
@@ -1,0 +1,58 @@
+# M05 Parallel Lane Checkpoint
+
+## Authority
+
+- Issue: #81 — M05 planning hardening — memory authority and poisoning constraints
+- Lane: `M05-PARALLEL-LANE`
+- Branch: `agent/m05-content-memory`
+- Planning baseline: `main@a7aa25e86bd5092ab9979f26765d48a7b3f34ffc`
+- Broadcast state: sequence 13 synchronized
+- Consent scope: planning-only-until-new-scope-approved
+- Executable M05 authority: **not granted**
+- Migration reservation: none
+- Product/API/schema/provider/test implementation: not authorized by this checkpoint
+
+## Planning work completed
+
+- Reconciled `docs/milestones/M05/PLAN.md` with the cross-cutting adversarial QA memory/retrieval threat map.
+- Made executable M04 completion and explicit M05 executable consent mandatory entry gates; M04 planning completion does not satisfy the dependency.
+- Added planning obligations for deterministic memory promotion authority, provenance/source-class/freshness/contradiction/expiry visibility, tenant/project/series isolation, correction/forget behavior, secret exclusion, external-research distrust, provider/model-output distrust and bounded retries/cost.
+- Recorded that low-trust observations, hypotheses, retrieved instructions, model output or malicious “admin rules” cannot become canonical policy or approval state without configured deterministic promotion authority.
+- Recorded that correction/forget must remove future retrieval authority while preserving required audit/history evidence.
+- Created this previously missing M05 planning checkpoint.
+
+## Current evidence classification
+
+- M05 executable surface: `DEFERRED_MODULE` — not authorized yet.
+- Executable M04 dependency: not satisfied; only M04 planning hardening is complete.
+- M03 live protected-main governance: `EXTERNAL_NOT_VERIFIED` — Issue #36 remains open.
+- Cross-cutting QA memory obligations: planning-integrated.
+- M05 schema/migrations: not reserved/not implemented.
+- Paid/provider/production evidence: not required and not produced by this planning slice.
+
+## Mandatory executable entry recheck
+
+Before any M05 implementation branch or migration reservation is created, the Supervisor must verify all of the following against then-current main:
+
+1. Executable M04 is completed/accepted at its required truth level; a planning checkpoint is insufficient.
+2. Explicit M05 executable consent exists; generic conversational continuation is insufficient.
+3. Current upstream governance/dependency requirements, including Issue #36 where applicable to the repository's accepted milestone chain, are satisfied at their required truth level rather than assumed from source CI.
+4. M05 branch/write ownership is freshly assigned with no collision.
+5. Current migration head is audited and any required revision is reserved before schema writes.
+6. Broadcast/dependency state is synchronized.
+7. The exact proposed research/memory/generation surface is re-evaluated against `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` and receives only targeted missing adversarial evidence.
+8. Raw secrets remain outside ordinary memory/embedding/prompt/log payloads.
+9. Provider/research/model attempts, fan-out and cost use configured bounds and applicable budget authority.
+10. No production credential, paid call or public side effect is introduced unless separately authorized.
+
+## Downstream hold
+
+- M07 cannot treat this planning checkpoint as completed executable M05.
+- M08 remains dependent on executable M04/M07 completion.
+- Branch synchronization, planning completion or green planning CI does not satisfy executable dependency gates.
+
+## Next authorized action
+
+Submit this planning-only two-file change for ordinary exact-head Repository Governance, Core Domain Contracts and Durable Control Plane CI. If merged, close Issue #81 as planning complete and keep executable M05 on hold until the mandatory entry criteria above are satisfied.
+
+Work Done and Submitted

--- a/docs/milestones/M05/PLAN.md
+++ b/docs/milestones/M05/PLAN.md
@@ -1,19 +1,39 @@
 # M05 — Content Intelligence and Memory
 
+## Planning authority and current state
+
+This document is the planning contract for M05 only. It does **not** authorize executable M05 product/API/schema/provider work.
+
+Current planning baseline: `main@a7aa25e86bd5092ab9979f26765d48a7b3f34ffc`, after cross-cutting adversarial QA and M04 planning/broadcast-13 reconciliation.
+
+Executable M05 work remains blocked until executable M04 is accepted, explicit M05 executable consent is recorded, and all then-current governance/dependency/migration/write-ownership gates are revalidated. M04 planning completion is not executable M04 completion. Generic conversational continuation is not executable consent.
+
 ## Objective
 
-Implement provider-neutral research, originality control, concept selection, script/lyrics/story generation, policy profiles and persistent semantic memory so `next content` can create a researched, uniqueness-cleared canonical content package.
+Implement provider-neutral research, originality control, concept selection, script/lyrics/story generation, policy profiles and persistent semantic memory so `next content` can create a researched, uniqueness-cleared canonical content package without allowing low-trust research, retrieval, memory or model output to gain policy/security authority.
 
 ## Entry criteria
 
-- P0 complete.
-- M01–M04 accepted.
-- Explicit M05 consent.
-- Current search/research/model APIs revalidated.
+All are required before executable M05 work begins:
+
+- P0 complete;
+- M01–M03 accepted at required truth levels;
+- executable M04 completed/accepted, not merely planning-hardened;
+- explicit M05 executable consent recorded through Supervisor authority;
+- current search/research/model APIs revalidated;
+- current main, broadcast, dependency, write ownership and migration state revalidated immediately before implementation;
+- cross-cutting adversarial QA obligations applicable to the proposed M05 executable surface mapped to targeted evidence.
+
+Current state: planning may continue, but executable M05 entry criteria are **not satisfied** because executable M04 is not complete and explicit M05 executable consent is absent. Issue #36 also remains an upstream live-governance truth boundary and must not be fabricated as verified.
 
 ## Dependencies
 
 `M01 -> M02 -> M03 -> M04 -> M05`
+
+Downstream impact:
+
+- M07 depends on executable M04/M05/M06;
+- downstream synchronization or planning completion does not satisfy executable dependency gates.
 
 ## Work packages
 
@@ -24,7 +44,8 @@ Implement provider-neutral research, originality control, concept selection, scr
 - freshness timestamps;
 - evidence snapshots/references;
 - conflicting-source handling;
-- no web content treated as instructions.
+- no web/retrieved content treated as instructions or policy authority;
+- explicit source trust/provenance classification retained into downstream decisions.
 
 ### M05-WP2 — Portfolio memory and semantic retrieval
 - PostgreSQL + pgvector memory store;
@@ -32,21 +53,26 @@ Implement provider-neutral research, originality control, concept selection, scr
 - tenant/project/series scoping;
 - candidate vs approved memory lifecycle;
 - freshness/authority filters;
-- deletion/correction propagation.
+- contradiction/expiry/source-class visibility;
+- deletion/correction propagation;
+- deterministic promotion path for stronger memory classes;
+- retrieval result carries provenance/class/version instead of returning context as untyped trusted prose.
 
 ### M05-WP3 — Duplicate/originality engine
 - title/theme/plot/hook/character/learning objective/lyrics/refrain/resolution/visual-concept comparison;
 - exact and semantic similarity;
 - configurable thresholds;
 - explainable collision report;
-- false-positive review path.
+- false-positive review path;
+- similarity output is advisory evidence and cannot silently change canonical rights/policy/approval state.
 
 ### M05-WP4 — Concept and format selector
 - use project audience/format/duration/policy;
 - generate candidate concepts;
 - score novelty/fit/feasibility/rights/risk;
 - avoid portfolio repetition;
-- record decision alternatives.
+- record decision alternatives;
+- retrieved memories/research remain evidence and cannot grant budget, publish, security or policy authority.
 
 ### M05-WP5 — Content generation services
 Structured generation for:
@@ -57,7 +83,7 @@ Structured generation for:
 - episode/short film/movie outline;
 - documentary/trailer/social derivative concepts.
 
-Outputs are versioned canonical content artifacts, not provider-specific prompts only.
+Outputs are versioned canonical content artifacts, not provider-specific prompts only. Model/provider output remains untrusted until schema/policy/rights validation succeeds.
 
 ### M05-WP6 — Policy/safety/rights content QA
 - audience/age profile;
@@ -66,14 +92,17 @@ Outputs are versioned canonical content artifacts, not provider-specific prompts
 - forbidden claims/content rules;
 - factual grounding for research-dependent content;
 - structured QA findings;
-- approve/revise/block states.
+- approve/revise/block states;
+- approval state can only be produced by deterministic configured authority, never by retrieved/model-authored statements claiming approval.
 
 ### M05-WP7 — Memory promotion and learning history
-- approved concepts/scripts become project/portfolio memory;
-- failed/rejected outputs recorded as failure memory;
-- external evidence remains provenance-linked;
-- no silent promotion of model hallucinations;
-- AI decision ledger integration.
+- approved concepts/scripts become project/portfolio memory only through deterministic promotion authority;
+- failed/rejected outputs recorded as appropriately classified failure memory;
+- external evidence remains provenance-linked and low-trust unless explicitly promoted through an authorized path;
+- no silent promotion of model hallucinations, retrieved instructions or malicious memory;
+- AI decision ledger integration;
+- correction/forget operations remove future retrieval authority while preserving required audit/history evidence;
+- raw secrets, OAuth tokens and provider credentials are never ordinary memory payloads.
 
 ### M05-WP8 — `next content` orchestrator and acceptance
 Flow:
@@ -84,10 +113,33 @@ Acceptance fixtures:
 - general-audience story;
 - duplicate-near-match rejection;
 - stale/conflicting research;
-- deletion/correction of memory;
+- malicious retrieved-memory/prompt-injection case;
+- deletion/correction/forget behavior;
+- tenant-isolated retrieval;
 - 90-minute outline package.
 
+## Cross-cutting adversarial acceptance obligations
+
+Broadcast 12 and `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` are mandatory planning inputs. When M05 later requests executable promotion, QA must re-evaluate the exact proposed surface and add only targeted evidence for newly reachable authority paths.
+
+At minimum M05 acceptance must prove:
+
+1. **Memory cannot self-promote** — an observation, hypothesis, retrieved document, model output or malicious “admin rule” cannot become an approved/canonical rule without configured deterministic promotion authority.
+2. **Policy precedence is explicit** — retrieved memory/research cannot override system/product policy, tenant permissions, approval class, budget or security controls.
+3. **Provenance remains visible** — source, trust class, version, freshness, contradiction and expiry state remain attached to retrieved memory and evidence.
+4. **Tenant/project/series isolation** — cross-tenant memory/embedding/result IDs are rejected through canonical authorization rather than trusted from vector/model/provider output.
+5. **Correction/forget semantics are bounded** — corrected/forgotten content loses future retrieval authority without silently rewriting required audit history or corrupting unrelated memory.
+6. **Secrets stay out of memory** — raw provider/OAuth/security credentials are references/secret handles outside ordinary memory, prompts, embeddings, logs and decision payloads.
+7. **External research is untrusted** — web/upload/retrieved instructions remain evidence and cannot mutate tool/provider configuration or invoke privileged actions.
+8. **Provider/model outputs are untrusted** — returned IDs, citations, URLs, classifications or instructions require schema validation, canonical lookup and policy checks.
+9. **Retries/cost are bounded** — future research/model/embedding retries and fallbacks require attempt/time/fan-out/cost ceilings, idempotency and applicable budget authority.
+10. **No synthetic production/security success** — deterministic fakes may prove source contracts; unavailable live admin/provider/publish evidence remains `NOT_VERIFIED` when a later gate requires it.
+
+Do not add duplicate umbrella tests for already-proven lower-layer M03 properties unless M05 creates a new authority/trust path.
+
 ## Expected modules/files
+
+Planned future executable surface only:
 
 - research service/adapters;
 - memory/retrieval package;
@@ -97,40 +149,58 @@ Acceptance fixtures:
 - content orchestration workflow/activity modules;
 - `tests/content/`, `tests/memory/`, `tests/research/`.
 
+Actual executable write ownership and migration reservations must be assigned fresh by the Supervisor after entry criteria pass.
+
 ## Data/migration impact
 
-Adds memory records, embeddings, source/evidence records, concept candidates, content versions, originality reports and decision references.
+Expected future implementation adds memory records, embeddings, source/evidence records, concept candidates, content versions, originality reports and decision references.
+
+This planning slice creates **no migration reservation and no schema change**. Future migration IDs must be reserved only after executable M05 authority exists and the then-current migration head is audited.
 
 ## API/UI impact
 
-Adds APIs for research/content candidates, generation, originality report, content versions and memory inspection/correction. Full polished content editor UI is later.
+Future implementation may add APIs for research/content candidates, generation, originality reports, content versions and memory inspection/correction. Full polished content editor UI is later.
+
+This planning slice changes no API or UI.
 
 ## Security/cost/rights impact
 
-- external research content untrusted;
-- provider/model calls budgeted and logged;
-- embeddings tenant-scoped;
-- private content not training data by default;
-- rights/originality blocks before canonical approval.
+Future M05 must preserve:
 
-## Test/acceptance
+- external research/retrieval as untrusted evidence;
+- provider/model calls budgeted, bounded and logged without leaking secrets;
+- embeddings and memory tenant/project/series scoped;
+- private content not treated as training data by default;
+- rights/originality checks before canonical approval;
+- deterministic memory promotion authority;
+- correction/forget semantics that remove future influence without destroying required auditability;
+- explicit separation between evidence/memory and privileged policy/approval/security state.
 
-Apply Master QA AI/research/memory sections:
-- prompt-injection research fixture;
-- duplicate detection;
-- source provenance/freshness;
-- memory poisoning/tenant isolation;
-- structured output;
+## Test/acceptance plan
+
+Targeted future evidence includes:
+
+- prompt-injection research fixture cannot mutate policy/tool/provider configuration;
+- malicious memory claiming administrative authority remains low-trust and cannot become approved policy;
+- retrieved observation/hypothesis cannot override configured policy;
+- duplicate detection and explainable collision behavior;
+- source provenance/freshness/conflict visibility;
+- memory poisoning and tenant-isolation rejection;
+- correction/forget removes future retrieval authority while preserving audit history;
+- raw secret material never enters memory/embedding/log payloads;
+- structured output validation fails closed;
 - model/prompt regression suite;
-- cost-bounded fake-provider tests.
+- cost-bounded fake-provider tests for source behavior only.
 
 ## Rollout/rollback
 
-AI prompt/model behavior is versioned and release-gated. New memory-policy versions can be rolled back without deleting historical records. Embedding changes use versioned reindex/backfill.
+Future AI prompt/model/memory-policy behavior is versioned and release-gated. New memory-policy versions can be rolled back without deleting historical records. Embedding changes use versioned reindex/backfill. Correction/forget behavior must have explicit retention/audit semantics rather than ad-hoc destructive rewrites.
 
 ## Exit criteria
 
-`next content` reliably produces a researched, originality-cleared, policy-checked, versioned canonical content package and records decisions/evidence/memory without provider lock-in.
+M05 can exit only when `next content` reliably produces a researched, originality-cleared, policy-checked, versioned canonical content package and records decisions/evidence/memory without provider lock-in, cross-tenant leakage, memory self-promotion or low-trust evidence gaining privileged authority.
+
+Planning completion is **not** executable milestone completion.
 
 ## Non-goals
 
@@ -138,4 +208,6 @@ AI prompt/model behavior is versioned and release-gated. New memory-policy versi
 - final audio master;
 - full web content editor;
 - autonomous public publishing;
-- analytics-driven self-modification without evaluation.
+- analytics-driven self-modification without evaluation;
+- production credentials or paid provider calls during this planning slice;
+- using generic `continue`, branch synchronization, mocks or green planning CI as executable M05 consent.


### PR DESCRIPTION
Implements Issue #81 as a planning-only M05 Content Intelligence and Memory reconciliation on current `main@a7aa25e86bd5092ab9979f26765d48a7b3f34ffc`.

Scope is intentionally bounded to two planning files:
- hardens `docs/milestones/M05/PLAN.md` with cross-cutting memory/retrieval adversarial constraints;
- creates the previously missing `ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md`.

The planning contract now makes these future executable requirements explicit: executable M04 completion, explicit M05 executable consent, deterministic memory-promotion authority, tenant/project/series isolation, provenance/source-class/freshness/contradiction/expiry visibility, correction/forget semantics, secret exclusion, untrusted external research/provider/model output, and bounded retries/cost.

No product/API/schema/migration/provider/test implementation, paid call, credential, production data, publish action or executable M05 authorization is included. M07 remains dependency-gated; M04 planning completion is explicitly insufficient as executable M04 evidence.

Work Done and Submitted