### PR TITLE
GOV: broadcast M07 planning promotion constraints

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -1,4 +1,4 @@
-version: 12
+version: 13
 supervisor:
   role: supervisor
   assigned_agent: supervisor-agent
@@ -13,7 +13,7 @@ active:
     role: supervisor-governance
     assigned_agent: supervisor-agent
     branch: supervisor/m03-governance-hold-current
-    base_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    base_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
     module: m03_governance_hold
     status: active-governance-hold
     writes:
@@ -24,8 +24,8 @@ active:
     migration_reservation: null
     consent_scope: M03-governance-closeout-only
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
-    last_acknowledged_broadcast: 15
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_broadcast: 16
     required_broadcast: null
 
   - task_id: M04-PARALLEL-LANE
@@ -44,8 +44,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
-    last_acknowledged_broadcast: 15
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_broadcast: 16
     required_broadcast: null
 
   - task_id: M05-PARALLEL-LANE
@@ -64,8 +64,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
-    last_acknowledged_broadcast: 15
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_broadcast: 16
     required_broadcast: null
 
   - task_id: M06-PARALLEL-LANE
@@ -84,15 +84,15 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
-    last_acknowledged_broadcast: 15
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_broadcast: 16
     required_broadcast: null
 
   - task_id: M07-PARALLEL-LANE
     title: Storyboard and Timeline planning/contracts
     role: planning-contract
     assigned_agent: timeline-agent
-    branch: agent/m07-storyboard-timeline
+    branch: agent/m07-storyboard-timeline-current
     module: timeline_storyboard
     status: planning-only
     writes:
@@ -106,8 +106,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
-    last_acknowledged_broadcast: 15
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_broadcast: 16
     required_broadcast: null
 
   - task_id: M08-PARALLEL-LANE
@@ -127,8 +127,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
-    last_acknowledged_broadcast: 15
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_broadcast: 16
     required_broadcast: null
 
   - task_id: CROSS-CUTTING-QA
@@ -147,8 +147,8 @@ active:
     migration_reservation: null
     consent_scope: audit-planning; executable test changes require applicable scope
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
-    last_acknowledged_broadcast: 15
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_broadcast: 16
     required_broadcast: null
 
 rules:

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "source_branch_required": "main",
   "assignment_authority": "supervisor",
   "no_slot_response": "Go Home Come Back Next Time",
@@ -16,7 +16,7 @@
     {"slot_id":"M04-CHARACTER","module":"characters_entities","branch":"agent/m04-character-library-current","status":"occupied","assigned_agent":"character-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory-current","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production-current","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},
-    {"slot_id":"M07-TIMELINE","module":"timeline_storyboard","branch":"agent/m07-storyboard-timeline","status":"occupied","assigned_agent":"timeline-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"M07-TIMELINE","module":"timeline_storyboard","branch":"agent/m07-storyboard-timeline-current","status":"occupied","assigned_agent":"timeline-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M08-PROVIDER","module":"providers","branch":"agent/m08-video-provider-router","status":"occupied","assigned_agent":"provider-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"CROSS-CUTTING-QA","module":"media_qa","branch":"agent/cross-cutting-qa-security-current","status":"occupied","assigned_agent":"qa-security-agent","accepts_new_agent":true,"start_status":"active-audit-planning"}
   ]

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
-version: 11
-latest_sequence: 15
+version: 12
+latest_sequence: 16
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -200,43 +200,76 @@ broadcasts:
       - agent/m08-video-provider-router
       - agent/cross-cutting-qa-security-current
     mandatory: true
+  - sequence: 16
+    trigger: m07-planning-promotion
+    merged_pr: 90
+    merged_branch: agent/m07-storyboard-timeline
+    submitted_head_sha: 9f7f1073823eb898f8dd3dc7de162a040d40d8b4
+    merged_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-m07-timeline-planning-hardening-sync
+    changed_areas:
+      - M07 storyboard/timeline planning contract hardened against authority and reference corruption
+      - missing M07 planning checkpoint created
+      - canonical tenant/project authorization required for entity, asset, audio, keyframe and timeline references
+      - provider-specific IDs, URLs and hidden state remain outside canonical timeline truth
+      - OTIO/imported editorial structures and metadata remain untrusted until supported-semantics, schema, ownership, hierarchy, timing, rights and reference validation
+      - pinned version/reference lineage, rights/provenance continuity and non-destructive approved versions recorded
+      - malformed hierarchy/timing/reference/continuity structures and stale optimistic writes fail safely
+      - executable M04/M05/M06 acceptance plus explicit M07 executable consent remain gates
+      - M08 remains dependency-gated; planning completion is not executable completion
+      - Issue 36 protected-main governance remains externally unverified
+    contract_changes:
+      - generated/imported editorial data cannot mint tool, publish, approval, budget or security authority
+      - future M07 executable work must revalidate dependencies, consent, migration, write ownership, reference authority, rights/provenance and version conflict controls
+      - planning synchronization does not grant executable M07 or downstream M08 authority
+    schema_migration_changes: []
+    recipients:
+      - supervisor/m03-governance-hold-current
+      - agent/m04-character-library-current
+      - agent/m05-content-memory-current
+      - agent/m06-audio-production-current
+      - agent/m07-storyboard-timeline-current
+      - agent/m08-video-provider-router
+      - agent/cross-cutting-qa-security-current
+    mandatory: true
 
 recipient_states:
   supervisor/m03-governance-hold-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 15
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_sequence: 16
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
   agent/m04-character-library-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 15
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_sequence: 16
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
   agent/m05-content-memory-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 15
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_sequence: 16
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
   agent/m06-audio-production-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 15
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
-  agent/m07-storyboard-timeline:
+    last_acknowledged_sequence: 16
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+  agent/m07-storyboard-timeline-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 15
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_sequence: 16
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
   agent/m08-video-provider-router:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 15
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_sequence: 16
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
   agent/cross-cutting-qa-security-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 15
