### PR TITLE
GOV: broadcast M05 planning promotion constraints

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -1,4 +1,4 @@
-version: 10
+version: 11
 supervisor:
   role: supervisor
   assigned_agent: supervisor-agent
@@ -13,7 +13,7 @@ active:
     role: supervisor-governance
     assigned_agent: supervisor-agent
     branch: supervisor/m03-governance-hold-current
-    base_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    base_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
     module: m03_governance_hold
     status: active-governance-hold
     writes:
@@ -24,8 +24,8 @@ active:
     migration_reservation: null
     consent_scope: M03-governance-closeout-only
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
-    last_acknowledged_broadcast: 13
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_broadcast: 14
     required_broadcast: null
 
   - task_id: M04-PARALLEL-LANE
@@ -44,15 +44,15 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
-    last_acknowledged_broadcast: 13
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_broadcast: 14
     required_broadcast: null
 
   - task_id: M05-PARALLEL-LANE
     title: Content Intelligence and Memory planning/contracts
     role: planning-contract
     assigned_agent: content-agent
-    branch: agent/m05-content-memory
+    branch: agent/m05-content-memory-current
     module: content_memory
     status: planning-only
     writes:
@@ -64,8 +64,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
-    last_acknowledged_broadcast: 13
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_broadcast: 14
     required_broadcast: null
 
   - task_id: M06-PARALLEL-LANE
@@ -84,8 +84,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
-    last_acknowledged_broadcast: 13
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_broadcast: 14
     required_broadcast: null
 
   - task_id: M07-PARALLEL-LANE
@@ -106,8 +106,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
-    last_acknowledged_broadcast: 13
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_broadcast: 14
     required_broadcast: null
 
   - task_id: M08-PARALLEL-LANE
@@ -127,8 +127,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
-    last_acknowledged_broadcast: 13
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_broadcast: 14
     required_broadcast: null
 
   - task_id: CROSS-CUTTING-QA
@@ -147,8 +147,8 @@ active:
     migration_reservation: null
     consent_scope: audit-planning; executable test changes require applicable scope
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
-    last_acknowledged_broadcast: 13
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_broadcast: 14
     required_broadcast: null
 
 rules:

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "source_branch_required": "main",
   "assignment_authority": "supervisor",
   "no_slot_response": "Go Home Come Back Next Time",
