### PR TITLE
GOV: broadcast M06 planning promotion constraints

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -1,4 +1,4 @@
-version: 11
+version: 12
 supervisor:
   role: supervisor
   assigned_agent: supervisor-agent
@@ -13,7 +13,7 @@ active:
     role: supervisor-governance
     assigned_agent: supervisor-agent
     branch: supervisor/m03-governance-hold-current
-    base_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    base_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
     module: m03_governance_hold
     status: active-governance-hold
     writes:
@@ -24,8 +24,8 @@ active:
     migration_reservation: null
     consent_scope: M03-governance-closeout-only
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
-    last_acknowledged_broadcast: 14
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_broadcast: 15
     required_broadcast: null
 
   - task_id: M04-PARALLEL-LANE
@@ -44,8 +44,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
-    last_acknowledged_broadcast: 14
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_broadcast: 15
     required_broadcast: null
 
   - task_id: M05-PARALLEL-LANE
@@ -64,15 +64,15 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
-    last_acknowledged_broadcast: 14
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_broadcast: 15
     required_broadcast: null
 
   - task_id: M06-PARALLEL-LANE
     title: Hybrid Audio Production planning/contracts
     role: planning-contract
     assigned_agent: audio-agent
-    branch: agent/m06-audio-production
+    branch: agent/m06-audio-production-current
     module: audio
     status: planning-only
     writes:
@@ -84,8 +84,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
-    last_acknowledged_broadcast: 14
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_broadcast: 15
     required_broadcast: null
 
   - task_id: M07-PARALLEL-LANE
@@ -106,8 +106,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
-    last_acknowledged_broadcast: 14
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_broadcast: 15
     required_broadcast: null
 
   - task_id: M08-PARALLEL-LANE
@@ -127,8 +127,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
-    last_acknowledged_broadcast: 14
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_broadcast: 15
     required_broadcast: null
 
   - task_id: CROSS-CUTTING-QA
@@ -147,8 +147,8 @@ active:
     migration_reservation: null
     consent_scope: audit-planning; executable test changes require applicable scope
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
-    last_acknowledged_broadcast: 14
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_broadcast: 15
     required_broadcast: null
 
 rules:

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 7,
   "source_branch_required": "main",
   "assignment_authority": "supervisor",
   "no_slot_response": "Go Home Come Back Next Time",