-    last_synced_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+    last_acknowledged_sequence: 16
+    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
 
 rules:
   - Supervisor increments latest_sequence after every successful promotion merge to main that active agents must observe.

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -12,21 +12,21 @@ Planning synchronization, a green planning PR, deterministic fakes, or conversat
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 15 synchronized |
-| M04 Character | `character-agent` | `agent/m04-character-library-current` | broadcast 15 synchronized; planning hardened; executable hold |
-| M05 Content | `content-agent` | `agent/m05-content-memory-current` | broadcast 15 synchronized; planning hardened; executable hold |
-| M06 Audio | `audio-agent` | `agent/m06-audio-production-current` | broadcast 15 synchronized; planning hardened; executable hold |
-| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline` | broadcast 15 synchronized; planning-only; dependent on executable M04/M05/M06 |
-| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 15 synchronized; planning-only; dependent on executable M04/M07 |
-| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 15 synchronized; audit/planning only |
+| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 16 synchronized |
+| M04 Character | `character-agent` | `agent/m04-character-library-current` | broadcast 16 synchronized; planning hardened; executable hold |
+| M05 Content | `content-agent` | `agent/m05-content-memory-current` | broadcast 16 synchronized; planning hardened; executable hold |
+| M06 Audio | `audio-agent` | `agent/m06-audio-production-current` | broadcast 16 synchronized; planning hardened; executable hold |
+| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline-current` | broadcast 16 synchronized; planning hardened; executable hold |
+| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 16 synchronized; planning-only; dependent on executable M04/M07 |
+| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 16 synchronized; audit/planning only |
 
-Completed `agent/m04-character-library`, `agent/m05-content-memory`, and `agent/m06-audio-production` are retired after their planning promotions and are not force-reset or reused as promotion authority. Fresh current-main planning branches are `agent/m04-character-library-current`, `agent/m05-content-memory-current`, and `agent/m06-audio-production-current`. Earlier completed QA and M03/WP8 submission/review/closeout branches remain retired.
+Completed `agent/m04-character-library`, `agent/m05-content-memory`, `agent/m06-audio-production`, and `agent/m07-storyboard-timeline` are retired after their planning promotions and are not force-reset or reused as promotion authority. Fresh current-main planning branches are `agent/m04-character-library-current`, `agent/m05-content-memory-current`, `agent/m06-audio-production-current`, and `agent/m07-storyboard-timeline-current`. Earlier completed QA and M03/WP8 submission/review/closeout branches remain retired.
 
 ## M03 source completion and external hold
 
 M03 implementation, WP8 source acceptance, and source-side closeout are complete. Issue #36 remains the final M03 protected-main governance blocker because live GitHub enforcement is not verified.
 
-Migrations `20260901_0015` and `20260901_0016` remain landed. There is no active M03, M04, M05 or M06 migration reservation. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
+Migrations `20260901_0015` and `20260901_0016` remain landed. There is no active M03, M04, M05, M06 or M07 migration reservation. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
 
 ## Cross-cutting QA promotion
 
@@ -48,30 +48,36 @@ M05 planning completion is not executable M05 completion and does not satisfy M0
 
 ## M06 planning promotion
 
