### PR TITLE
M08: harden provider-router planning trust boundaries

### DIFF
--- a/ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md
+++ b/ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md
@@ -1,0 +1,82 @@
+# M08 Parallel Lane Checkpoint
+
+- Task: `M08-PARALLEL-LANE`
+- Issue: #93
+- Agent role: provider planning-contract
+- Branch: `agent/m08-video-provider-router`
+- Synchronized baseline before planning write: `main@ba97ccbe9ebaa8df3a864ea7a98e2aa3389e4165`
+- Broadcast acknowledged: 16
+- Authority: planning-only
+- Migration reservation: none
+- Executable M08 authority: **false**
+
+## Bounded write scope
+
+This slice changes only:
+
+- `docs/milestones/M08/**`
+- `ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md`
+
+No product/API/schema/provider adapter/test implementation, migration, credential, paid provider call, media generation, publication, security-setting mutation or production data access is authorized.
+
+## Reconciliation performed
+
+The existing M08 provider-router plan was audited against:
+
+- broadcast-16 / M07 planning promotion constraints;
+- `docs/qa/ADVERSARIAL-AUDIT-PLAN.md` provider-router obligations;
+- current Supervisor dependency/consent holds;
+- M07 canonical reference/version/rights/provenance requirements.
+
+The previous plan already included provider-neutral requests/attempts, quotas, fallback, budgets, rights and ambiguous-completion reconciliation, but it did not state the latest authority/trust boundaries strongly enough and had no M08 checkpoint.
+
+Planning was hardened to require:
+
+1. provider/model returned IDs, URLs, metadata, JSON, moderation labels, OCR/transcripts and instructions remain untrusted until schema validation and canonical lookup/policy checks;
+2. every M07/provider-supplied entity/asset/shot/audio/keyframe/reference/version ID is re-authorized for the active workspace/project and pinned to exact lineage;
+3. generated/imported text or media cannot mint tool, publish, budget, approval, account or security authority;
+4. raw provider/OAuth/signing secrets remain server-side references outside prompts, model memory, generated artifacts, manifests, decision/attempt ledgers and logs;
+5. rights, consent, commercial-use eligibility and provenance survive routing, regeneration and cross-provider handoff;
+6. retries/fallbacks/fan-out/time/cost remain bounded by idempotency, circuit breaking and budget reservation;
+7. ambiguous external completion reconciles before retry/fallback and cannot trigger duplicate paid work;
+8. unsupported/unknown/stale capability fails explicitly rather than silently substituting another privileged operation;
+9. eligible provider outputs must be validated and canonically ingested before accepted reuse;
+10. deterministic fakes prove source contracts only and cannot be relabeled as live provider/admin/production truth.
+
+## Executable entry gates preserved
+
+Future executable M08 remains blocked until the then-current repository proves all applicable gates, including:
+
+- executable M04 acceptance;
+- executable M07 acceptance;
+- explicit M08 executable consent;
+- Issue #36/live protected-main governance where required by the accepted dependency chain;
+- collision-free write ownership and migration reservation where required;
+- fresh official-source revalidation of provider APIs/auth/scopes/model availability/prices/quotas/moderation/rights/licensing/output-use constraints;
+- applicable exact-head QA/security acceptance for the newly reachable provider/router attack surface.
+
+Planning completion, green planning CI, synchronization, mocks/fakes or generic `continue` do not satisfy these gates.
+
+## Data / provider / cost impact
+
+- Schema/migration change: none.
+- Provider credential use: none.
+- Paid/free provider execution: none.
+- Media generated/downloaded/published: none.
+- Production data used: none.
+- Security/admin setting mutation: none.
+
+## Review target
+
+Supervisor review should verify:
+
+- changed files remain inside the claimed M08 planning surfaces;
+- executable dependency/consent/governance gates remain closed;
+- no provider-specific hidden state became canonical authority;
+- M07 pinned reference/version and rights/provenance constraints survive cross-provider fallback;
+- retry/fallback/budget and ambiguous-completion rules fail closed;
+- ordinary exact-head repository/source regression CI is green.
+
+## Completion signal
+
+Work Done and Submitted

--- a/docs/milestones/M08/PLAN.md
+++ b/docs/milestones/M08/PLAN.md
@@ -1,24 +1,60 @@
 # M08 — Hybrid Image and Video Router
 
