### PR TITLE
M06: harden audio planning against voice and provider trust failures

### DIFF
--- a/ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md
+++ b/ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md
@@ -1,0 +1,65 @@
+# M06 Parallel Lane Checkpoint
+
+## Authority
+
+- Issue: #85 — M06 planning hardening — voice rights and provider trust constraints
+- Lane: `M06-PARALLEL-LANE`
+- Branch: `agent/m06-audio-production`
+- Planning baseline: `main@496cff2fe7aa4dbf5777b4a5b4cb5616a29ae432`
+- Broadcast state: sequence 14 synchronized
+- Consent scope: planning-only-until-new-scope-approved
+- Executable M06 authority: **not granted**
+- Migration reservation: none
+- Product/API/schema/provider/test implementation: not authorized by this checkpoint
+
+## Planning work completed
+
+- Reconciled `docs/milestones/M06/PLAN.md` with the cross-cutting adversarial QA audio threat map.
+- Made executable dependency acceptance, explicit M06 executable consent and fresh governance/write/migration/provider revalidation mandatory entry gates.
+- Added voice/likeness consent and immutable VoiceProfile version-pinning requirements.
+- Recorded that provider IDs, URLs, transcripts, status, licensing claims and other returned metadata are untrusted until canonical validation.
+- Added tenant/project/provider-asset isolation requirements for voices, music, SFX, stems and imported/generated audio.
+- Required malformed audio and parser/probe/transcode failures to fail closed.
+- Kept raw provider/OAuth/signing credentials outside prompts, generated artifacts, manifests, ledgers and logs.
+- Added rights/consent/provenance continuity through generation and deterministic mixing.
+- Added bounded retries/fallback/fan-out/spend with idempotent attempt semantics to prevent duplicate billing.
+- Created this previously missing M06 planning checkpoint.
+
+## Current evidence classification
+
+- M06 executable surface: `DEFERRED_MODULE` — not authorized yet.
+- Upstream executable dependency chain: not satisfied by planning promotions.
+- Explicit M06 executable consent: absent.
+- M03 live protected-main governance: `EXTERNAL_NOT_VERIFIED` — Issue #36 remains open.
+- Cross-cutting QA audio obligations: planning-integrated.
+- M06 schema/migrations: not reserved/not implemented.
+- Paid/provider/production evidence: not required and not produced by this planning slice.
+
+## Mandatory executable entry recheck
+
+Before any M06 implementation branch or migration reservation is created, the Supervisor must verify all of the following against then-current main:
+
+1. M01–M05 are accepted at the executable truth levels required by the milestone chain; planning checkpoints are insufficient.
+2. Explicit M06 executable consent exists; generic conversational continuation is insufficient.
+3. Current upstream governance requirements, including Issue #36 where applicable to the accepted chain, are satisfied at their required truth level rather than assumed from source CI.
+4. M06 branch/write ownership is freshly assigned with no collision.
+5. Current migration head is audited and any required revision is reserved before schema writes.
+6. Broadcast/dependency state is synchronized.
+7. Current audio/TTS/music provider APIs, licensing and commercial-use constraints are revalidated.
+8. Voice/likeness consent and pinned voice-profile version authority are canonical and provider output cannot bypass them.
+9. Provider IDs/URLs/transcripts/licensing claims remain untrusted until schema/canonical validation.
+10. Raw secrets remain outside ordinary audio records, prompts, generated metadata, manifests, logs and ledgers.
+11. Audio parser/probe/transcode failure semantics remain fail closed.
+12. Provider attempts/fallbacks/fan-out/cost use configured ceilings, idempotency and applicable budget authority.
+13. No production credential, paid call or public side effect is introduced unless separately authorized.
+
+## Downstream hold
+
+- M07 cannot treat this planning checkpoint as completed executable M06.
+- Planning synchronization, green CI, deterministic fakes or a completed checkpoint do not satisfy executable dependency gates.
+
+## Next authorized action
+
+Submit this planning-only two-file change for ordinary exact-head Repository Governance, Core Domain Contracts and Durable Control Plane CI. If merged, close Issue #85 as planning complete and keep executable M06 on hold until the mandatory entry criteria above are satisfied.
+
+Work Done and Submitted

--- a/docs/milestones/M06/PLAN.md
+++ b/docs/milestones/M06/PLAN.md
@@ -1,19 +1,39 @@
 # M06 — Hybrid Audio OS
 
