### PR TITLE
M07: harden timeline planning against authority and reference corruption

### DIFF
--- a/ai-native/parallel/checkpoints/M07-PARALLEL-LANE.md
+++ b/ai-native/parallel/checkpoints/M07-PARALLEL-LANE.md
@@ -1,0 +1,66 @@
+# M07 Parallel Lane Checkpoint
+
+## Authority
+
+- Issue: #89 — M07 planning hardening — timeline authority and reference integrity
+- Lane: `M07-PARALLEL-LANE`
+- Branch: `agent/m07-storyboard-timeline`
+- Planning baseline: `main@fc3382689431e811f2c3c2007e53ccd216e8bb31`
+- Broadcast state: sequence 15 synchronized
+- Consent scope: planning-only-until-new-scope-approved
+- Executable M07 authority: **not granted**
+- Migration reservation: none
+- Product/API/schema/provider/test implementation: not authorized by this checkpoint
+
+## Planning work completed
+
+- Reconciled `docs/milestones/M07/PLAN.md` with the cross-cutting adversarial QA timeline/storyboard threat map.
+- Made executable M04/M05/M06 acceptance, explicit M07 executable consent and fresh governance/write/migration revalidation mandatory entry gates.
+- Recorded that generated/imported scene/timeline text cannot create tool, publish, approval, budget or security authority.
+- Required entity/asset/audio/keyframe/reference IDs to resolve through canonical tenant/project authority.
+- Kept provider-specific IDs, URLs and hidden state outside canonical timeline truth.
+- Made OTIO/imported editorial structures and metadata untrusted until schema, supported-semantics, ownership, rights, hierarchy, timing and reference validation pass.
+- Required later edits/imports to preserve exact pinned version/reference lineage and rights/provenance continuity.
+- Required malformed hierarchy/timing/reference/continuity structures to fail closed before downstream execution.
+- Preserved non-destructive approved versions and safe optimistic-conflict behavior.
+- Created this previously missing M07 planning checkpoint.
+
+## Current evidence classification
+
+- M07 executable surface: `DEFERRED_MODULE` — not authorized yet.
+- M04/M05/M06 executable dependency chain: not satisfied by planning promotions.
+- Explicit M07 executable consent: absent.
+- M03 live protected-main governance: `EXTERNAL_NOT_VERIFIED` — Issue #36 remains open.
+- Cross-cutting M07 adversarial obligations: planning-integrated.
+- M07 schema/migrations: not reserved/not implemented.
+- Video/provider/publish/production evidence: not required and not produced by this planning slice.
+
+## Mandatory executable entry recheck
+
+Before any M07 implementation branch or migration reservation is created, the Supervisor must verify all of the following against then-current main:
+
+1. M04, M05 and M06 are accepted at their required executable truth levels; planning checkpoints are insufficient.
+2. Explicit M07 executable consent exists; generic conversational continuation is insufficient.
+3. Current upstream governance requirements, including Issue #36 where applicable to the accepted chain, are satisfied at their required truth level rather than assumed from source CI.
+4. M07 branch/write ownership is freshly assigned with no collision.
+5. Current migration head is audited and any required revision is reserved before schema writes.
+6. Broadcast/dependency state is synchronized.
+7. Entity/asset/audio/keyframe/reference IDs are canonically tenant/project authorized before use.
+8. Generated scene/timeline text and imported metadata cannot create tool/publish/approval/budget/security authority.
+9. Provider-specific IDs/URLs/hidden state are not canonical timeline truth.
+10. OTIO/import structures are schema, semantics, ownership, timing, hierarchy, rights and reference validated before canonicalization.
+11. Approved/pinned versions cannot be silently overwritten; import/edit creates reviewable versions and stale optimistic writes fail safely.
+12. Malformed hierarchy/timing/reference/continuity structures fail closed before downstream execution.
+13. Rights/provenance/version lineage survives storyboard/timeline edits and rollback.
+14. No production credential, paid provider call, video generation or publish side effect is introduced unless separately authorized.
+
+## Downstream hold
+
+- M08 cannot treat this planning checkpoint as completed executable M07.
+- Planning synchronization, green CI, deterministic fakes or a completed checkpoint do not satisfy executable dependency gates.
+
+## Next authorized action
+
+Submit this planning-only two-file change for ordinary exact-head Repository Governance, Core Domain Contracts and Durable Control Plane CI. If merged, close Issue #89 as planning complete and keep executable M07 on hold until the mandatory entry criteria above are satisfied.
+
+Work Done and Submitted

--- a/docs/milestones/M07/PLAN.md
+++ b/docs/milestones/M07/PLAN.md
@@ -1,18 +1,39 @@
 # M07 — Storyboard, Timeline and Rhythm Engine
 