+## Planning authority and current hold
+
+This document is currently a **planning-only contract**. It does not authorize provider SDK integration, schema/API/product/test implementation, migrations, credentials, paid calls, media generation, publication, security-setting mutation, or production data access.
+
+Executable M08 remains blocked until all then-current gates are satisfied, including:
+
+- executable M04 acceptance;
+- executable M07 acceptance;
+- explicit M08 executable consent;
+- Issue #36/live protected-main governance where required by the accepted dependency chain;
+- fresh collision-free write ownership and migration reservation where required;
+- current provider APIs, authentication/scopes, prices/quotas, model availability, commercial rights/licensing, moderation and output-use restrictions revalidated from official sources.
+
+Planning completion, deterministic fakes, green planning CI, branch synchronization, or generic conversational continuation cannot satisfy those executable gates.
+
 ## Objective
 
-Implement provider capability adapters and HYBRID_SMART routing for image/video generation so canonical requests can move across legitimate free/paid providers without losing character, scene, continuity, cost or history state.
+Plan provider capability adapters and HYBRID_SMART routing for image/video generation so canonical requests can later move across legitimate free/paid providers without losing character, scene, continuity, cost, rights, provenance, authority or history state.
 
-## Entry criteria
+## Entry criteria for later executable work
 
 - P0 complete.
-- M01–M07 accepted.
-- Explicit M08 consent.
-- Current provider APIs, scopes, prices, rights and limits revalidated from official sources.
+- Required M01–M07 executable dependencies accepted, including executable M04 and M07.
+- Explicit M08 executable consent.
+- Live governance and repository entry gates satisfied.
+- Current provider APIs, scopes, prices, quotas, model capabilities, moderation, rights/licensing and output restrictions revalidated from official sources.
+- Write ownership and any required migration IDs reserved from the then-current repository state.
 
 ## Dependencies
 
 `M02 workflows + M03 assets + M04 entities + M07 shot/reference plans -> M08`
 
+M07 planning/reference completion is not executable M07 acceptance. Every M07-supplied asset/entity/reference/version identifier remains subject to canonical tenant/project authorization and pinned-version/rights/provenance validation before later M08 execution.
+
+## Cross-cutting trust boundary
+
+M08 introduces a high-risk external provider boundary. Future execution must preserve these invariants:
+
+1. **Provider/model output is untrusted evidence.** Returned IDs, URLs, filenames, MIME/type claims, dimensions, metadata, JSON, moderation labels, transcripts/OCR and natural-language instructions require schema validation and canonical policy checks before use.
+2. **Returned IDs never grant authority.** Every entity, asset, shot, audio, keyframe, reference, version, connection or provider-returned resource ID must be looked up canonically and re-authorized for the active workspace/project.
+3. **Generated/imported text cannot mint privilege.** Prompts, provider output, embedded media text, OCR/transcripts or model recommendations cannot create tool, publish, budget, approval, account or security authority.
+4. **Secrets remain references.** Raw API keys, OAuth tokens, signing credentials and provider secrets stay in server-side secret resolution and must not enter ordinary prompts, model memory, generated artifacts, manifests, decision ledgers or logs.
+5. **Rights/provenance survive routing.** Cross-provider fallback or regeneration must preserve exact reference/version lineage, ownership, consent, likeness/voice rights and commercial-use eligibility.
+6. **Retries/fallbacks are bounded.** Attempt count, elapsed time, provider fan-out and money require explicit ceilings, idempotency, circuit-breaking and budget reservation.
+7. **Ambiguous completion fails closed.** If an external request may have completed but acknowledgement is lost, reconcile before retrying, switching provider or settling spend; do not create duplicate paid generation.
+8. **Unknown capability cannot be silently substituted.** Unsupported/unknown operations fail explicitly or require an authorized alternative; a provider/model may not infer a privileged substitute.
+9. **Canonical storage is the trust anchor.** Provider-hosted URLs/hidden state are temporary evidence only. Eligible outputs are validated, downloaded and recorded through canonical asset authority before later reuse.
+10. **Source acceptance is not production truth.** Fakes may prove contracts; missing live provider/admin/production evidence remains NOT_VERIFIED until an explicit later gate requires and obtains it.
+
 ## Work packages
 
 ### M08-WP1 — Runtime provider capability registry
-Canonical capability records for:
+
+Plan canonical capability records for:
+
 - text-to-image;
 - image editing/inpaint/outpaint;
 - image-to-image/reference/style controls;
@@ -31,34 +67,65 @@ Canonical capability records for:
 - moderation;
 - cost/free quota evidence;
 - commercial/right posture;
-- last verified timestamp.
+- watermark/output-use restrictions;
+- capability source/provenance and last verified timestamp.
+
+Rules:
+
+- capability evidence is provider/model/version scoped and freshness-stamped;
+- unknown/stale capability is not equivalent to supported;
+- provider marketing prose or model-generated descriptions are not canonical capability authority;
+- execution later revalidates material volatile fields rather than freezing discovery-time assumptions indefinitely.
 
 ### M08-WP2 — Provider connection and credential model