@@ -15,7 +15,7 @@
     {"slot_id":"SUPERVISOR-M03-GOV-HOLD","module":"m03_governance_hold","branch":"supervisor/m03-governance-hold-current","status":"occupied","assigned_agent":"supervisor-agent","accepts_new_agent":false,"start_status":"active-governance-hold"},
     {"slot_id":"M04-CHARACTER","module":"characters_entities","branch":"agent/m04-character-library-current","status":"occupied","assigned_agent":"character-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory-current","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
-    {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production-current","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M07-TIMELINE","module":"timeline_storyboard","branch":"agent/m07-storyboard-timeline","status":"occupied","assigned_agent":"timeline-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M08-PROVIDER","module":"providers","branch":"agent/m08-video-provider-router","status":"occupied","assigned_agent":"provider-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"CROSS-CUTTING-QA","module":"media_qa","branch":"agent/cross-cutting-qa-security-current","status":"occupied","assigned_agent":"qa-security-agent","accepts_new_agent":true,"start_status":"active-audit-planning"}

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
-version: 10
-latest_sequence: 14
+version: 11
+latest_sequence: 15
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -167,43 +167,76 @@ broadcasts:
       - agent/m08-video-provider-router
       - agent/cross-cutting-qa-security-current
     mandatory: true
+  - sequence: 15
+    trigger: m06-planning-promotion
+    merged_pr: 86
+    merged_branch: agent/m06-audio-production
+    submitted_head_sha: ca32cfc9b7fc4dda249188f4524ef11c562215cc
+    merged_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-m06-audio-planning-hardening-sync
+    changed_areas:
+      - M06 audio planning contract hardened against voice and provider trust failures
+      - missing M06 planning checkpoint created
+      - voice and likeness consent plus pinned VoiceProfile identity requirements recorded
+      - provider IDs, URLs, transcripts, status and licensing claims remain untrusted until canonical validation
+      - malformed audio and parser, probe or transcode failures fail closed
+      - raw secrets remain excluded from prompts, generated artifacts, manifests, ledgers and logs
+      - rights, consent and provenance continuity plus bounded retry, fallback, fan-out and no-duplicate-billing rules recorded
+      - required upstream executable acceptance and explicit M06 executable consent remain gates
+      - M07 remains dependency-gated; planning completion is not executable completion
+      - Issue 36 protected-main governance remains externally unverified
+    contract_changes:
+      - provider output cannot override voice rights, pinned identity, approval, budget or security authority
+      - future M06 executable work must revalidate dependencies, consent, migration, write ownership, provider licensing, canonical asset authority and bounded cost/retry controls
+      - planning synchronization does not grant executable M06 or downstream authority
+    schema_migration_changes: []
+    recipients:
+      - supervisor/m03-governance-hold-current
+      - agent/m04-character-library-current
+      - agent/m05-content-memory-current
+      - agent/m06-audio-production-current
+      - agent/m07-storyboard-timeline
+      - agent/m08-video-provider-router
+      - agent/cross-cutting-qa-security-current
+    mandatory: true
 
 recipient_states:
   supervisor/m03-governance-hold-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 14
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_sequence: 15
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
   agent/m04-character-library-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 14
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_sequence: 15
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
   agent/m05-content-memory-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 14
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
-  agent/m06-audio-production:
+    last_acknowledged_sequence: 15
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+  agent/m06-audio-production-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 14
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_sequence: 15
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
   agent/m07-storyboard-timeline:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 14
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_sequence: 15
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
   agent/m08-video-provider-router:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 14
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_sequence: 15
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
   agent/cross-cutting-qa-security-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 14
-    last_synced_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+    last_acknowledged_sequence: 15
+    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
 
 rules:
   - Supervisor increments latest_sequence after every successful promotion merge to main that active agents must observe.

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -6,31 +6,31 @@ The Supervisor owns assignment, coordination-state mutation, review order, and p
 
 New agents start from `main`, read `AGENT-SLOTS.json`, and may work only after Supervisor assignment. All defined slots are occupied, so an additional arrival receives exactly **Go Home Come Back Next Time**.
 
-Planning synchronization, a green planning PR, or conversational continuation does not grant privileged/executable development authority.
+Planning synchronization, a green planning PR, deterministic fakes, or conversational continuation does not grant privileged/executable development authority.
 
 ## Current branch matrix
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 14 synchronized |
-| M04 Character | `character-agent` | `agent/m04-character-library-current` | broadcast 14 synchronized; planning hardened; executable hold |
-| M05 Content | `content-agent` | `agent/m05-content-memory-current` | broadcast 14 synchronized; planning hardened; executable hold |
-| M06 Audio | `audio-agent` | `agent/m06-audio-production` | broadcast 14 synchronized; planning-only; M03 governance dependency retained |
-| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | broadcast 14 synchronized; planning-only; dependent on executable M04/M05/M06 |
-| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 14 synchronized; planning-only; dependent on executable M04/M07 |
-| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 14 synchronized; audit/planning only |
+| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 15 synchronized |
+| M04 Character | `character-agent` | `agent/m04-character-library-current` | broadcast 15 synchronized; planning hardened; executable hold |
+| M05 Content | `content-agent` | `agent/m05-content-memory-current` | broadcast 15 synchronized; planning hardened; executable hold |
+| M06 Audio | `audio-agent` | `agent/m06-audio-production-current` | broadcast 15 synchronized; planning hardened; executable hold |
+| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | broadcast 15 synchronized; planning-only; dependent on executable M04/M05/M06 |
+| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 15 synchronized; planning-only; dependent on executable M04/M07 |
+| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 15 synchronized; audit/planning only |
 
-Completed `agent/m04-character-library` and `agent/m05-content-memory` are retired after their planning promotions and are not force-reset or reused as promotion authority. Fresh current-main planning branches are `agent/m04-character-library-current` and `agent/m05-content-memory-current`. Earlier completed QA and M03/WP8 submission/review/closeout branches remain retired.
+Completed `agent/m04-character-library`, `agent/m05-content-memory`, and `agent/m06-audio-production` are retired after their planning promotions and are not force-reset or reused as promotion authority. Fresh current-main planning branches are `agent/m04-character-library-current`, `agent/m05-content-memory-current`, and `agent/m06-audio-production-current`. Earlier completed QA and M03/WP8 submission/review/closeout branches remain retired.
 
 ## M03 source completion and external hold
 
 M03 implementation, WP8 source acceptance, and source-side closeout are complete. Issue #36 remains the final M03 protected-main governance blocker because live GitHub enforcement is not verified.
 
-Migrations `20260901_0015` and `20260901_0016` remain landed. There is no active M03, M04 or M05 migration reservation. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
+Migrations `20260901_0015` and `20260901_0016` remain landed. There is no active M03, M04, M05 or M06 migration reservation. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
 
 ## Cross-cutting QA promotion
 
-PR #74 landed `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` and broadcast 12 made its authority/tenant/secret/memory/provider/budget/rights/multimodal adversarial obligations mandatory planning inputs for future milestone acceptance.
+PR #74 landed `docs/qa/ADVERSARIAL-AUDIT-PLAN.md`; broadcast 12 made its authority/tenant/secret/memory/provider/budget/rights/multimodal adversarial obligations mandatory planning inputs for future milestone acceptance.
 
 The QA plan remains an audit/planning constraint and grants no feature execution, provider spend, production credentials, publication or security-setting authority.
 
@@ -42,28 +42,38 @@ M04 planning completion is not executable M04 completion and does not satisfy do
 
 ## M05 planning promotion
 
-PR #82 `M05: harden memory planning against poisoning and authority escalation` passed exact-head Repository Governance, Core Domain Contracts and Durable Control Plane and merged to `main@4a6f03c9476fee7dada6df48e6ea6e64fb164a1d`.
+PR #82 hardened the M05 memory/content planning contract against memory poisoning and authority escalation and created `ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md`. Broadcast 14 preserved executable M04 completion plus explicit M05 executable consent as M05 executable gates.
+
+M05 planning completion is not executable M05 completion and does not satisfy M07 executable dependency.
+
+## M06 planning promotion
+
+PR #86 `M06: harden audio planning against voice and provider trust failures` passed exact-head Repository Governance, Core Domain Contracts and Durable Control Plane and merged to `main@9762ea1e7c640aa91b8eec777055915030a71ebc`.
 
 That promotion:
 
-- hardened the M05 planning contract against malicious memory, prompt injection, low-trust authority escalation and provider/model output trust;
-- created the previously missing `ai-native/parallel/checkpoints/M05-PARALLEL-LANE.md`;
-- required deterministic memory promotion authority, provenance/source-class/freshness/contradiction/expiry visibility, tenant/project/series isolation, correction/forget semantics, raw-secret exclusion and bounded retry/cost behavior;
-- explicitly retained executable M04 completion plus explicit M05 executable consent as mandatory executable entry gates;
+- hardened the M06 audio planning contract against provider-output authority escalation and malformed-media trust;
+- created the previously missing `ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md`;
+- required voice/likeness consent and immutable/pinned VoiceProfile identity;
+- made provider IDs, URLs, transcripts, status and licensing claims untrusted until canonical validation;
+- required malformed audio and parser/probe/transcode failures to fail closed;
+- excluded raw provider/OAuth/signing secrets from prompts, generated artifacts, manifests, ledgers and logs;
+- required rights/consent/provenance continuity plus bounded retry/fallback/fan-out/spend and idempotent no-duplicate-billing semantics;
+- explicitly retained upstream executable milestone acceptance plus explicit M06 executable consent as mandatory executable entry gates;
 - created no product/API/schema/provider/test implementation and no migration reservation;
-- did not satisfy M07 executable dependency because planning completion is not executable M05 completion.
+- did not satisfy M07 executable dependency because planning completion is not executable M06 completion.
 
-Broadcast 14 records this planning promotion for every affected active lane.
+Broadcast 15 records this planning promotion for every affected active lane.
 
 ## Dependency and consent boundary
 
 - M04 executable work remains dependent on `M03-GOV-HOLD` and explicit M04 executable consent.
 - M05 executable work remains dependent on executable M04 completion and explicit M05 executable consent.
-- M06 executable work retains its M03 governance dependency and requires applicable executable consent.
+- M06 executable work requires the accepted upstream executable chain, explicit M06 executable consent and then-current provider/licensing/governance revalidation.
 - M07 executable work remains dependent on executable M04/M05/M06 completion.
 - M08 executable work remains dependent on executable M04/M07 completion.
 - Cross-cutting QA remains audit/planning only unless an applicable executable scope authorizes targeted tests.
-- Generic `continue`, branch synchronization, green planning CI, mocks, or a planning checkpoint cannot satisfy a privileged development/publish/security gate.
+- Generic `continue`, branch synchronization, green planning CI, mocks, deterministic fakes, or a planning checkpoint cannot satisfy a privileged development/publish/security gate.
 
 ## Parallel safety
 
@@ -74,16 +84,16 @@ Future migration IDs are reserved only after executable authority exists and the
 ## Hold order
 
 1. keep Issue #36 `EXTERNAL_NOT_VERIFIED` until live protected-main evidence exists;
-2. preserve broadcast 12 adversarial obligations plus broadcasts 13 and 14 planning constraints in future milestone acceptance;
+2. preserve broadcast 12 adversarial obligations plus broadcasts 13, 14 and 15 planning constraints in future milestone acceptance;
 3. do not start executable M04 until Issue #36 and explicit M04 executable consent both clear;
 4. do not start executable M05 until executable M04 is accepted and explicit M05 executable consent exists;
-5. do not treat M04/M05 planning completion as satisfying M07 or M08 executable dependencies;
-6. do not promote M06 executable work while its M03 governance/consent gates remain unresolved;
+5. do not start executable M06 until its upstream executable chain is accepted and explicit M06 executable consent exists;
+6. do not treat M04/M05/M06 planning completion as satisfying M07 or M08 executable dependencies;
 7. do not create synthetic provider/admin/production success from source CI, mocks or deterministic fakes.
 
 ## Next safe planning work
 
-While executable gates remain closed, a later planning lane may be audited and hardened only within its existing planning consent scope. Any such slice must identify a real documentation/checkpoint gap, preserve all dependency/consent holds, avoid implementation/schema/provider work, and pass ordinary exact-head repository/source regression CI before merge.
+While executable gates remain closed, a later planning lane may be audited and hardened only within its existing planning consent scope. M07 currently has a real planning-only documentation/checkpoint gap and may be reconciled after broadcast-15 coordination is promoted. Any planning slice must preserve all dependency/consent holds, avoid implementation/schema/provider spend, and pass ordinary exact-head repository/source regression CI before merge.
 
 ## Completion and review
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -1,9 +1,9 @@
-version: 11
+version: 12
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
-  main_sha_last_reconciled: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+  main_sha_last_promotion: 9762ea1e7c640aa91b8eec777055915030a71ebc
+  main_sha_last_reconciled: 9762ea1e7c640aa91b8eec777055915030a71ebc
   own_task_id: M03-GOV-HOLD
   own_branch: supervisor/m03-governance-hold-current
   current_mode: external-governance-hold
@@ -11,9 +11,9 @@ supervisor:
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 82
-  submitted_head_sha: 7a50697258127e7b263dfc3c32215ae405033c7e
-  merged_main_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+  pr: 86
+  submitted_head_sha: ca32cfc9b7fc4dda249188f4524ef11c562215cc
+  merged_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
   result: success
 
 new_agent_onboarding:
@@ -26,7 +26,7 @@ new_agent_onboarding:
 pause_checkpoint:
   active: true
   branch: supervisor/m03-governance-hold-current
-  head_sha: 4a6f03c9476fee7dada6df48e6ea6e64fb164a1d
+  head_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
   task_id: M03-GOV-HOLD
   subtask: wait-for-live-protected-main-evidence
   next_action: verify Issue 36 live ruleset/protection read-back from an admin-capable context
@@ -35,7 +35,7 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 14
+  latest_broadcast_sequence: 15
   agents_with_mandatory_sync: []
   policy: branches-with-unacknowledged-mandatory-broadcast-cannot-seek-promotion
 
@@ -64,8 +64,17 @@ planning_state:
       - executable M04 completion and acceptance
       - explicit M05 executable consent
       - then-current governance, write ownership and migration reservation if required
+  m06:
+    status: planning-hardened-only
+    promotion_pr: 86
+    active_branch: agent/m06-audio-production-current
+    executable_authority: false
+    executable_gates:
+      - required upstream executable milestone acceptance
+      - explicit M06 executable consent
+      - then-current governance, write ownership and migration reservation if required
+      - current audio provider APIs, licensing and commercial-use constraints revalidated
   downstream:
-    m06: dependency-gated-planning-only
     m07: dependency-gated-planning-only
     m08: dependency-gated-planning-only
 


### PR DESCRIPTION
Implements Issue #87 as governance-only coordination after M06 planning PR #86 merged to `main@9762ea1e7c640aa91b8eec777055915030a71ebc`.

This PR changes exactly the five canonical Supervisor coordination files and:
- records mandatory broadcast sequence 15 for the M06 planning promotion;
- retires completed `agent/m06-audio-production` from active authority and binds fresh `agent/m06-audio-production-current`;
- records Supervisor/M04/M05/M06/M07/M08/QA lanes synchronized to the triggering main after zero-unique-commit verification;
- preserves upstream executable acceptance + explicit M06 executable consent + provider/licensing/governance revalidation as M06 executable gates;
- preserves M07 dependency on executable M04/M05/M06 and M08 dependency on executable M04/M07;
- preserves Issue #36 as live protected-main governance `EXTERNAL_NOT_VERIFIED`;
- records that planning synchronization, green CI, mocks/deterministic fakes and generic continuation do not grant executable authority.

No product/API/schema/provider/test implementation, migration, credential, paid call, production data, publish action, security-setting mutation or executable milestone unlock.

Work Done and Submitted