### PR TITLE
GOV: broadcast M08 planning promotion constraints

### DIFF
--- a/ai-native/parallel/ACTIVE-WORK.yaml
+++ b/ai-native/parallel/ACTIVE-WORK.yaml
@@ -1,4 +1,4 @@
-version: 13
+version: 14
 supervisor:
   role: supervisor
   assigned_agent: supervisor-agent
@@ -13,7 +13,7 @@ active:
     role: supervisor-governance
     assigned_agent: supervisor-agent
     branch: supervisor/m03-governance-hold-current
-    base_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    base_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
     module: m03_governance_hold
     status: active-governance-hold
     writes:
@@ -24,8 +24,8 @@ active:
     migration_reservation: null
     consent_scope: M03-governance-closeout-only
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
-    last_acknowledged_broadcast: 16
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
+    last_acknowledged_broadcast: 17
     required_broadcast: null
 
   - task_id: M04-PARALLEL-LANE
@@ -44,8 +44,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
-    last_acknowledged_broadcast: 16
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
+    last_acknowledged_broadcast: 17
     required_broadcast: null
 
   - task_id: M05-PARALLEL-LANE
@@ -64,8 +64,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
-    last_acknowledged_broadcast: 16
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
+    last_acknowledged_broadcast: 17
     required_broadcast: null
 
   - task_id: M06-PARALLEL-LANE
@@ -84,8 +84,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
-    last_acknowledged_broadcast: 16
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
+    last_acknowledged_broadcast: 17
     required_broadcast: null
 
   - task_id: M07-PARALLEL-LANE
@@ -106,8 +106,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
-    last_acknowledged_broadcast: 16
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
+    last_acknowledged_broadcast: 17
     required_broadcast: null
 
   - task_id: M08-PARALLEL-LANE
@@ -116,7 +116,7 @@ active:
     assigned_agent: provider-agent
     branch: agent/m08-video-provider-router
     module: providers