+## Planning authority and current state
+
+This document is the planning contract for M07 only. It does **not** authorize executable M07 product/API/schema/provider work.
+
+Current planning baseline: `main@fc3382689431e811f2c3c2007e53ccd216e8bb31`, after cross-cutting adversarial QA plus M04–M06 planning promotions and broadcast-15 reconciliation.
+
+Executable M07 work remains blocked until M04, M05 and M06 are accepted at the executable truth levels required by the milestone chain, explicit M07 executable consent is recorded, and then-current governance, branch/write ownership, migration and downstream-provider boundaries are revalidated. Planning completion, branch synchronization, green planning CI, deterministic fakes or generic conversational continuation is not executable consent.
+
 ## Objective
 
-Implement the provider-neutral editorial planning layer from Project -> Act/Chapter -> Sequence -> Scene -> Shot -> Take, with storyboard, timeline tracks, audio/beat markers, continuity states, keyframes, non-destructive edits and OpenTimelineIO mapping.
+Implement the provider-neutral editorial planning layer from Project -> Act/Chapter -> Sequence -> Scene -> Shot -> Take, with storyboard, timeline tracks, audio/beat markers, continuity states, keyframes, non-destructive edits and OpenTimelineIO mapping, while ensuring generated/imported editorial data cannot bypass canonical tenant/project authority, version lineage, rights/provenance, hierarchy invariants or approval/security boundaries.
 
 ## Entry criteria
 
-- P0 complete.
-- M01–M06 accepted.
-- Explicit M07 consent.
+All are required before executable M07 work begins:
+
+- P0 complete;
+- M01–M06 accepted at their required executable truth levels;
+- explicit M07 executable consent recorded through Supervisor authority;
+- current main, broadcast, dependency, write ownership and migration state revalidated immediately before implementation;
+- Issue #36/live repository-governance requirements satisfied where they remain part of the accepted upstream milestone chain;
+- cross-cutting adversarial QA obligations applicable to the exact proposed M07 surface mapped to targeted evidence;
+- current OpenTimelineIO/import/export assumptions revalidated against the implementation surface before interoperability becomes executable authority.
+
+Current state: planning may continue, but executable M07 entry criteria are **not satisfied**. M04/M05/M06 planning promotions do not satisfy executable dependencies, and no explicit M07 executable consent is recorded.
 
 ## Dependencies
 
-`M05 content + M06 audio + M04 entities -> M07`
+`M04 entities + M05 content + M06 audio -> M07`
+
+Downstream impact:
+
+- M08 depends on executable M04 and executable M07 completion;
+- planning completion or synchronization does not satisfy M08 executable dependency gates.
 
 ## Work packages
 
@@ -21,7 +42,9 @@ Implement the provider-neutral editorial planning layer from Project -> Act/Chap
 - stable order/time relationships;
 - duration aggregation;
 - validation against project ceiling;
-- long-form pagination/loading boundaries.
+- long-form pagination/loading boundaries;
+- imported/generated hierarchy IDs and parent relations require canonical project authorization and schema validation;
+- impossible hierarchy, cross-project parents, cyclic relations, negative/overflow timing and ceiling violations fail closed before downstream execution.
 
 ### M07-WP2 — Shot planner/storyboard
 - shot purpose/type/size;
@@ -34,7 +57,9 @@ Implement the provider-neutral editorial planning layer from Project -> Act/Chap
 - dialogue/audio links;
 - transition intent;
 - generation notes;
-- approval status.
+- approval status;
+- generated scene/shot text remains advisory evidence and cannot mint approval, publish, budget, tool or security authority;
+- all referenced entities/assets/audio resolve through canonical tenant/project authority rather than trusting generated/provider IDs.
 
 ### M07-WP3 — Timing/rhythm engine
 Timing modes:
@@ -52,6 +77,8 @@ Represent:
 - handles/overlap;
 - transition timing.
 
+Timing imported from models/providers/editors is input evidence only. Canonical duration ceilings, clip bounds and monotonic timeline invariants remain deterministic product authority.
+
 ### M07-WP4 — Timeline tracks
 Canonical tracks:
 - video;
@@ -64,6 +91,12 @@ Canonical tracks:
 
 Support clip timing, trims, gaps, overlays and linked media references without embedding binaries.
 
+Rules:
+- linked media IDs are canonical object references, tenant/project authorized on use;
+- foreign provider IDs/URLs or model-returned references cannot become timeline authority without canonical resolution;
+- provider-specific hidden state is never required to interpret canonical timeline truth;
+- clip operations preserve rights/provenance/version references rather than copying unverified metadata into stronger classes.
+
 ### M07-WP5 — Continuity in/out state
 Per shot:
 - incoming character/entity state;