+
+Plan:
+
 - one authorized connection/account per provider by default;
-- server-side secret handles;
+- server-side secret handles only;
 - token/API-key lifecycle;
-- status/scopes;
+- non-secret readiness/status/scopes;
 - funding source;
 - test/revoke/reconnect;
+- workspace/project authorization boundaries;
 - no multiple-account quota-rotation design.
 
+Raw secret values must not be persisted in canonical generation requests/attempts, prompts, manifests or logs.
+
 ### M08-WP3 — Canonical generation request/attempt contract
-`GenerationRequest` contains:
-- asset/shot intent;
+
+`GenerationRequest` later contains only canonically authorized/pinned inputs such as:
+
+- workspace/project/asset/shot intent;
 - prompt version;
-- reference asset IDs;
-- first/end frame;
-- character/world/style locks;
+- reference asset/version IDs;
+- first/end frame references;
+- character/world/style locks with pinned version lineage;
 - duration/aspect/resolution;
 - motion/camera;
 - negative/forbidden constraints;
-- budget/funding;
-- rights requirement.
+- budget/funding ceiling and authority reference;
+- rights/consent/commercial-use requirement;
+- stable idempotency/business-operation key.
 
-Every provider maps into this contract and returns normalized Attempt state/cost/output refs/errors.
+Every provider maps into this contract and returns normalized Attempt evidence:
+
+- provider/model/version and connection reference;
+- request fingerprint/idempotency lineage;
+- submitted/started/finished timestamps;
+- normalized status/error class;
+- observed quota/rate/cost evidence;
+- provider references as non-authoritative provenance;
+- output candidates pending validation/canonical ingest;
+- ambiguity/reconciliation state;
+- actual settled cost when known.
+
+Provider IDs/URLs must never become the canonical operation key or bypass tenant/project authorization.
 
 ### M08-WP4 — Initial image adapters
-Implement a small approved set, chosen at execution after current API audit. Required adapter behaviors:
+
+Later executable work may integrate a small approved set selected only after a fresh official API audit. Required adapter behaviors:
+
 - capability discovery/config;
 - submit;
 - async status where applicable;
@@ -66,63 +133,91 @@ Implement a small approved set, chosen at execution after current API audit. Req
 - edit/reference support;
 - cost/quota/error mapping;
 - cancellation when supported;
-- fake adapter for tests.
+- strict schema/type/size/output validation;
+- canonical ingest handoff;
+- fake adapter for deterministic source tests.
 
-Do not integrate every provider discovered.
+Do not integrate every provider discovered. Unknown/unsupported capability must fail explicitly rather than silently selecting another privileged operation.
 
 ### M08-WP5 — Initial video adapters
-At least two providers capable of executing the same canonical representative shot through supported official APIs/authorized flows.
+
+Later executable acceptance requires at least two approved providers capable of executing the same canonical representative shot through supported official APIs/authorized flows.
 
 Normalize:
+
 - text/image-to-video;
 - reference/first/end frame where supported;
 - duration/resolution;
 - job status;
 - output download;
-- error/moderation/cost.
+- error/moderation/cost;
+- provider/model/version provenance;
+- ambiguous/lost-ack reconciliation.
+
+Provider output metadata remains untrusted until validated and canonically ingested.
 
 ### M08-WP6 — Routing engine
-Default `HYBRID_SMART` utility considers:
-- capability fit;
+
+Default `HYBRID_SMART` utility may later consider only authorized/canonical evidence:
+
+- capability fit and freshness;
 - expected quality;
 - continuity fit;
-- historical acceptance;
-- rights confidence;
+- historical acceptance from tenant-authorized evidence;
+- rights/commercial-use confidence;
 - expected accepted-output cost;
-- retry risk;
-- speed/queue;
+- retry/ambiguity risk;
+- speed/queue/rate-limit evidence;
 - legitimate free quota;
 - watermark/manual-labor penalties;
-- workspace provider policy.
+- workspace provider policy;
+- budget authority and remaining reservation;
+- provider/connection circuit state.
 
 Modes:
+
 - FREE_ONLY
 - FREE_FIRST
 - HYBRID_SMART
 - BUDGET_CAPPED
 - QUALITY_FIRST
 
+Routing output is a recommendation/decision record, not new authority. It cannot override budget, rights, tenant, publish, security or explicit consent gates.
+
 ### M08-WP7 — Quota/fallback/recovery and cross-provider handoff