-    status: planning-only
+    status: planning-hardened-only
     writes:
       - docs/milestones/M08/**
       - ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md
@@ -127,8 +127,8 @@ active:
     migration_reservation: null
     consent_scope: planning-only-until-new-scope-approved
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
-    last_acknowledged_broadcast: 16
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
+    last_acknowledged_broadcast: 17
     required_broadcast: null
 
   - task_id: CROSS-CUTTING-QA
@@ -147,8 +147,8 @@ active:
     migration_reservation: null
     consent_scope: audit-planning; executable test changes require applicable scope
     completion_signal: Work Done and Submitted
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
-    last_acknowledged_broadcast: 16
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
+    last_acknowledged_broadcast: 17
     required_broadcast: null
 
 rules:

--- a/ai-native/parallel/AGENT-SLOTS.json
+++ b/ai-native/parallel/AGENT-SLOTS.json
@@ -1,5 +1,5 @@
 {
-  "version": 8,
+  "version": 9,
   "source_branch_required": "main",
   "assignment_authority": "supervisor",
   "no_slot_response": "Go Home Come Back Next Time",
@@ -17,7 +17,7 @@
     {"slot_id":"M05-CONTENT","module":"content_memory","branch":"agent/m05-content-memory-current","status":"occupied","assigned_agent":"content-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M06-AUDIO","module":"audio","branch":"agent/m06-audio-production-current","status":"occupied","assigned_agent":"audio-agent","accepts_new_agent":true,"start_status":"planning-only"},
     {"slot_id":"M07-TIMELINE","module":"timeline_storyboard","branch":"agent/m07-storyboard-timeline-current","status":"occupied","assigned_agent":"timeline-agent","accepts_new_agent":true,"start_status":"planning-only"},
-    {"slot_id":"M08-PROVIDER","module":"providers","branch":"agent/m08-video-provider-router","status":"occupied","assigned_agent":"provider-agent","accepts_new_agent":true,"start_status":"planning-only"},
+    {"slot_id":"M08-PROVIDER","module":"providers","branch":"agent/m08-video-provider-router","status":"occupied","assigned_agent":"provider-agent","accepts_new_agent":true,"start_status":"planning-hardened-only"},
     {"slot_id":"CROSS-CUTTING-QA","module":"media_qa","branch":"agent/cross-cutting-qa-security-current","status":"occupied","assigned_agent":"qa-security-agent","accepts_new_agent":true,"start_status":"active-audit-planning"}
   ]
 }

--- a/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
+++ b/ai-native/parallel/SUPERVISOR-BROADCASTS.yaml
@@ -1,5 +1,5 @@
-version: 12
-latest_sequence: 16
+version: 13
+latest_sequence: 17
 canonical_alert_text: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 broadcasts:
@@ -233,43 +233,78 @@ broadcasts:
       - agent/m08-video-provider-router
       - agent/cross-cutting-qa-security-current
     mandatory: true
+  - sequence: 17
+    trigger: m08-planning-promotion
+    merged_pr: 94
+    merged_branch: agent/m08-video-provider-router
+    submitted_head_sha: 8d4c1770598f4a5dac8a87304076ff62d4dad47d
+    merged_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
+    alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
+    classification: mandatory-m08-provider-router-planning-hardening-sync
+    changed_areas:
+      - M08 provider-router planning contract hardened against authority, reference and spend failures
+      - missing M08 planning checkpoint created
+      - provider-returned IDs, URLs, metadata, JSON, OCR, transcripts and instructions remain untrusted evidence
+      - canonical tenant/project authorization required for provider-returned and M07-supplied entity, asset, reference and version IDs
+      - pinned reference/version lineage and rights/provenance must survive routing and fallback
+      - raw provider, OAuth and signing secrets remain outside prompts, memory, generated artifacts, manifests, ledgers and logs
+      - retry, fallback, fan-out, time and cost require bounded idempotency, circuit-breaking and budget reservation
+      - ambiguous external completion must reconcile before retry or fallback
+      - unknown, stale or unsupported capability cannot be silently substituted for privileged execution
+      - deterministic fake/source evidence is not live provider, admin or production truth
+      - executable M04/M07 acceptance plus explicit M08 executable consent remain gates
+      - Issue 36 protected-main governance remains externally unverified
+    contract_changes:
+      - provider/generated/imported content cannot mint tenant, tool, publish, budget, account or security authority
+      - future M08 executable work must revalidate dependency, consent, migration, write ownership, canonical references, rights/licensing, provider APIs/scopes/quotas/costs and bounded retry/reconciliation controls
+      - planning synchronization does not grant executable M08 or downstream M09 authority
+    schema_migration_changes: []
+    recipients:
+      - supervisor/m03-governance-hold-current
+      - agent/m04-character-library-current
+      - agent/m05-content-memory-current
+      - agent/m06-audio-production-current
+      - agent/m07-storyboard-timeline-current
+      - agent/m08-video-provider-router
+      - agent/cross-cutting-qa-security-current
+    mandatory: true
 
 recipient_states:
   supervisor/m03-governance-hold-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 16
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_sequence: 17
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
   agent/m04-character-library-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 16
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_sequence: 17
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
   agent/m05-content-memory-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 16
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_sequence: 17
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
   agent/m06-audio-production-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 16
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_sequence: 17
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
   agent/m07-storyboard-timeline-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 16
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_sequence: 17
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
   agent/m08-video-provider-router:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 16
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_sequence: 17
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
   agent/cross-cutting-qa-security-current:
     state: synchronized
     required_sequence: null
-    last_acknowledged_sequence: 16
-    last_synced_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+    last_acknowledged_sequence: 17
+    last_synced_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
 
 rules:
   - Supervisor increments latest_sequence after every successful promotion merge to main that active agents must observe.

--- a/ai-native/parallel/SUPERVISOR-PLAN.md
+++ b/ai-native/parallel/SUPERVISOR-PLAN.md
@@ -12,13 +12,13 @@ Planning synchronization, a green planning PR, deterministic fakes, or conversat
 
 | Lane | Agent | Branch | State |
 | --- | --- | --- | --- |
-| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 16 synchronized |
-| M04 Character | `character-agent` | `agent/m04-character-library-current` | broadcast 16 synchronized; planning hardened; executable hold |
-| M05 Content | `content-agent` | `agent/m05-content-memory-current` | broadcast 16 synchronized; planning hardened; executable hold |
-| M06 Audio | `audio-agent` | `agent/m06-audio-production-current` | broadcast 16 synchronized; planning hardened; executable hold |
-| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline-current` | broadcast 16 synchronized; planning hardened; executable hold |
-| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 16 synchronized; planning-only; dependent on executable M04/M07 |
-| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 16 synchronized; audit/planning only |
+| M03 Governance Hold | `supervisor-agent` | `supervisor/m03-governance-hold-current` | active governance-only hold; broadcast 17 synchronized |
+| M04 Character | `character-agent` | `agent/m04-character-library-current` | broadcast 17 synchronized; planning hardened; executable hold |
+| M05 Content | `content-agent` | `agent/m05-content-memory-current` | broadcast 17 synchronized; planning hardened; executable hold |
+| M06 Audio | `audio-agent` | `agent/m06-audio-production-current` | broadcast 17 synchronized; planning hardened; executable hold |
+| M07 Timeline | `timeline-agent` | `agent/m07-storyboard-timeline-current` | broadcast 17 synchronized; planning hardened; executable hold |
+| M08 Provider | `provider-agent` | `agent/m08-video-provider-router` | broadcast 17 synchronized; planning hardened; executable hold |
+| QA / Security | `qa-security-agent` | `agent/cross-cutting-qa-security-current` | broadcast 17 synchronized; audit/planning only |
 
 Completed `agent/m04-character-library`, `agent/m05-content-memory`, `agent/m06-audio-production`, and `agent/m07-storyboard-timeline` are retired after their planning promotions and are not force-reset or reused as promotion authority. Fresh current-main planning branches are `agent/m04-character-library-current`, `agent/m05-content-memory-current`, `agent/m06-audio-production-current`, and `agent/m07-storyboard-timeline-current`. Earlier completed QA and M03/WP8 submission/review/closeout branches remain retired.
 
@@ -26,7 +26,7 @@ Completed `agent/m04-character-library`, `agent/m05-content-memory`, `agent/m06-
 
 M03 implementation, WP8 source acceptance, and source-side closeout are complete. Issue #36 remains the final M03 protected-main governance blocker because live GitHub enforcement is not verified.
 
-Migrations `20260901_0015` and `20260901_0016` remain landed. There is no active M03, M04, M05, M06 or M07 migration reservation. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
+Migrations `20260901_0015` and `20260901_0016` remain landed. There is no active M03, M04, M05, M06, M07 or M08 migration reservation. No additional WP7/WP8 product/API/schema/provider work is authorized by this state.
 
 ## Cross-cutting QA promotion
 
@@ -56,20 +56,31 @@ M06 planning completion is not executable M06 completion and does not satisfy M0
 
 PR #90 `M07: harden timeline planning against authority and reference corruption` merged to `main@29c66616ce1e79c90b4bb40f8e2158d0f9edd434`.
 
+That promotion hardened storyboard/timeline planning against generated/imported authority escalation, created the missing M07 checkpoint, required canonical tenant/project authorization for entity/asset/audio/keyframe/reference IDs, kept provider IDs/URLs/hidden state outside canonical timeline truth, required pinned version/reference lineage and rights/provenance continuity, and preserved executable M04/M05/M06 acceptance plus explicit M07 executable consent as gates. Broadcast 16 recorded those constraints.
+
+M07 planning completion is not executable M07 completion and does not satisfy M08 executable dependency.
+
+## M08 planning promotion
+
+PR #94 `M08: harden provider-router planning trust boundaries` merged to `main@9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc` from exact submitted head `8d4c1770598f4a5dac8a87304076ff62d4dad47d` after Repository Governance, Durable Control Plane and Core Domain Contracts passed.
+
 That promotion:
 
-- hardened storyboard/timeline planning against authority escalation from generated or imported editorial text;
-- created the previously missing `ai-native/parallel/checkpoints/M07-PARALLEL-LANE.md`;
-- required canonical tenant/project authorization for entity, asset, audio, keyframe and reference IDs;
-- kept provider IDs, URLs and hidden provider state outside canonical timeline truth;
-- treated OTIO/imported editorial structure and metadata as untrusted until supported-semantics, schema, ownership, hierarchy, timing, rights and reference validation pass;
-- required pinned version/reference lineage, rights/provenance continuity and non-destructive approved versions;
-- required malformed hierarchy/timing/reference/continuity structures and stale optimistic writes to fail safely before downstream execution;
-- retained executable M04/M05/M06 acceptance plus explicit M07 executable consent as mandatory executable entry gates;
-- created no product/API/schema/provider/test implementation, paid call, credential, video generation, publish action or migration reservation;
-- did not satisfy M08 executable dependency because planning completion is not executable M07 completion.
+- hardened the M08 provider-router plan and created the previously missing `ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md`;
+- treats provider-returned IDs, URLs, metadata, JSON, OCR, transcripts and instructions as untrusted evidence;
+- requires canonical tenant/project re-authorization for provider-returned and M07-supplied entity, asset, reference and version identifiers;
+- preserves pinned reference/version lineage plus rights/provenance through routing and fallback;
+- prevents provider/generated/imported content from minting tool, publish, budget, account or security authority;
+- keeps raw provider/OAuth/signing secrets outside prompts, memory, generated artifacts, manifests, ledgers and logs;
+- bounds retry, fallback, fan-out, time and cost with idempotency, circuit-breaking and budget reservation;
+- requires ambiguous external completion to reconcile before retry or fallback;
+- rejects unknown, stale or unsupported capability instead of silently substituting a privileged operation;
+- keeps deterministic fake/source acceptance distinct from live provider/admin/production truth;
+- creates no product/API/schema/provider adapter/test implementation, migration, credential use, paid call, media generation, publication or production-data access.
 
-After the merge, every pre-existing active branch except the completed squash-merged M07 submission branch was verified at zero unique commits and non-force fast-forwarded to the triggering main. The completed M07 submission branch was retired rather than force-reset, and fresh `agent/m07-storyboard-timeline-current` was created from current main. Broadcast 16 records this planning promotion for all affected active lanes.
+Before broadcast 17 coordination, every active Supervisor/M04/M05/M06/M07/M08/QA branch was verified at zero unique commits relative to resulting main and was non-force fast-forwarded to `9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc`.
+
+M08 planning completion is not executable M08 completion. It does not activate M09 or any provider execution authority.
 
 ## Dependency and consent boundary
 
@@ -77,9 +88,9 @@ After the merge, every pre-existing active branch except the completed squash-me
 - M05 executable work remains dependent on executable M04 completion and explicit M05 executable consent.
 - M06 executable work requires the accepted upstream executable chain, explicit M06 executable consent and then-current provider/licensing/governance revalidation.
 - M07 executable work remains dependent on executable M04/M05/M06 completion plus explicit M07 executable consent and then-current governance/write/migration/reference/right/provenance revalidation.
-- M08 executable work remains dependent on executable M04/M07 completion plus explicit M08 executable consent and current provider/API/rights/cost revalidation.
+- M08 executable work remains dependent on executable M04/M07 completion plus explicit M08 executable consent, fresh ownership/migration state, canonical reference authority and current provider API/scope/quota/rights/licensing/cost revalidation.
 - Cross-cutting QA remains audit/planning only unless an applicable executable scope authorizes targeted tests.
-- Generic `continue`, branch synchronization, green planning CI, mocks, deterministic fakes, or a planning checkpoint cannot satisfy a privileged development/publish/security gate.
+- Generic `continue`, branch synchronization, green planning CI, mocks, deterministic fakes, or a planning checkpoint cannot satisfy a privileged development/publish/security/provider/spend gate.
 
 ## Parallel safety
 
@@ -90,17 +101,18 @@ Future migration IDs are reserved only after executable authority exists and the
 ## Hold order
 
 1. keep Issue #36 `EXTERNAL_NOT_VERIFIED` until live protected-main evidence exists;
-2. preserve broadcast 12 adversarial obligations plus broadcasts 13, 14, 15 and 16 planning constraints in future milestone acceptance;
+2. preserve broadcasts 12 through 17 adversarial/planning constraints in future milestone acceptance;
 3. do not start executable M04 until Issue #36 and explicit M04 executable consent both clear;
 4. do not start executable M05 until executable M04 is accepted and explicit M05 executable consent exists;
 5. do not start executable M06 until its upstream executable chain is accepted and explicit M06 executable consent exists;
 6. do not start executable M07 until executable M04/M05/M06 are accepted and explicit M07 executable consent exists;
-7. do not treat M04/M05/M06/M07 planning completion as satisfying M08 executable dependency;
-8. do not create synthetic provider/admin/production success from source CI, mocks or deterministic fakes.
+7. do not start executable M08 until executable M04/M07 are accepted, explicit M08 executable consent exists, and current provider/reference/rights/cost gates pass;
+8. do not treat planning completion as satisfying executable dependencies or as authorization for M09;
+9. do not create synthetic provider/admin/production success from source CI, mocks or deterministic fakes.
 
 ## Next safe planning work
 
-While executable gates remain closed, M08 may be audited and hardened only within its existing planning consent scope and claimed files. Its current plan predates the latest cross-cutting and M07 authority/reference constraints, so a bounded planning-only reconciliation may update `docs/milestones/M08/**` and create/update `ai-native/parallel/checkpoints/M08-PARALLEL-LANE.md` after broadcast-16 coordination is promoted. It must preserve all executable dependency/consent holds, avoid implementation/schema/provider spend or credential use, revalidate current provider assumptions only when execution is later authorized, and pass ordinary exact-head repository/source regression CI before merge.
+No new executable milestone is authorized by the M08 planning promotion. While Issue #36 and upstream executable gates remain closed, current lanes may only perform their already-claimed planning/audit work after broadcast-17 synchronization. M09 is not activated by implication. Any future planning expansion must first receive an explicit collision-free scope and must not introduce provider spend, credentials, schema/product writes or privileged execution authority.
 
 ## Completion and review
 

--- a/ai-native/parallel/SUPERVISOR-STATE.yaml
+++ b/ai-native/parallel/SUPERVISOR-STATE.yaml
@@ -1,9 +1,9 @@
-version: 13
+version: 14
 supervisor:
   role: supervisor
   main_branch: main
-  main_sha_last_promotion: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
-  main_sha_last_reconciled: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+  main_sha_last_promotion: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
+  main_sha_last_reconciled: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
   own_task_id: M03-GOV-HOLD
   own_branch: supervisor/m03-governance-hold-current
   current_mode: external-governance-hold
@@ -11,9 +11,9 @@ supervisor:
   post_merge_alert: New changes have been merged — please merge these changes into your branch first, then resume your own work.
 
 last_promotion:
-  pr: 90
-  submitted_head_sha: 9f7f1073823eb898f8dd3dc7de162a040d40d8b4
-  merged_main_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+  pr: 94
+  submitted_head_sha: 8d4c1770598f4a5dac8a87304076ff62d4dad47d
+  merged_main_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
   result: success
 
 new_agent_onboarding:
@@ -26,7 +26,7 @@ new_agent_onboarding:
 pause_checkpoint:
   active: true
   branch: supervisor/m03-governance-hold-current
-  head_sha: 29c66616ce1e79c90b4bb40f8e2158d0f9edd434
+  head_sha: 9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc
   task_id: M03-GOV-HOLD
   subtask: wait-for-live-protected-main-evidence
   next_action: verify Issue 36 live ruleset/protection read-back from an admin-capable context
@@ -35,7 +35,7 @@ pause_checkpoint:
 review_queue: []
 
 synchronization:
-  latest_broadcast_sequence: 16
+  latest_broadcast_sequence: 17
   agents_with_mandatory_sync: []
   policy: branches-with-unacknowledged-mandatory-broadcast-cannot-seek-promotion
 
@@ -85,8 +85,21 @@ planning_state:
       - Issue 36/live governance where required by the accepted upstream chain
       - fresh write ownership and migration reservation if required
       - canonical reference authorization, rights/provenance and non-destructive versioning revalidation
+  m08:
+    status: planning-hardened-only
+    promotion_pr: 94
+    active_branch: agent/m08-video-provider-router
+    executable_authority: false
+    executable_gates:
+      - executable M04 and M07 completion and acceptance
+      - explicit M08 executable consent
+      - Issue 36/live governance where required by the accepted upstream chain
+      - fresh write ownership and migration reservation if required
+      - canonical tenant/project/reference authority and pinned lineage revalidation
+      - current provider APIs, scopes, rights, licensing, quotas and cost evidence revalidated
+      - bounded retry, fallback, fan-out, time, cost, idempotency and reconciliation controls executable
   downstream:
-    m08: dependency-gated-planning-only
+    m09: planning-not-activated
 
 rules:
   - The Supervisor reviews and merges incoming module PRs; module agents do not merge themselves.


### PR DESCRIPTION
Implements Issue #95 as governance-only coordination after M08 planning PR #94 merged to `main@9bc9e5f7e3ebda5166dca42a04be27dc9c3096bc`.

This PR changes exactly the five canonical Supervisor coordination files and:
- records mandatory broadcast sequence 17 for the M08 provider-router planning promotion;
- records Supervisor/M04/M05/M06/M07/M08/QA lanes synchronized to the resulting main after zero-unique-commit verification and non-force fast-forward;
- records M08 as planning-hardened-only after PR #94;
- preserves executable M04/M05/M06/M07/M08 dependency and explicit-consent gates;
- preserves Issue #36 protected-main governance as externally not verified;
- explicitly does not activate M09 or grant provider/spend/credential/publication authority.

No product/API/schema/provider adapter/test implementation, migration, credential use, paid call, media generation, publication, security-setting mutation or production data access.

Closes #95

Work Done and Submitted