+## Planning authority and current state
+
+This document is the planning contract for M06 only. It does **not** authorize executable M06 product/API/schema/provider work.
+
+Current planning baseline: `main@496cff2fe7aa4dbf5777b4a5b4cb5616a29ae432`, after cross-cutting adversarial QA plus M04/M05 planning promotion and broadcast-14 reconciliation.
+
+Executable M06 work remains blocked until the milestone dependency chain is accepted at executable truth levels, explicit M06 executable consent is recorded, and then-current governance, branch/write ownership, migration and provider/licensing gates are revalidated. Planning completion, branch synchronization, green planning CI or generic conversational continuation is not executable consent.
+
 ## Objective
 
-Implement provider-neutral narration, dialogue, music/song generation, ambience/SFX, pronunciation, stems, deterministic mixing and audio QA so canonical content can reach an approved audio master with cost/provenance history.
+Implement provider-neutral narration, dialogue, music/song generation, ambience/SFX, pronunciation, stems, deterministic mixing and audio QA so canonical content can reach an approved audio master with cost/provenance history without allowing provider output, retrieved metadata, voice references or low-trust media to bypass rights, identity, approval, budget or security authority.
 
 ## Entry criteria
 
-- P0 complete.
-- M01–M05 accepted.
-- Explicit M06 consent.
-- Current audio/TTS/music provider APIs/licensing revalidated.
+All are required before executable M06 work begins:
+
+- P0 complete;
+- M01–M05 accepted at their required executable truth levels;
+- explicit M06 executable consent recorded through Supervisor authority;
+- current audio/TTS/music provider APIs, commercial terms and licensing revalidated;
+- current main, broadcast, dependency, write ownership and migration state revalidated immediately before implementation;
+- Issue #36/live repository-governance requirements satisfied where they remain part of the accepted upstream milestone chain;
+- cross-cutting adversarial QA obligations applicable to the exact proposed M06 surface mapped to targeted evidence.
+
+Current state: planning may continue, but executable M06 entry criteria are **not satisfied**. Issue #36 remains `EXTERNAL_NOT_VERIFIED`, upstream executable milestone gates are not replaced by planning promotions, and no explicit M06 executable consent is recorded.
 
 ## Dependencies
 
-`M05 -> M06`
+`M01 -> M02 -> M03 -> M04 -> M05 -> M06`
+
+Downstream impact:
+
+- M07 depends on executable M04/M05/M06 completion;
+- planning completion or synchronization does not satisfy M07 executable dependency gates.
 
 ## Work packages
 
@@ -24,7 +44,8 @@ Implement provider-neutral narration, dialogue, music/song generation, ambience/
 - song/narration structure;
 - ambience/SFX plan;
 - mix/ducking/loudness targets;
-- AI decision record and user overrides.
+- AI decision record and user overrides;
+- retrieved/provider/model suggestions remain advisory evidence and cannot grant approval, budget, rights or security authority.
 
 ### M06-WP2 — Voice/TTS adapter contract
 - canonical speech request/response;
@@ -33,7 +54,9 @@ Implement provider-neutral narration, dialogue, music/song generation, ambience/
 - streaming vs async output normalization;
 - provider/model references;
 - cost/rights metadata;
-- fake adapter plus initial real adapters later within scope.
+- fake adapter plus initial real adapters later within separately authorized executable scope;
+- provider-returned voice IDs, status, URLs, transcripts and metadata validated against canonical tenant/project/voice authority before use;
+- provider output cannot bypass voice-profile rights or pinned version identity.
 
 ### M06-WP3 — Music/song adapter contract
 - instrumental/full-song capability;
@@ -41,7 +64,8 @@ Implement provider-neutral narration, dialogue, music/song generation, ambience/
 - duration/structure/style controls;
 - stems capability where available;
 - commercial-use/right facts;
-- provider-neutral generation attempts.
+- provider-neutral generation attempts;
+- provider-reported licensing or ownership facts remain untrusted until validated against retained policy/provenance evidence.
 
 ### M06-WP4 — Dialogue and character voice system
 - character-version -> VoiceProfile-version;
@@ -49,7 +73,9 @@ Implement provider-neutral narration, dialogue, music/song generation, ambience/
 - line segmentation;
 - emotion/style;
 - language variants;
-- no silent voice identity mutation.
+- no silent voice identity mutation;
+- likeness/voice consent and permitted-use facts required before an identity-bound voice can become generation authority;
+- pinned prior voice assignments are immutable/versioned rather than silently overwritten by provider recommendations or replacements.
 
 ### M06-WP5 — Pronunciation/localization
 - pronunciation dictionary;
@@ -57,14 +83,17 @@ Implement provider-neutral narration, dialogue, music/song generation, ambience/
 - locale-specific voice selection;
 - transliteration where needed;
 - human override/pin;