@@ -75,6 +108,8 @@ Per shot:
 - outgoing state;
 - first/end frame references.
 
+Continuity state is versioned evidence, not a model-owned authority surface. Later generated suggestions cannot silently mutate pinned character/entity/reference versions or approved prior-shot continuity.
+
 ### M07-WP6 — Keyframe/reference strategy
 - first-frame;
 - end-frame;
@@ -82,7 +117,9 @@ Per shot:
 - character/style/world references;
 - approved asset version pinning;
 - image-generation strategy integration;
-- no provider-specific state as canonical timeline data.
+- no provider-specific state as canonical timeline data;
+- reference asset/version lineage, ownership/rights and project scope remain explicit;
+- unknown/foreign provider-returned reference IDs are rejected until canonical lookup proves authority.
 
 ### M07-WP7 — OTIO interchange and versioned edits
 - map approved editorial structure to OpenTimelineIO;
@@ -90,7 +127,11 @@ Per shot:
 - namespaced AI metadata;
 - version snapshots;
 - undo/redo-safe operation model;
-- optimistic conflict handling.
+- optimistic conflict handling;
+- imported OTIO/external metadata remains untrusted until schema, project ownership, referenced-asset authority, duration/hierarchy invariants and supported-semantics validation pass;
+- unsupported/unknown metadata cannot create privileged actions or silently mutate approved state;
+- import creates a new reviewable version and never destructively overwrites an approved timeline;
+- stale optimistic writes fail safely rather than silently winning over a newer approved version.
 
 ### M07-WP8 — Acceptance
 Create a 10-minute representative project from approved content/audio:
@@ -100,9 +141,33 @@ Create a 10-minute representative project from approved content/audio:
 - continuity in/out;
 - references/keyframes;
 - OTIO export/import round trip within supported semantics;
-- no provider video spend.
+- no provider video spend;
+- no cross-tenant/foreign reference acceptance;
+- no silent approved-version overwrite;
+- no generated/imported text or metadata authority escalation.
+
+## Cross-cutting adversarial acceptance obligations
+
+`docs/qa/ADVERSARIAL-AUDIT-PLAN.md` is a mandatory planning input. When M07 later requests executable promotion, QA must re-evaluate the exact reachable authority surface and add only targeted missing evidence.
+
+At minimum M07 acceptance must prove:
+
+1. **Generated editorial text cannot grant authority** — model/provider/imported text cannot create tool, publish, approval, budget, account or security authority.
+2. **Canonical tenant/project reference authorization** — entity, asset, audio, keyframe, first/end-frame and other reference IDs are canonical-looked-up and tenant/project authorized before use.
+3. **Provider state is not canonical timeline truth** — provider IDs, URLs, hidden job state or model-returned metadata cannot become the only source of timeline/reference authority.
+4. **Pinned lineage survives edits** — later edits preserve exact character/entity/asset/audio/reference versions and cannot silently rewrite approved prior versions.
+5. **Malformed/generated structures fail closed** — invalid hierarchy, timing, duration, schema, reference or continuity structures are rejected before downstream execution.
+6. **OTIO/import data is untrusted** — imported external structures and metadata require supported-semantics, schema, ownership, hierarchy, timing and reference validation before becoming canonical.
+7. **Approved state is non-destructive** — import/edit operations create reviewable versions; approved timelines are not silently overwritten.
+8. **Optimistic conflicts fail safely** — stale writes cannot silently replace a newer approved version or reference lineage.
+9. **Rights/provenance remain attached** — referenced media/entity/voice assets retain ownership, rights/consent and provenance continuity through storyboard/timeline versions.
+10. **No synthetic downstream success** — deterministic planning fixtures prove contracts only; no video/provider/publish/production truth is inferred from planning CI.
+
+Do not add duplicate umbrella tests for already-proven lower-layer M03 asset isolation or M04–M06 planning statements unless M07 introduces a newly reachable authority/trust path.
 
 ## Expected modules/files
+
+Planned future executable surface only:
 
 - hierarchy/editorial services;
 - rhythm/timing package;
@@ -112,39 +177,58 @@ Create a 10-minute representative project from approved content/audio:
 - storyboard/timeline APIs;
 - fixtures/tests.
 
+Actual executable write ownership and migration reservations must be assigned fresh by the Supervisor after entry criteria pass.
+
 ## Data/migration impact
 