-Flow:
-`Provider A -> quota/failure/QA-retry condition -> preserve canonical request/reference state -> Provider B -> normalize -> QA`
+
+Planned flow:
+
+`Provider A -> known retry-safe quota/failure/QA condition -> preserve canonical request/reference state -> authorized Provider B -> normalize -> validate -> QA`
 
 Rules:
+
 - successful prior shots remain untouched;
 - one provider’s hidden state is never required;
-- approved references/first/end frames bridge providers;
-- same-provider account rotation to evade quotas prohibited;
+- approved canonical references/first/end frames bridge providers;
+- every bridged reference is re-authorized and pinned to exact lineage/version;
+- same-provider account rotation to evade quotas is prohibited;
 - consumer web credits are not automated unless provider officially supports the authorized mechanism;
-- ambiguous external completion reconciled before retry.
+- retries/fallbacks/fan-out/time/cost are bounded;
+- paid retries require remaining budget reservation/authority;
+- a permanent rights/policy/authorization failure is not converted into a retryable provider-selection problem;
+- ambiguous external completion reconciles before retry/fallback and may not trigger duplicate paid work;
+- circuit-open/unavailable state yields wait/manual/authorized fallback, never uncontrolled fan-out.
 
 ### M08-WP8 — Cost/rights/acceptance
-- estimate/reserve/settle usage;
-- provider cost records every attempt, including failure where cost incurred;
-- rights/commercial-use gate;
-- watermark/output eligibility;
-- representative image generation + one shot switch across at least two video providers;
-- all attempts/history retained.
 
-## Expected modules/files
+Later executable work must:
+
+- estimate/reserve/settle usage idempotently;
+- record cost evidence for every attempt where cost may be incurred, including failures;
+- fail closed when budget authority/reservation is insufficient;
+- enforce current rights/commercial-use/consent requirements before dispatch and before canonical reuse;
+- enforce watermark/output eligibility;
+- preserve provider/model/version, input reference lineage and output provenance;
+- demonstrate representative image generation and one authorized shot switch across at least two video providers;
+- retain all attempt/reconciliation/history evidence without granting provider output canonical authority.
+
+## Expected modules/files for later executable work
 
 - provider registry/runtime snapshot service;
 - image/video adapter packages;
@@ -130,49 +225,80 @@ Rules:
 - generation workflows/activities;
 - provider connection/secret integration;
 - cost/quota normalization;
+- canonical output validation/ingest handoff;
 - contract/fake-provider tests.
 
-## Data/migration impact
+This planning slice creates none of those executable surfaces.
 
-Adds provider connections/capability snapshots, generation requests/attempts, quota/cost observations, provider references and routing decisions.
+## Data/migration impact for later executable work
 
-## API/UI impact
+Expected future data may include provider connections/capability snapshots, generation requests/attempts, quota/cost observations, provider references, routing decisions and reconciliation state.
 
-Adds provider connection/status, generation request, attempts, comparison/cost/fallback APIs. Provider admin/full UI later M11.
+No migration is reserved or authorized by this planning document. Any future migration IDs must be reserved only after executable authority exists and the then-current migration head/write ownership is re-audited.
+
+## API/UI impact for later executable work
+
+Potential future surfaces include provider connection/status, generation request, attempts, comparison/cost/fallback APIs. Provider admin/full UI remains later M11.
+
+No API/UI change is authorized by this planning slice.
 
 ## Security/cost/rights impact
 
-- credentials secret-managed;
-- current ToS/API evidence required;
+Future implementation must ensure:
+
+- credentials are secret-managed and resolved outside ordinary provider/model-visible state;
+- current ToS/API/rights/licensing evidence is required at executable entry and revalidated when stale/materially changed;
 - no quota circumvention;
-- budget reservation before paid work;
-- rights/commercial-use requirement can exclude provider;
-- outputs validated/downloaded into canonical storage.
+- budget reservation before paid work and bounded spend through retries/fallbacks;
+- rights/consent/commercial-use requirements can exclude a provider/model/output;
+- returned IDs/URLs/metadata/instructions are untrusted;
+- cross-tenant/project references are denied canonically;
+- output validation/download/canonical ingest precedes accepted reuse;
+- provider/model output cannot grant publish, budget, account or security authority;
+- generated media/OCR/transcript instructions remain low-trust evidence.
 
-## Test/acceptance
+## Test/acceptance obligations for later executable promotion
 