-- pronunciation QA fixtures.
+- pronunciation QA fixtures;
+- provider/transcript guesses cannot silently overwrite pinned canonical pronunciation or identity facts.
 
 ### M06-WP6 — SFX/ambience/stem management
 - separate assets/tracks;
 - loop/placement metadata;
 - rights/provenance;
 - fade/duck intent;
-- no destructive mixing into source assets.
+- no destructive mixing into source assets;
+- imported/generated audio remains tenant/project scoped and foreign provider asset IDs are rejected unless resolved through canonical authority;
+- rights/consent/provenance continuity retained through derivatives and mix manifests.
 
 ### M06-WP7 — Deterministic audio assembly
 Using FFmpeg/media tools:
@@ -74,7 +103,9 @@ Using FFmpeg/media tools:
 - loudness normalization;
 - sample-rate/channel conversion;
 - final master + preview;
-- reproducible render manifest.
+- reproducible render manifest;
+- malformed media, parser/probe failures, invalid duration/channel/sample metadata and unexpected tool output fail closed rather than producing an approved master;
+- source assets are not destructively mutated.
 
 ### M06-WP8 — Audio QA and acceptance
 Checks:
@@ -86,14 +117,40 @@ Checks:
 - loudness;
 - channel/sample validity;
 - stem alignment;
-- rights/cost/provenance.
+- rights/cost/provenance;
+- voice/likeness consent continuity;
+- canonical provider/asset identity validation;
+- secret/log hygiene;
+- bounded retry/fallback and duplicate-billing behavior.
 
 Acceptance outputs:
 - one approved song audio master;
 - one approved narrated story with background mix;
-- full attempt/cost/QA history.
+- full attempt/cost/QA history;
+- no stronger production/provider truth state than the evidence actually proves.
+
+## Cross-cutting adversarial acceptance obligations
+
+`docs/qa/ADVERSARIAL-AUDIT-PLAN.md` is a mandatory planning input. When M06 later requests executable promotion, QA must re-evaluate the exact reachable authority surface and add only targeted missing evidence.
+
+At minimum M06 acceptance must prove:
+
+1. **Voice rights/version authority cannot be bypassed** — provider output, retrieved metadata or a malicious prompt cannot select or mutate an identity-bound voice without canonical authorization, consent and pinned version checks.
+2. **Provider output is untrusted** — returned IDs, URLs, transcripts, status, licensing claims and classifications require schema validation and canonical lookup before becoming decision input.
+3. **Tenant/project isolation is canonical** — foreign voice/audio/stem/provider asset IDs are rejected rather than trusted because an external provider/model returned them.
+4. **Audio parsing fails closed** — parser/probe/transcode errors, malformed audio and inconsistent duration/channel/sample facts cannot be relabeled as valid/approved.
+5. **Secrets stay outside media artifacts** — raw provider/OAuth/signing credentials never enter prompts, generated metadata, manifests, ledgers, logs, transcripts, embeddings or ordinary audio records.
+6. **Rights/provenance remain attached** — voice consent, imported audio/music/SFX rights, source provenance and derivative lineage remain visible through generation and mixing.
+7. **Retries and cost are bounded** — attempts/fallbacks/fan-out use configured ceilings, idempotency and budget authority; retries cannot silently duplicate billable generations.
+8. **Approval authority is deterministic** — provider/model text saying “approved”, “licensed” or “safe” cannot create canonical QA/rights/approval state.
+9. **Versioned identity is immutable** — approved/pinned voice or audio source versions are not silently rewritten when new provider capabilities or recommendations appear.
+10. **No synthetic production success** — deterministic fakes prove source contracts only; unavailable live provider/licensing/publish/admin evidence remains `NOT_VERIFIED` where required.
+
+Do not add duplicate umbrella tests for already-proven lower-layer properties unless M06 creates a newly reachable authority/trust path.
 
 ## Expected modules/files
+
+Planned future executable surface only:
 
 - audio director/services;
 - provider audio adapters;
@@ -103,39 +160,59 @@ Acceptance outputs:
 - schemas/API routes;
 - audio fixtures/tests.
 
+Actual executable write ownership and migration reservations must be assigned fresh by the Supervisor after entry criteria pass.
+
 ## Data/migration impact
 
-Adds AudioPlan, VoiceProfile/version associations, audio generation attempts, stems/tracks, pronunciation entries, mix manifests and audio QA records.
+Expected future implementation may add AudioPlan, VoiceProfile/version associations, audio generation attempts, stems/tracks, pronunciation entries, mix manifests and audio QA records.
+
+This planning slice creates **no migration reservation and no schema change**. Future migration IDs must be reserved only after executable M06 authority exists and the then-current migration head is audited.
 
 ## API/UI impact
 