-Adds hierarchy nodes, track/clip/marker/timing data, continuity states, reference links and editorial versions/operations.
+Expected future implementation may add hierarchy nodes, track/clip/marker/timing data, continuity states, reference links and editorial versions/operations.
+
+This planning slice creates **no migration reservation and no schema change**. Future migration IDs must be reserved only after executable M07 authority exists and the then-current migration head is audited.
 
 ## API/UI impact
 
-Adds storyboard/timeline read/write/version APIs. Full rich editor UI arrives M11, but the API/state model is fixed here.
+Future implementation may add storyboard/timeline read/write/version APIs. Full rich editor UI arrives M11, but the API/state model is fixed here.
+
+This planning slice changes no API or UI.
 
 ## Security/cost/rights impact
 
-- referenced assets tenant/right checked;
-- no generation spend required;
+Future M07 must preserve:
+
+- referenced asset/entity/audio/keyframe canonical tenant/project authorization;
+- exact version/reference lineage and rights/provenance continuity;
+- no generation/video-provider spend required for M07 source acceptance;
 - edit permissions/version conflict model compatible with future RBAC;
-- sensitive media remains object references.
+- sensitive media remains object references rather than embedded secret-bearing payloads;
+- imported/generated metadata remains low-trust until deterministic validation;
+- provider/model text cannot elevate approval/publish/tool/security authority.
 
-## Test/acceptance
+## Test/acceptance plan
 
-- hierarchy/duration invariants;
-- shot reorder/time edits;
-- audio/beat alignment;
-- continuity state propagation;
-- first/end frame links;
-- optimistic conflicts;
-- OTIO round trip;
+Targeted future evidence includes:
+
+- hierarchy/duration invariants and invalid-parent/cycle/ceiling rejection;
+- cross-project/foreign asset/entity/audio/reference ID denial;
+- shot reorder/time edits with exact pinned lineage preservation;
+- audio/beat alignment and duration-bound validation;
+- continuity state propagation without silent identity/version mutation;
+- first/end frame links using canonical authorized assets;
+- generated malformed timeline/storyboard structure rejection;
+- optimistic stale-write conflict rejection;
+- OTIO round trip for supported semantics;
+- malicious/foreign OTIO references and authority-like metadata rejection;
+- import creates a new version rather than overwriting approved state;
 - long list/query performance fixtures.
 
 ## Rollout/rollback
 
-Editorial operations/version snapshots are non-destructive. OTIO import creates a new version rather than overwriting approved state without review.
+Editorial operations/version snapshots are non-destructive. OTIO import creates a new version rather than overwriting approved state without review. Rollback selects an earlier valid version; it does not erase lineage/audit evidence or silently repoint pinned references.
 
 ## Exit criteria
 
-A 10-minute project can be fully planned and edited as a provider-neutral storyboard/timeline with rhythm, audio markers, continuity and keyframes before any video-generation spend.
+M07 can exit only when a representative project can be fully planned and edited as a provider-neutral storyboard/timeline with rhythm, audio markers, continuity and keyframes while preserving canonical tenant/project authority, supported import semantics, version lineage, rights/provenance and fail-closed validation before any video-generation spend.
+
+Planning completion is **not** executable milestone completion.
 
 ## Non-goals
 
@@ -152,4 +236,6 @@ A 10-minute project can be fully planned and edited as a provider-neutral storyb
 - final FFmpeg master;
 - full M11 visual timeline UI;
 - professional NLE feature parity;
-- provider-specific clip limits defining project structure.
+- provider-specific clip limits/state defining canonical project structure;
+- production credentials or paid provider calls during this planning slice;
+- using generic `continue`, branch synchronization, mocks or green planning CI as executable M07 consent.


### PR DESCRIPTION
Implements Issue #89 as a planning-only M07 Storyboard/Timeline reconciliation on current `main@fc3382689431e811f2c3c2007e53ccd216e8bb31`.

Scope is intentionally bounded to two planning files:
- hardens `docs/milestones/M07/PLAN.md` with cross-cutting timeline/storyboard adversarial constraints;
- creates the previously missing `ai-native/parallel/checkpoints/M07-PARALLEL-LANE.md`.

The planning contract now makes these future executable requirements explicit: executable M04/M05/M06 completion, explicit M07 executable consent, canonical tenant/project authorization for asset/entity/audio/keyframe references, provider-state exclusion from canonical timeline truth, untrusted OTIO/import metadata, fail-closed malformed hierarchy/timing/reference structures, pinned version/reference lineage, non-destructive approved versions, optimistic conflict safety and rights/provenance continuity.

No product/API/schema/migration/provider/test implementation, paid call, credential, production data, video generation, publish action or executable M07 authorization is included. M08 remains dependency-gated and Issue #36 remains `EXTERNAL_NOT_VERIFIED`.

Work Done and Submitted