@@ -14,7 +14,7 @@
   "slots": [
     {"slot_id":"SUPERVISOR-M03-GOV-HOLD","module":"m03_governance_hold","branch":"supervisor/m03-governance-hold-current","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-governance-hold"},
     {"slot_id":"M04-CHARACTER","module":"characters_entities","branch":"agent/m04-character-library-current","status":"occupied","assigned_agent":"character-agent","accepts_new_agent":true,"start_status":"planning-only"},
-    {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory-current","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M07-TIMELINE","module":"timeline_storyboard","branch":"agent/m07-storyboard-timeline","status":"occupied","assigned_agent":"timeline-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M08-PROVIDER","module":"providers","branch":"agent/m08-video-provider-router","status":"occupied","assigned_agent":"provider-agent","accepts_new_agent":true,"start_status":"planning-only"},

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
-version: 9
-latest_sequence: 13
+version: 10
+latest_sequence: 14
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -138,43 +138,72 @@ broadcasts:
       - agent/m08-video-provider-router
       - agent/cross-cutting-qa-security-current
     mandatory: true
+  - sequence: 14
+    trigger: m05-planning-promotion
+    merged_pr: 82
+    merged_branch: agent/m05-content-memory
+    submitted_head_sha: 7a50697258127e7b263dfc3c32215ae405033c7e
+    merged_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-m05-memory-planning-hardening-sync
+    changed_areas:
+      - M05 planning contract hardened against memory poisoning and authority escalation
+      - missing M05 planning checkpoint created
+      - deterministic memory promotion, provenance, isolation, correction/forget and secret-exclusion obligations recorded
+      - executable M04 completion and explicit M05 executable consent remain mandatory gates
+      - M07 dependency remains a hold; planning completion is not executable completion
+      - Issue 36 protected-main governance remains externally unverified
+    contract_changes:
+      - low-trust memory, research and model output cannot self-promote into policy, approval, budget or security authority
+      - future M05 executable work must revalidate dependency, consent, migration, write ownership, provider trust, tenant isolation and bounded cost/retry controls
+      - planning synchronization does not grant executable M05 or downstream authority
+    schema_migration_changes: []
+    recipients:
+      - supervisor/m03-governance-hold-current
+      - agent/m04-character-library-current
+      - agent/m05-content-memory-current
+      - agent/m06-audio-production
+      - agent/m07-storyboard-timeline
+      - agent/m08-video-provider-router
+      - agent/cross-cutting-qa-security-current
+    mandatory: true
 
 recipient_states:
   supervisor/m03-governance-hold-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 13
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_sequence: 14
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
   agent/m04-character-library-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 13
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
-  agent/m05-content-memory:
+    last_acknowledged_sequence: 14
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+  agent/m05-content-memory-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 13
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_sequence: 14
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
   agent/m06-audio-production:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 13
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_sequence: 14
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
   agent/m07-storyboard-timeline:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 13
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_sequence: 14
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
   agent/m08-video-provider-router:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 13
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_sequence: 14
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
   agent/cross-cutting-qa-security-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 13
-    last_synced_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+    last_acknowledged_sequence: 14
+    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
 
 rules:
   - Supervisor increments latest_sequence after every successful promotion merge to main that active agents must observe.

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -12,50 +12,57 @@ Planning synchronization, a green planning PR, or conversational continuation do
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 13 synchronized |
-| M04 Character | `character-agent` | `agent/m04-character-library-current` | broadcast 13 synchronized; planning hardened; executable hold |
-| M05 Content | `content-agent` | `agent/m05-content-memory` | broadcast 13 synchronized; planning-only; dependent on executable M04 |
-| M06 Audio | `audio-agent` | `agent/m06-audio-production` | broadcast 13 synchronized; planning-only; M03 governance dependency retained |
-| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | broadcast 13 synchronized; planning-only; dependent on M04/M05/M06 |
-| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 13 synchronized; planning-only; dependent on M04/M07 |
-| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 13 synchronized; audit/planning only |
+| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 14 synchronized |
+| M04 Character | `character-agent` | `agent/m04-character-library-current` | broadcast 14 synchronized; planning hardened; executable hold |
+| M05 Content | `content-agent` | `agent/m05-content-memory-current` | broadcast 14 synchronized; planning hardened; executable hold |
+| M06 Audio | `audio-agent` | `agent/m06-audio-production` | broadcast 14 synchronized; planning-only; M03 governance dependency retained |
+| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | broadcast 14 synchronized; planning-only; dependent on executable M04/M05/M06 |
+| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 14 synchronized; planning-only; dependent on executable M04/M07 |
+| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 14 synchronized; audit/planning only |
 
-Completed `agent/m04-character-library` is retired after squash-merge PR #78 and is not force-reset or reusable as promotion authority. `agent/m04-character-library-current` is the fresh current-main planning branch. Earlier completed QA and M03/WP8 submission/review/closeout branches remain retired.
+Completed `agent/m04-character-library` and `agent/m05-content-memory` are retired after their planning promotions and are not force-reset or reused as promotion authority. Fresh current-main planning branches are `agent/m04-character-library-current` and `agent/m05-content-memory-current`. Earlier completed QA and M03/WP8 submission/review/closeout branches remain retired.
 
 ## M03 source completion and external hold
 
 M03 implementation, WP8 source acceptance, and source-side closeout are complete. Issue #36 remains the final M03 protected-main governance blocker because live GitHub enforcement is not verified.
 
-Migrations `20260901_0015` and `20260901_0016` remain landed; there is no active M03 or M04 migration reservation. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
+Migrations `20260901_0015` and `20260901_0016` remain landed. There is no active M03, M04 or M05 migration reservation. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
 
 ## Cross-cutting QA promotion
 
-PR #74 landed `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` at `main@6eab0440ef32280c16e41b41851deb3f11937495`. Broadcast 12 made its authority/tenant/secret/memory/provider/budget/rights/multimodal adversarial obligations mandatory inputs for future milestone acceptance.
+PR #74 landed `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` and broadcast 12 made its authority/tenant/secret/memory/provider/budget/rights/multimodal adversarial obligations mandatory planning inputs for future milestone acceptance.
 
-The QA plan is an audit/planning constraint. It does not grant feature execution, provider spend, production credentials, publication or security-setting authority.
+The QA plan remains an audit/planning constraint and grants no feature execution, provider spend, production credentials, publication or security-setting authority.
 
 ## M04 planning promotion
 
-PR #78 `M04: harden planning against adversarial trust boundaries` passed exact-head Repository Governance, Core Domain Contracts and Durable Control Plane and merged to `main@5367ffe5401292744cbe29d8f1a16c36591fae27`.
+PR #78 hardened the M04 planning contract and created `ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md`. Broadcast 13 preserved Issue #36 live governance and explicit M04 executable consent as mandatory entry gates.
+
+M04 planning completion is not executable M04 completion and does not satisfy downstream executable dependencies.
+
+## M05 planning promotion
+
+PR #82 `M05: harden memory planning against poisoning and authority escalation` passed exact-head Repository Governance, Core Domain Contracts and Durable Control Plane and merged to `main@4a6f03c9476fee7dada6df48e6ea6e64fb164a1d`.
 
 That promotion:
 
-- hardened the M04 planning contract with canonical tenant/project authorization, lock integrity, append/version immutability, rights/consent/provenance continuity, reference-pack trust boundaries and provider-output distrust hooks;
-- created the previously missing `ai-native/parallel/checkpoints/M04-PARALLEL-LANE.md`;
-- explicitly retained Issue #36 live protected-main governance and explicit M04 executable consent as mandatory entry gates;
-- created no product/API/schema/provider implementation and no migration reservation;
-- did not complete executable M04 and therefore did not satisfy downstream M05/M07/M08 executable dependencies.
+- hardened the M05 planning contract against malicious memory, prompt injection, low-trust authority escalation and provider/model output trust;
+- created the previously missing `ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md`;
+- required deterministic memory promotion authority, provenance/source-class/freshness/contradiction/expiry visibility, tenant/project/series isolation, correction/forget semantics, raw-secret exclusion and bounded retry/cost behavior;
+- explicitly retained executable M04 completion plus explicit M05 executable consent as mandatory executable entry gates;
+- created no product/API/schema/provider/test implementation and no migration reservation;
+- did not satisfy M07 executable dependency because planning completion is not executable M05 completion.
 
-Broadcast 13 records this planning promotion for every affected active lane.
+Broadcast 14 records this planning promotion for every affected active lane.
 
 ## Dependency and consent boundary
 
 - M04 executable work remains dependent on `M03-GOV-HOLD` and explicit M04 executable consent.
-- M05 executable work remains dependent on executable M04 completion; M04 planning completion is insufficient.
+- M05 executable work remains dependent on executable M04 completion and explicit M05 executable consent.
 - M06 executable work retains its M03 governance dependency and requires applicable executable consent.
 - M07 executable work remains dependent on executable M04/M05/M06 completion.
 - M08 executable work remains dependent on executable M04/M07 completion.
-- Cross-cutting QA has no module dependency but remains audit/planning only unless an applicable executable scope authorizes targeted tests.
+- Cross-cutting QA remains audit/planning only unless an applicable executable scope authorizes targeted tests.
 - Generic `continue`, branch synchronization, green planning CI, mocks, or a planning checkpoint cannot satisfy a privileged development/publish/security gate.
 
 ## Parallel safety
@@ -67,15 +74,16 @@ Future migration IDs are reserved only after executable authority exists and the
 ## Hold order
 
 1. keep Issue #36 `EXTERNAL_NOT_VERIFIED` until live protected-main evidence exists;
-2. preserve broadcast 12 adversarial obligations and broadcast 13 M04 planning constraints in future milestone acceptance;
+2. preserve broadcast 12 adversarial obligations plus broadcasts 13 and 14 planning constraints in future milestone acceptance;
 3. do not start executable M04 until Issue #36 and explicit M04 executable consent both clear;
-4. do not treat M04 planning completion as satisfying M05/M07/M08 executable dependencies;
-5. do not promote M06 executable work while its M03 governance/consent gates remain unresolved;
-6. do not create synthetic provider/admin/production success from source CI, mocks or deterministic fakes.
+4. do not start executable M05 until executable M04 is accepted and explicit M05 executable consent exists;
+5. do not treat M04/M05 planning completion as satisfying M07 or M08 executable dependencies;
+6. do not promote M06 executable work while its M03 governance/consent gates remain unresolved;
+7. do not create synthetic provider/admin/production success from source CI, mocks or deterministic fakes.
 
 ## Next safe planning work
 
-While executable gates remain closed, a later planning lane may be audited and hardened only within its existing planning consent scope. Any such planning slice must identify a real documentation/checkpoint gap, preserve all dependency/consent holds, avoid implementation/schema/provider work, and pass ordinary exact-head repository/source regression CI before merge.
+While executable gates remain closed, a later planning lane may be audited and hardened only within its existing planning consent scope. Any such slice must identify a real documentation/checkpoint gap, preserve all dependency/consent holds, avoid implementation/schema/provider work, and pass ordinary exact-head repository/source regression CI before merge.
 
 ## Completion and review
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -1,9 +1,9 @@
-version: 10
+version: 11
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 5367ffe5401292744cbe29d8f1a16c36591fae27
-  main_sha_last_reconciled: 5367ffe5401292744cbe29d8f1a16c36591fae27
+  main_sha_last_promotion: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+  main_sha_last_reconciled: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
   own_task_id: M03-GOV-HOLD
   own_branch: supervisor/m03-governance-hold-current
   current_mode: external-governance-hold
@@ -11,9 +11,9 @@ supervisor:
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 78
-  submitted_head_sha: 8525499dcaf6889c252de89369ff312cde0464f7
-  merged_main_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+  pr: 82
+  submitted_head_sha: 7a50697258127e7b263dfc3c32215ae405033c7e
+  merged_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
   result: success
 
 new_agent_onboarding:
@@ -26,7 +26,7 @@ new_agent_onboarding:
 pause_checkpoint:
   active: true
   branch: supervisor/m03-governance-hold-current
-  head_sha: 5367ffe5401292744cbe29d8f1a16c36591fae27
+  head_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
   task_id: M03-GOV-HOLD
   subtask: wait-for-live-protected-main-evidence
   next_action: verify Issue 36 live ruleset/protection read-back from an admin-capable context
@@ -35,7 +35,7 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 13
+  latest_broadcast_sequence: 14
   agents_with_mandatory_sync: []
   policy: branches-with-unacknowledged-mandatory-broadcast-cannot-seek-promotion
 
@@ -55,8 +55,16 @@ planning_state:
       - Issue 36 live protected-main governance
       - explicit M04 executable consent
       - fresh write ownership and migration reservation if required
+  m05:
+    status: planning-hardened-only
+    promotion_pr: 82
+    active_branch: agent/m05-content-memory-current
+    executable_authority: false
+    executable_gates:
+      - executable M04 completion and acceptance
+      - explicit M05 executable consent
+      - then-current governance, write ownership and migration reservation if required
   downstream:
-    m05: dependency-gated-planning-only
     m06: dependency-gated-planning-only
     m07: dependency-gated-planning-only
     m08: dependency-gated-planning-only


### PR DESCRIPTION
Implements Issue #83 as governance-only coordination after M05 planning PR #82 merged to `main@4a6f03c9476fee7dada6df48e6ea6e64fb164a1d`.

This PR changes exactly the five canonical Supervisor coordination files and:
- records mandatory broadcast sequence 14 for the M05 planning promotion;
- retires completed `agent/m05-content-memory` from active authority and binds fresh `agent/m05-content-memory-current`;
- records Supervisor/M04/M05/M06/M07/M08/QA lanes synchronized to the triggering main after confirming all pre-existing active branches had zero unique commits;
- preserves executable M04 completion + explicit M05 executable consent as M05 executable gates;
- preserves M07 dependency on executable M04/M05/M06 and M08 dependency on executable M04/M07;
- preserves Issue #36 as live protected-main governance `EXTERNAL_NOT_VERIFIED`;
- records that planning synchronization, green planning CI and generic continuation do not grant executable authority.

No product/API/schema/provider/test implementation, migration, credential, paid call, production data, publish action, security-setting mutation or executable milestone unlock.

Work Done and Submitted