-Adds audio plan/generate/status/preview/approve APIs. Full mixer UI later, but contracts support it.
+Future implementation may add audio plan/generate/status/preview/approve APIs. Full mixer UI is later, but contracts should support it.
+
+This planning slice changes no API or UI.
 
 ## Security/cost/rights impact
 
-- voice/likeness consent and provider licensing enforced;
+Future M06 must preserve:
+
+- voice/likeness consent and provider licensing enforcement;
 - no unauthorized celebrity/person voice cloning;
-- spend reservations per attempt;
-- provider secrets server-side;
-- generated/imported audio provenance retained.
+- immutable/versioned voice-profile identity;
+- spend reservation plus bounded attempt/fallback/fan-out behavior;
+- provider secrets server-side and excluded from generated artifacts/prompts/logs/ledgers;
+- generated/imported audio provenance retained through derivatives;
+- canonical tenant/project/provider-asset authorization;
+- fail-closed media parsing/probing and approval semantics.
 
-## Test/acceptance
+## Test/acceptance plan
 
-- fake TTS/music adapters;
-- provider malformed/rate-limit/failure;
+Targeted future evidence includes:
+
+- fake TTS/music adapters for source contracts only;
+- provider malformed/rate-limit/failure/untrusted-metadata cases;
+- foreign voice/audio/provider asset-ID rejection;
+- malicious provider output attempting to override voice rights/version pinning;
 - deterministic mix fixtures;
-- pronunciation/localization;
-- character voice version pinning;
-- clipping/loudness/dropout QA;
-- retry/fallback no duplicate billing.
+- malformed audio/parser/probe fail-closed behavior;
+- pronunciation/localization and pinned override behavior;
+- character voice version pinning and no silent identity mutation;
+- clipping/loudness/dropout/channel/sample QA;
+- rights/consent/provenance continuity through stems/mixes;
+- raw secret exclusion from prompts/manifests/logs/ledgers;
+- retry/fallback idempotency and no duplicate billing.
 
 ## Rollout/rollback
 
-Provider/prompt/model changes versioned and canaried. Mix manifests allow deterministic re-render. Approved source/master assets are immutable/versioned.
+Future provider/prompt/model changes are versioned and canaried. Mix manifests allow deterministic re-render. Approved source/master and voice-profile versions are immutable/versioned. Provider or licensing changes must not silently rewrite historical truth; later corrections use explicit versions/state transitions with retained auditability.
 
 ## Exit criteria
 
-A song and narrated story progress from canonical content through provider-neutral audio plans/generation to approved deterministic masters with complete rights, cost and QA history.
+M06 can exit only when a song and narrated story progress from canonical content through provider-neutral audio plans/generation to approved deterministic masters with complete rights, consent, cost, provenance and QA history, without provider-output authority escalation, cross-tenant asset trust, silent voice mutation, secret leakage or unbounded retries/cost.
+
+Planning completion is **not** executable milestone completion.
 
 ## Non-goals
 
@@ -143,4 +220,6 @@ A song and narrated story progress from canonical content through provider-neutr
 - full DAW replacement;
 - unrestricted voice cloning;
 - final web mixer UI;
-- live real-time voice chat.
+- live real-time voice chat;
+- production credentials or paid provider calls during this planning slice;
+- using generic `continue`, branch synchronization, mocks or green planning CI as executable M06 consent.


### PR DESCRIPTION
Implements Issue #85 as a planning-only M06 Hybrid Audio OS reconciliation on current `main@496cff2fe7aa4dbf5777b4a5b4cb5616a29ae432`.

Scope is intentionally bounded to two planning files:
- hardens `docs/milestones/M06/PLAN.md` with cross-cutting audio adversarial constraints;
- creates the previously missing `ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md`.

The planning contract now makes these future executable requirements explicit: executable upstream dependency acceptance, explicit M06 executable consent, voice/likeness consent, immutable voice-profile version pinning, canonical tenant/project/provider-asset authorization, untrusted provider IDs/transcripts/metadata/licensing claims, fail-closed audio parser/probe behavior, secret exclusion, rights/provenance continuity, bounded retries/fallbacks/spend and idempotent no-duplicate-billing semantics.

No product/API/schema/migration/provider/test implementation, paid call, credential, production data, publish action or executable M06 authorization is included. M07 remains dependency-gated and Issue #36 remains `EXTERNAL_NOT_VERIFIED`.

Work Done and Submitted