-- fake adapters cover every normalized failure class;
-- token/quota/rate-limit;
-- malformed/partial output;
-- cost settlement/idempotency;
+Targeted tests must be added only when M08 execution is authorized. They must include at least:
+
+- fake adapters for every normalized failure class;
+- unknown/stale capability fails closed;
+- foreign tenant/project/entity/asset/reference/provider-returned IDs rejected;
+- provider URLs/metadata cannot bypass canonical ingest/authorization;
+- token/quota/rate-limit handling;
+- malformed/partial/mismatched media output fails closed;
+- embedded/generated instruction text cannot mutate provider/tool/publish/budget/security authority;
+- raw secrets absent from prompts, artifacts, manifests, attempt/decision ledgers and logs;
+- budget reservation, settlement and idempotency;
 - router scoring deterministic for fixture state;
-- fallback preserves references;
-- two-provider same-shot acceptance;
-- no duplicate paid request after replay;
-- provider unavailable produces manual/wait/fallback path.
+- routing cannot override rights/budget/authority policy;
+- fallback preserves canonical pinned references/version/rights/provenance;
+- ambiguous completion reconciles before retry/fallback;
+- no duplicate paid request after worker replay/lost acknowledgement;
+- bounded retry/fallback/fan-out/circuit-breaker behavior under persistent 429/500/timeout faults;
+- provider unavailable produces manual/wait/authorized-fallback path;
+- representative same-shot execution through two approved providers only when real-provider evidence is explicitly authorized/required;
+- deterministic fakes/source tests never relabeled as production/provider truth.
 
-## Rollout/rollback
+Existing M03 lower-layer asset/private-delivery evidence should be reused rather than duplicated; M08 adds tests only for new provider/router trust boundaries.
 
-Adapters/model versions feature-flagged and release-gated. Provider can be disabled globally without corrupting canonical projects. Router reverts to prior registry/scoring version.
+## Rollout/rollback for later executable work
 
-## Exit criteria
+Adapters/model versions are feature-flagged and release-gated. A provider/model may be disabled without corrupting canonical projects. Router registry/scoring versions are pinned so decisions remain reproducible, and rollback does not rewrite accepted attempt/history evidence.
 
-The same canonical shot/reference package can be generated through at least two approved providers and switch safely on failure/quota while retaining full provider-neutral state, cost, rights and attempt history.
+## Exit criteria for later executable M08
+
+M08 is executable-complete only when the same canonical, tenant-authorized, rights-valid shot/reference package can be processed through at least two approved providers and switch safely on a **known retry/fallback-safe** condition while retaining provider-neutral state, pinned lineage, rights/provenance, cost, authority, reconciliation and attempt history.
+
+An ambiguous prior attempt must not be silently switched. Source mocks/fakes alone cannot prove live provider/admin/production truth where the later acceptance gate explicitly requires external evidence.
 
 ## Non-goals
 
 - every market provider;
 - guaranteed pixel-identical cross-provider output;
 - quota evasion/multi-account rotation;
+- trusting provider/model-returned IDs or URLs as canonical authority;
+- allowing generated text/media to mint tool/publish/budget/security authority;
 - full multimodal continuity scoring (M09);
-- final render assembly (M10).
+- final render assembly (M10);
+- any executable provider work during the current planning-only slice.


### PR DESCRIPTION
Implements Issue #93 as a planning-only M08 reconciliation from broadcast-16 synchronized `main@ba97ccbe9ebaa8df3a864ea7a98e2aa3389e4165`.

Scope is exactly two claimed planning files:
- `docs/milestones/M08/PLAN.md`
- `ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md`

The planning contract now explicitly:
- treats provider-returned IDs/URLs/metadata/JSON/OCR/transcripts/instructions as untrusted evidence;
- re-authorizes every provider/M07-supplied entity/asset/reference/version ID canonically for the active workspace/project;
- preserves pinned reference/version lineage and rights/provenance through routing and fallback;
- prevents generated/imported content from minting tool/publish/budget/account/security authority;
- keeps raw provider/OAuth/signing secrets outside prompts, memory, generated artifacts, manifests, ledgers and logs;
- bounds retry/fallback/fan-out/time/cost with idempotency, circuit-breaking and budget reservation;
- requires ambiguous external completion reconciliation before retry/fallback;
- fails explicitly on unknown/stale/unsupported capability instead of silently substituting a privileged operation;
- keeps source fakes distinct from live provider/admin/production truth;
- preserves executable M08 gates: executable M04 + M07 acceptance, explicit M08 consent, applicable live governance, fresh ownership/migration reservations and current provider API/rights/licensing/cost revalidation.

No product/API/schema/provider adapter/test implementation, migration, credential use, paid call, media generation, publication, security-setting mutation or production data access.

Closes #93

Work Done and Submitted