-PR #86 `M06: harden audio planning against voice and provider trust failures` passed exact-head Repository Governance, Core Domain Contracts and Durable Control Plane and merged to `main@9762ea1e7c640aa91b8eec777055915030a71ebc`.
+PR #86 `M06: harden audio planning against voice and provider trust failures` merged to `main@9762ea1e7c640aa91b8eec777055915030a71ebc`. Broadcast 15 recorded the promotion while preserving upstream executable acceptance, explicit M06 executable consent, provider/licensing revalidation, and the M07 executable dependency hold.
+
+M06 planning completion is not executable M06 completion and does not satisfy M07 executable dependency.
+
+## M07 planning promotion
+
+PR #90 `M07: harden timeline planning against authority and reference corruption` merged to `main@29c66616ce1e79c90b4bb40f8e2158d0f9edd434`.
 
 That promotion:
 
-- hardened the M06 audio planning contract against provider-output authority escalation and malformed-media trust;
-- created the previously missing `ai-native/parallel/checkpoints/M06-PARALLEL-LANE.md`;
-- required voice/likeness consent and immutable/pinned VoiceProfile identity;
-- made provider IDs, URLs, transcripts, status and licensing claims untrusted until canonical validation;
-- required malformed audio and parser/probe/transcode failures to fail closed;
-- excluded raw provider/OAuth/signing secrets from prompts, generated artifacts, manifests, ledgers and logs;
-- required rights/consent/provenance continuity plus bounded retry/fallback/fan-out/spend and idempotent no-duplicate-billing semantics;
-- explicitly retained upstream executable milestone acceptance plus explicit M06 executable consent as mandatory executable entry gates;
-- created no product/API/schema/provider/test implementation and no migration reservation;
-- did not satisfy M07 executable dependency because planning completion is not executable M06 completion.
+- hardened storyboard/timeline planning against authority escalation from generated or imported editorial text;
+- created the previously missing `ai-native/parallel/checkpoints/M07-PARALLEL-LANE.md`;
+- required canonical tenant/project authorization for entity, asset, audio, keyframe and reference IDs;
+- kept provider IDs, URLs and hidden provider state outside canonical timeline truth;
+- treated OTIO/imported editorial structure and metadata as untrusted until supported-semantics, schema, ownership, hierarchy, timing, rights and reference validation pass;
+- required pinned version/reference lineage, rights/provenance continuity and non-destructive approved versions;
+- required malformed hierarchy/timing/reference/continuity structures and stale optimistic writes to fail safely before downstream execution;
+- retained executable M04/M05/M06 acceptance plus explicit M07 executable consent as mandatory executable entry gates;
+- created no product/API/schema/provider/test implementation, paid call, credential, video generation, publish action or migration reservation;
+- did not satisfy M08 executable dependency because planning completion is not executable M07 completion.
 
-Broadcast 15 records this planning promotion for every affected active lane.
+After the merge, every pre-existing active branch except the completed squash-merged M07 submission branch was verified at zero unique commits and non-force fast-forwarded to the triggering main. The completed M07 submission branch was retired rather than force-reset, and fresh `agent/m07-storyboard-timeline-current` was created from current main. Broadcast 16 records this planning promotion for all affected active lanes.
 
 ## Dependency and consent boundary
 
 - M04 executable work remains dependent on `M03-GOV-HOLD` and explicit M04 executable consent.
 - M05 executable work remains dependent on executable M04 completion and explicit M05 executable consent.
 - M06 executable work requires the accepted upstream executable chain, explicit M06 executable consent and then-current provider/licensing/governance revalidation.
-- M07 executable work remains dependent on executable M04/M05/M06 completion.
-- M08 executable work remains dependent on executable M04/M07 completion.
+- M07 executable work remains dependent on executable M04/M05/M06 completion plus explicit M07 executable consent and then-current governance/write/migration/reference/right/provenance revalidation.
+- M08 executable work remains dependent on executable M04/M07 completion plus explicit M08 executable consent and current provider/API/rights/cost revalidation.
 - Cross-cutting QA remains audit/planning only unless an applicable executable scope authorizes targeted tests.
 - Generic `continue`, branch synchronization, green planning CI, mocks, deterministic fakes, or a planning checkpoint cannot satisfy a privileged development/publish/security gate.
 
@@ -84,16 +90,17 @@ Future migration IDs are reserved only after executable authority exists and the
 ## Hold order
 
 1. keep Issue #36 `EXTERNAL_NOT_VERIFIED` until live protected-main evidence exists;
-2. preserve broadcast 12 adversarial obligations plus broadcasts 13, 14 and 15 planning constraints in future milestone acceptance;
+2. preserve broadcast 12 adversarial obligations plus broadcasts 13, 14, 15 and 16 planning constraints in future milestone acceptance;
 3. do not start executable M04 until Issue #36 and explicit M04 executable consent both clear;
 4. do not start executable M05 until executable M04 is accepted and explicit M05 executable consent exists;
 5. do not start executable M06 until its upstream executable chain is accepted and explicit M06 executable consent exists;
-6. do not treat M04/M05/M06 planning completion as satisfying M07 or M08 executable dependencies;
-7. do not create synthetic provider/admin/production success from source CI, mocks or deterministic fakes.
+6. do not start executable M07 until executable M04/M05/M06 are accepted and explicit M07 executable consent exists;
+7. do not treat M04/M05/M06/M07 planning completion as satisfying M08 executable dependency;
+8. do not create synthetic provider/admin/production success from source CI, mocks or deterministic fakes.
 
 ## Next safe planning work
 
-While executable gates remain closed, a later planning lane may be audited and hardened only within its existing planning consent scope. M07 currently has a real planning-only documentation/checkpoint gap and may be reconciled after broadcast-15 coordination is promoted. Any planning slice must preserve all dependency/consent holds, avoid implementation/schema/provider spend, and pass ordinary exact-head repository/source regression CI before merge.
+While executable gates remain closed, M08 may be audited and hardened only within its existing planning consent scope and claimed files. Its current plan predates the latest cross-cutting and M07 authority/reference constraints, so a bounded planning-only reconciliation may update `docs/milestones/M08/**` and create/update `ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md` after broadcast-16 coordination is promoted. It must preserve all executable dependency/consent holds, avoid implementation/schema/provider spend or credential use, revalidate current provider assumptions only when execution is later authorized, and pass ordinary exact-head repository/source regression CI before merge.
 
 ## Completion and review
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -1,9 +1,9 @@
-version: 12
+version: 13
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 9762ea1e7c640aa91b8eec777055915030a71ebc
-  main_sha_last_reconciled: 9762ea1e7c640aa91b8eec777055915030a71ebc
+  main_sha_last_promotion: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+  main_sha_last_reconciled: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
   own_task_id: M03-GOV-HOLD
   own_branch: supervisor/m03-governance-hold-current
   current_mode: external-governance-hold
@@ -11,9 +11,9 @@ supervisor:
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 86
-  submitted_head_sha: ca32cfc9b7fc4dda249188f4524ef11c562215cc
-  merged_main_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+  pr: 90
+  submitted_head_sha: 9f7f1073823eb898f8dd3dc7de162a040d40d8b4
+  merged_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
   result: success
 
 new_agent_onboarding:
@@ -26,7 +26,7 @@ new_agent_onboarding:
 pause_checkpoint:
   active: true
   branch: supervisor/m03-governance-hold-current
-  head_sha: 9762ea1e7c640aa91b8eec777055915030a71ebc
+  head_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
   task_id: M03-GOV-HOLD
   subtask: wait-for-live-protected-main-evidence
   next_action: verify Issue 36 live ruleset/protection read-back from an admin-capable context
@@ -35,7 +35,7 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 15
+  latest_broadcast_sequence: 16
   agents_with_mandatory_sync: []
   policy: branches-with-unacknowledged-mandatory-broadcast-cannot-seek-promotion
 
@@ -74,8 +74,18 @@ planning_state:
       - explicit M06 executable consent
       - then-current governance, write ownership and migration reservation if required
       - current audio provider APIs, licensing and commercial-use constraints revalidated
+  m07:
+    status: planning-hardened-only
+    promotion_pr: 90
+    active_branch: agent/m07-storyboard-timeline-current
+    executable_authority: false
+    executable_gates:
+      - executable M04, M05 and M06 completion and acceptance
+      - explicit M07 executable consent
+      - Issue 36/live governance where required by the accepted upstream chain
+      - fresh write ownership and migration reservation if required
+      - canonical reference authorization, rights/provenance and non-destructive versioning revalidation
   downstream:
-    m07: dependency-gated-planning-only
     m08: dependency-gated-planning-only
 
 rules:


### PR DESCRIPTION
Implements Issue #91 as governance-only coordination after M07 planning PR #90 merged to `main@29c66616ce1e79c90b4bb40f8e2158d0f9edd434`.

This PR changes exactly the five canonical Supervisor coordination files and:
- records mandatory broadcast sequence 16 for the M07 planning promotion;
- retires completed `agent/m07-storyboard-timeline` and binds fresh `agent/m07-storyboard-timeline-current`;
- records Supervisor/M04/M05/M06/M07/M08/QA lanes synchronized to the triggering main after zero-unique-commit verification for all pre-existing active non-submission branches;
- preserves executable M04/M05/M06 acceptance + explicit M07 executable consent + then-current governance/write/migration/reference/right/provenance gates;
- preserves M08 dependency on executable M04/M07 and explicit M08 executable consent;
- preserves Issue #36 as live protected-main governance `EXTERNAL_NOT_VERIFIED`;
- records M08 as the next bounded planning-only audit surface without granting implementation/provider spend/credential authority.

No product/API/schema/provider/test implementation, migration, credential, paid call, production data, video generation, publish action, security-setting mutation or executable milestone unlock.

Closes #91

Work Done and Submitted